### PR TITLE
fix: issue #58 trivy-operator CRDs out-of-sync on ArgoCD

### DIFF
--- a/deploy/crd/ciskubebenchreports.crd.yaml
+++ b/deploy/crd/ciskubebenchreports.crd.yaml
@@ -45,6 +45,5 @@ spec:
     plural: ciskubebenchreports
     kind: CISKubeBenchReport
     listKind: CISKubeBenchReportList
-    categories: []
     shortNames:
       - kubebench

--- a/deploy/crd/clustercompliancedetailreports.crd.yaml
+++ b/deploy/crd/clustercompliancedetailreports.crd.yaml
@@ -37,6 +37,5 @@ spec:
     plural: clustercompliancedetailreports
     kind: ClusterComplianceDetailReport
     listKind: ClusterComplianceDetailReportList
-    categories: [ ]
     shortNames:
       - compliancedetail

--- a/deploy/crd/clustercompliancereports.crd.yaml
+++ b/deploy/crd/clustercompliancereports.crd.yaml
@@ -132,6 +132,5 @@ spec:
     plural: clustercompliancereports
     kind: ClusterComplianceReport
     listKind: ClusterComplianceReportList
-    categories: [ ]
     shortNames:
       - compliance

--- a/deploy/crd/clusterconfigauditreports.crd.yaml
+++ b/deploy/crd/clusterconfigauditreports.crd.yaml
@@ -51,6 +51,5 @@ spec:
     plural: clusterconfigauditreports
     kind: ClusterConfigAuditReport
     listKind: ClusterConfigAuditReportList
-    categories: []
     shortNames:
       - clusterconfigaudit

--- a/deploy/crd/clustervulnerabilityreports.crd.yaml
+++ b/deploy/crd/clustervulnerabilityreports.crd.yaml
@@ -237,7 +237,6 @@ spec:
     plural: clustervulnerabilityreports
     kind: ClusterVulnerabilityReport
     listKind: ClusterVulnerabilityReportList
-    categories: []
     shortNames:
       - clustervuln
       - clustervulns

--- a/deploy/crd/configauditreports.crd.yaml
+++ b/deploy/crd/configauditreports.crd.yaml
@@ -51,6 +51,5 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories: []
     shortNames:
       - configaudit

--- a/deploy/crd/kubehunterreports.crd.yaml
+++ b/deploy/crd/kubehunterreports.crd.yaml
@@ -127,6 +127,5 @@ spec:
     plural: kubehunterreports
     kind: KubeHunterReport
     listKind: KubeHunterReportList
-    categories: []
     shortNames:
       - kubehunter

--- a/deploy/crd/vulnerabilityreports.crd.yaml
+++ b/deploy/crd/vulnerabilityreports.crd.yaml
@@ -237,7 +237,6 @@ spec:
     plural: vulnerabilityreports
     kind: VulnerabilityReport
     listKind: VulnerabilityReportList
-    categories: []
     shortNames:
       - vuln
       - vulns

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Signed-off-by: David <davidcalvertfr@gmail.com>

## Description

- This is a fix proposal for https://github.com/aquasecurity/trivy-operator/issues/58
- Bumped helm chart version to 0.0.4

Another solution would be to add a category, but this fix seemed more appropriate to me.

Let me know if any change is needed for this PR.

David

Screenshots (theses were made with starboard but it's the same code):

- Broken: https://raw.githubusercontent.com/dotdc/media/main/github-issues/2022-05-30-starboard-crds-broken.png
- Diff Detail : https://raw.githubusercontent.com/dotdc/media/main/github-issues/2022-05-30-starboard-crds-detail.png
- Fixed: https://raw.githubusercontent.com/dotdc/media/main/github-issues/2022-05-30-starboard-crds-fixed.png

## Related issues

- Close #58 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
