### PR TITLE
docs: add ref to trivy-operator mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Trivy-operator logo](docs/images/trivy-operator-logo.png)
 
-> Kubernetes-native security toolkit.
+> Kubernetes-native security toolkit. ([Documentation](https://aquasecurity.github.io/trivy/latest/docs/kubernetes/operator/))
 
 [![GitHub Release][release-img]][release]
 [![Build Action][action-build-img]][action-build]


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
add ref to trivy-operator mkdocs

## Related issues
- Close #46 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant 