### PR TITLE
fix: fix plugin configmap name

### DIFF
--- a/pkg/plugin/conftest/plugin.go
+++ b/pkg/plugin/conftest/plugin.go
@@ -255,7 +255,7 @@ func (p *plugin) GetScanJobSpec(ctx trivyoperator.PluginContext, obj client.Obje
 		moduleName := strings.TrimPrefix(module, keyPrefixPolicy)
 		moduleName = strings.TrimPrefix(moduleName, keyPrefixLibrary)
 
-		// Copy policies so even if the trivyoperator-conftest-config ConfigMap has changed
+		// Copy policies so even if the trivy-operator-conftest-config ConfigMap has changed
 		// before the scan Job is run, it won't fail with references to non-existent config key error.
 		secretData[module] = script
 

--- a/pkg/plugin/conftest/plugin_test.go
+++ b/pkg/plugin/conftest/plugin_test.go
@@ -224,7 +224,7 @@ deny[res] {
 			client := fake.NewClientBuilder().WithObjects(
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "trivyoperator-conftest-config",
+						Name:            "trivy-operator-conftest-config",
 						Namespace:       "trivyoperator-ns",
 						ResourceVersion: "0",
 					},
@@ -268,7 +268,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-conftest-config",
+			Name:      "trivy-operator-conftest-config",
 		}, &cm)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cm).To(Equal(corev1.ConfigMap{
@@ -277,7 +277,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trivyoperator-conftest-config",
+				Name:      "trivy-operator-conftest-config",
 				Namespace: "trivyoperator-ns",
 				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "trivyoperator",
@@ -300,7 +300,7 @@ func TestPlugin_Init(t *testing.T) {
 		client := fake.NewClientBuilder().WithObjects(
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "trivyoperator-conftest-config",
+					Name:            "trivy-operator-conftest-config",
 					Namespace:       "trivyoperator-ns",
 					ResourceVersion: "0",
 				},
@@ -323,7 +323,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-conftest-config",
+			Name:      "trivy-operator-conftest-config",
 		}, &cm)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cm).To(Equal(corev1.ConfigMap{
@@ -332,7 +332,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "trivyoperator-conftest-config",
+				Name:            "trivy-operator-conftest-config",
 				Namespace:       "trivyoperator-ns",
 				ResourceVersion: "0",
 			},
@@ -352,7 +352,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 		WithServiceAccountName("trivyoperator-sa").
 		WithClient(fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trivyoperator-conftest-config",
+				Name:      "trivy-operator-conftest-config",
 				Namespace: "trivyoperator-ns",
 			},
 			Data: map[string]string{
@@ -538,7 +538,7 @@ func TestPlugin_ParseConfigAuditReportData(t *testing.T) {
 			WithServiceAccountName("trivyoperator-sa").
 			WithClient(fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trivyoperator-conftest-config",
+					Name:      "trivy-operator-conftest-config",
 					Namespace: "trivyoperator-ns",
 				},
 				Data: map[string]string{
@@ -680,7 +680,7 @@ func TestPlugin_ParseConfigAuditReportData(t *testing.T) {
 			WithServiceAccountName("trivyoperator-sa").
 			WithClient(fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trivyoperator-conftest-config",
+					Name:      "trivy-operator-conftest-config",
 					Namespace: "trivyoperator-ns",
 				},
 				Data: map[string]string{
@@ -820,7 +820,7 @@ func TestPlugin_ConfigHash(t *testing.T) {
 			WithClient(fake.NewClientBuilder().
 				WithObjects(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "trivyoperator-conftest-config",
+						Name:      "trivy-operator-conftest-config",
 						Namespace: "trivyoperator-ns",
 					},
 					Data: data,

--- a/pkg/plugin/polaris/plugin_test.go
+++ b/pkg/plugin/polaris/plugin_test.go
@@ -144,7 +144,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-polaris-config",
+			Name:      "trivy-operator-polaris-config",
 		}, &cm)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cm).To(Equal(corev1.ConfigMap{
@@ -153,7 +153,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trivyoperator-polaris-config",
+				Name:      "trivy-operator-polaris-config",
 				Namespace: "trivyoperator-ns",
 				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "trivyoperator",
@@ -176,7 +176,7 @@ func TestPlugin_Init(t *testing.T) {
 
 		client := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "trivyoperator-polaris-config",
+				Name:            "trivy-operator-polaris-config",
 				Namespace:       "trivyoperator-ns",
 				ResourceVersion: "0",
 			},
@@ -201,7 +201,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-polaris-config",
+			Name:      "trivy-operator-polaris-config",
 		}, &cm)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cm).To(Equal(corev1.ConfigMap{
@@ -210,7 +210,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "trivyoperator-polaris-config",
+				Name:            "trivy-operator-polaris-config",
 				Namespace:       "trivyoperator-ns",
 				ResourceVersion: "0",
 			},
@@ -321,7 +321,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				WithServiceAccountName("trivyoperator-sa").
 				WithClient(fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "trivyoperator-polaris-config",
+						Name:      "trivy-operator-polaris-config",
 						Namespace: "trivyoperator-ns",
 					},
 					Data: tc.config,
@@ -358,7 +358,7 @@ func TestPlugin_ParseConfigAuditReportData(t *testing.T) {
 		WithServiceAccountName("trivyoperator-sa").
 		WithClient(fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trivyoperator-polaris-config",
+				Name:      "trivy-operator-polaris-config",
 				Namespace: "trivyoperator-ns",
 			},
 			Data: map[string]string{
@@ -426,7 +426,7 @@ func TestPlugin_ConfigHash(t *testing.T) {
 			WithClient(fake.NewClientBuilder().
 				WithObjects(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "trivyoperator-polaris-config",
+						Name:      "trivy-operator-polaris-config",
 						Namespace: "trivyoperator-ns",
 					},
 					Data: data,

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -456,7 +456,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-trivy-config",
+			Name:      "trivy-operator-trivy-config",
 		}, &cm)
 		require.NoError(t, err)
 		assert.Equal(t, corev1.ConfigMap{
@@ -465,7 +465,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trivyoperator-trivy-config",
+				Name:      "trivy-operator-trivy-config",
 				Namespace: "trivyoperator-ns",
 				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "trivyoperator",
@@ -495,7 +495,7 @@ func TestPlugin_Init(t *testing.T) {
 					Kind:       "ConfigMap",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "trivyoperator-trivy-config",
+					Name:            "trivy-operator-trivy-config",
 					Namespace:       "trivyoperator-ns",
 					ResourceVersion: "1",
 				},
@@ -520,7 +520,7 @@ func TestPlugin_Init(t *testing.T) {
 		var cm corev1.ConfigMap
 		err = client.Get(context.Background(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
-			Name:      "trivyoperator-trivy-config",
+			Name:      "trivy-operator-trivy-config",
 		}, &cm)
 		require.NoError(t, err)
 		assert.Equal(t, corev1.ConfigMap{
@@ -529,7 +529,7 @@ func TestPlugin_Init(t *testing.T) {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "trivyoperator-trivy-config",
+				Name:            "trivy-operator-trivy-config",
 				Namespace:       "trivyoperator-ns",
 				ResourceVersion: "1",
 			},
@@ -564,7 +564,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 		ValueFrom: &corev1.EnvVarSource{
 			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "trivyoperator-trivy-config",
+					Name: "trivy-operator-trivy-config",
 				},
 				Key:      "trivy.timeout",
 				Optional: pointer.BoolPtr(true),
@@ -634,7 +634,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -646,7 +646,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -658,7 +658,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -671,7 +671,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -715,7 +715,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -727,7 +727,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -740,7 +740,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -752,7 +752,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -764,7 +764,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -776,7 +776,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -788,7 +788,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -883,7 +883,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -895,7 +895,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -907,7 +907,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -919,7 +919,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -963,7 +963,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -975,7 +975,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -988,7 +988,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -1000,7 +1000,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -1012,7 +1012,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1024,7 +1024,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1036,7 +1036,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1135,7 +1135,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1147,7 +1147,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1159,7 +1159,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1171,7 +1171,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -1215,7 +1215,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -1227,7 +1227,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -1240,7 +1240,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -1252,7 +1252,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -1264,7 +1264,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1276,7 +1276,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1288,7 +1288,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1383,7 +1383,7 @@ CVE-2019-1543`,
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "trivyoperator-trivy-config",
+									Name: "trivy-operator-trivy-config",
 								},
 								Items: []corev1.KeyToPath{
 									{
@@ -1407,7 +1407,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1419,7 +1419,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1431,7 +1431,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1443,7 +1443,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -1487,7 +1487,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -1499,7 +1499,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -1512,7 +1512,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -1524,7 +1524,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -1536,7 +1536,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1548,7 +1548,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1560,7 +1560,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1666,7 +1666,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1678,7 +1678,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1690,7 +1690,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1703,7 +1703,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -1747,7 +1747,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -1759,7 +1759,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -1772,7 +1772,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -1784,7 +1784,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -1796,7 +1796,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1808,7 +1808,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1820,7 +1820,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1912,7 +1912,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1924,7 +1924,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1936,7 +1936,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -1948,7 +1948,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -1960,7 +1960,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -1973,7 +1973,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -1985,7 +1985,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -1997,7 +1997,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverTokenHeader",
 										Optional: pointer.BoolPtr(true),
@@ -2009,7 +2009,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverToken",
 										Optional: pointer.BoolPtr(true),
@@ -2021,7 +2021,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverCustomHeaders",
 										Optional: pointer.BoolPtr(true),
@@ -2102,7 +2102,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2114,7 +2114,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2126,7 +2126,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2138,7 +2138,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -2150,7 +2150,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -2163,7 +2163,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -2175,7 +2175,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -2187,7 +2187,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverTokenHeader",
 										Optional: pointer.BoolPtr(true),
@@ -2199,7 +2199,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverToken",
 										Optional: pointer.BoolPtr(true),
@@ -2211,7 +2211,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverCustomHeaders",
 										Optional: pointer.BoolPtr(true),
@@ -2293,7 +2293,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2305,7 +2305,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2317,7 +2317,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2329,7 +2329,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -2341,7 +2341,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -2354,7 +2354,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -2366,7 +2366,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -2378,7 +2378,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverTokenHeader",
 										Optional: pointer.BoolPtr(true),
@@ -2390,7 +2390,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverToken",
 										Optional: pointer.BoolPtr(true),
@@ -2402,7 +2402,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverCustomHeaders",
 										Optional: pointer.BoolPtr(true),
@@ -2488,7 +2488,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2500,7 +2500,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2512,7 +2512,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2524,7 +2524,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -2536,7 +2536,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -2549,7 +2549,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -2561,7 +2561,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -2573,7 +2573,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverTokenHeader",
 										Optional: pointer.BoolPtr(true),
@@ -2585,7 +2585,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverToken",
 										Optional: pointer.BoolPtr(true),
@@ -2597,7 +2597,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverCustomHeaders",
 										Optional: pointer.BoolPtr(true),
@@ -2681,7 +2681,7 @@ CVE-2019-1543`,
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "trivyoperator-trivy-config",
+									Name: "trivy-operator-trivy-config",
 								},
 								Items: []corev1.KeyToPath{
 									{
@@ -2705,7 +2705,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2717,7 +2717,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2729,7 +2729,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2741,7 +2741,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -2753,7 +2753,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.ignoreUnfixed",
 										Optional: pointer.BoolPtr(true),
@@ -2766,7 +2766,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -2778,7 +2778,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -2790,7 +2790,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverTokenHeader",
 										Optional: pointer.BoolPtr(true),
@@ -2802,7 +2802,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverToken",
 										Optional: pointer.BoolPtr(true),
@@ -2814,7 +2814,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.serverCustomHeaders",
 										Optional: pointer.BoolPtr(true),
@@ -2945,7 +2945,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2957,7 +2957,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2969,7 +2969,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -2982,7 +2982,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.githubToken",
 										Optional: pointer.BoolPtr(true),
@@ -3030,7 +3030,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.severity",
 										Optional: pointer.BoolPtr(true),
@@ -3042,7 +3042,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipFiles",
 										Optional: pointer.BoolPtr(true),
@@ -3054,7 +3054,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
 										Optional: pointer.BoolPtr(true),
@@ -3066,7 +3066,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpProxy",
 										Optional: pointer.BoolPtr(true),
@@ -3078,7 +3078,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.httpsProxy",
 										Optional: pointer.BoolPtr(true),
@@ -3090,7 +3090,7 @@ CVE-2019-1543`,
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivyoperator-trivy-config",
+											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.noProxy",
 										Optional: pointer.BoolPtr(true),
@@ -3150,7 +3150,7 @@ CVE-2019-1543`,
 			fakeclient := fake.NewClientBuilder().WithObjects(
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "trivyoperator-trivy-config",
+						Name:      "trivy-operator-trivy-config",
 						Namespace: "trivyoperator-ns",
 					},
 					Data: tc.config,
@@ -3263,7 +3263,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.httpProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3275,7 +3275,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.httpsProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3287,7 +3287,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.noProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3300,7 +3300,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.githubToken",
 									Optional: pointer.BoolPtr(true),
@@ -3348,7 +3348,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.severity",
 									Optional: pointer.BoolPtr(true),
@@ -3360,7 +3360,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.skipFiles",
 									Optional: pointer.BoolPtr(true),
@@ -3372,7 +3372,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.skipDirs",
 									Optional: pointer.BoolPtr(true),
@@ -3384,7 +3384,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.httpProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3396,7 +3396,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.httpsProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3408,7 +3408,7 @@ CVE-2019-1543`,
 							ValueFrom: &corev1.EnvVarSource{
 								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "trivyoperator-trivy-config",
+										Name: "trivy-operator-trivy-config",
 									},
 									Key:      "trivy.noProxy",
 									Optional: pointer.BoolPtr(true),
@@ -3466,7 +3466,7 @@ CVE-2019-1543`,
 			fakeclient := fake.NewClientBuilder().WithObjects(
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "trivyoperator-trivy-config",
+						Name:      "trivy-operator-trivy-config",
 						Namespace: "trivyoperator-ns",
 					},
 					Data: tc.config,
@@ -3572,7 +3572,7 @@ var (
 func TestPlugin_ParseVulnerabilityReportData(t *testing.T) {
 	config := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "trivyoperator-trivy-config",
+			Name:      "trivy-operator-trivy-config",
 			Namespace: "trivyoperator-ns",
 		},
 		Data: map[string]string{

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -97,9 +97,9 @@ func TestConfigData_GetConfigAuditReportsScanner(t *testing.T) {
 
 func TestConfigData_GetScanJobTolerations(t *testing.T) {
 	testCases := []struct {
-		name     string
-		config   trivyoperator.ConfigData
-		expected []corev1.Toleration
+		name        string
+		config      trivyoperator.ConfigData
+		expected    []corev1.Toleration
 		expectError string
 	}{
 		{
@@ -166,9 +166,9 @@ func TestConfigData_GetScanJobTolerations(t *testing.T) {
 
 func TestConfigData_GetScanJobAnnotations(t *testing.T) {
 	testCases := []struct {
-		name     string
-		config   trivyoperator.ConfigData
-		expected map[string]string
+		name        string
+		config      trivyoperator.ConfigData
+		expected    map[string]string
 		expectError string
 	}{
 		{
@@ -219,9 +219,9 @@ func TestConfigData_GetScanJobAnnotations(t *testing.T) {
 
 func TestConfigData_GetScanJobPodTemplateLabels(t *testing.T) {
 	testCases := []struct {
-		name     string
-		config   trivyoperator.ConfigData
-		expected labels.Set
+		name        string
+		config      trivyoperator.ConfigData
+		expected    labels.Set
 		expectError string
 	}{
 		{
@@ -298,9 +298,9 @@ func TestConfigData_GetComplianceFailEntriesLimit(t *testing.T) {
 
 func TestConfigData_GetKubeBenchImageRef(t *testing.T) {
 	testCases := []struct {
-		name          string
-		configData    trivyoperator.ConfigData
-		expectedError string
+		name             string
+		configData       trivyoperator.ConfigData
+		expectedError    string
 		expectedImageRef string
 	}{
 		{
@@ -332,9 +332,9 @@ func TestConfigData_GetKubeBenchImageRef(t *testing.T) {
 
 func TestConfigData_GetKubeHunterImageRef(t *testing.T) {
 	testCases := []struct {
-		name          string
-		configData    trivyoperator.ConfigData
-		expectedError string
+		name             string
+		configData       trivyoperator.ConfigData
+		expectedError    string
 		expectedImageRef string
 	}{
 		{
@@ -560,7 +560,7 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 
 		_, err = clientset.CoreV1().ConfigMaps(namespace).
 			Get(context.TODO(), trivyoperator.GetPluginConfigMapName("Polaris"), metav1.GetOptions{})
-		g.Expect(err).To(gomega.MatchError(`configmaps "trivyoperator-polaris-config" not found`))
+		g.Expect(err).To(gomega.MatchError(`configmaps "trivy-operator-polaris-config" not found`))
 	})
 
 }

--- a/pkg/trivyoperator/plugin.go
+++ b/pkg/trivyoperator/plugin.go
@@ -52,7 +52,7 @@ type PluginContext interface {
 // with the given name.
 // TODO Rename to GetPluginConfigObjectName as this method is used to determine the name of ConfigMaps and Secrets.
 func GetPluginConfigMapName(pluginName string) string {
-	return "trivyoperator-" + strings.ToLower(pluginName) + "-config"
+	return "trivy-operator-" + strings.ToLower(pluginName) + "-config"
 }
 
 type pluginContext struct {
@@ -90,7 +90,7 @@ func (p *pluginContext) GetConfig() (PluginConfig, error) {
 
 	err := p.client.Get(context.Background(), types.NamespacedName{
 		Namespace: p.namespace,
-		Name:      fmt.Sprintf("trivyoperator-%s-config", strings.ToLower(p.GetName())),
+		Name:      GetPluginConfigMapName(strings.ToLower(p.GetName())),
 	}, cm)
 	if err != nil {
 		return PluginConfig{}, err
@@ -98,7 +98,7 @@ func (p *pluginContext) GetConfig() (PluginConfig, error) {
 
 	err = p.client.Get(context.Background(), types.NamespacedName{
 		Namespace: p.namespace,
-		Name:      fmt.Sprintf("trivyoperator-%s-config", strings.ToLower(p.GetName())),
+		Name:      GetPluginConfigMapName(strings.ToLower(p.GetName())),
 	}, secret)
 
 	var secretData map[string][]byte

--- a/pkg/trivyoperator/plugin_test.go
+++ b/pkg/trivyoperator/plugin_test.go
@@ -13,7 +13,7 @@ import (
 func TestGetPluginConfigMapName(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	name := trivyoperator.GetPluginConfigMapName("Conftest")
-	g.Expect(name).To(gomega.Equal("trivyoperator-conftest-config"))
+	g.Expect(name).To(gomega.Equal("trivy-operator-conftest-config"))
 }
 
 func TestPluginContext_GetConfig(t *testing.T) {
@@ -25,7 +25,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 			WithScheme(trivyoperator.NewScheme()).
 			WithObjects(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trivyoperator-polaris-config",
+					Name:      "trivy-operator-polaris-config",
 					Namespace: "trivyoperator-ns",
 				},
 				Data: map[string]string{
@@ -58,7 +58,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 			WithScheme(trivyoperator.NewScheme()).
 			WithObjects(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trivyoperator-polaris-config",
+					Name:      "trivy-operator-polaris-config",
 					Namespace: "trivyoperator-ns",
 				},
 				Data: map[string]string{
@@ -66,7 +66,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 				},
 			}, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trivyoperator-polaris-config",
+					Name:      "trivy-operator-polaris-config",
 					Namespace: "trivyoperator-ns",
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/41

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.