### PR TITLE
feat: add VulnerabilityReport summary metrics

### DIFF
--- a/deploy/static/05-trivy-operator.deployment.yaml
+++ b/deploy/static/05-trivy-operator.deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: "10s"
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: ":8080"
+            - name: OPERATOR_METRICS_FINDINGS_ENABLED
+              value: "true"
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1542,6 +1542,8 @@ spec:
               value: "10s"
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: ":8080"
+            - name: OPERATOR_METRICS_FINDINGS_ENABLED
+              value: "true"
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/open-policy-agent/opa v0.41.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/stretchr/testify v1.7.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.1
@@ -79,7 +80,6 @@ require (
 	github.com/owenrumney/squealer v1.0.1-0.20220510063705-c0be93f0edea // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+)
+
+var (
+	imageVulnLabels = []string{
+		"namespace",
+		"name",
+		"image_registry",
+		"image_repository",
+		"image_tag",
+		"image_digest",
+		"severity",
+	}
+	imageVulnDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("trivy", "vulnerabilityreport", "image_vulnerabilities"),
+		"Number of container image vulnerabilities",
+		imageVulnLabels,
+		nil,
+	)
+	severities = map[string]func(vs v1alpha1.VulnerabilitySummary) int{
+		"Critical": func(vs v1alpha1.VulnerabilitySummary) int {
+			return vs.CriticalCount
+		},
+		"High": func(vs v1alpha1.VulnerabilitySummary) int {
+			return vs.HighCount
+		},
+		"Medium": func(vs v1alpha1.VulnerabilitySummary) int {
+			return vs.MediumCount
+		},
+		"Low": func(vs v1alpha1.VulnerabilitySummary) int {
+			return vs.LowCount
+		},
+		"Unknown": func(vs v1alpha1.VulnerabilitySummary) int {
+			return vs.UnknownCount
+		},
+	}
+)
+
+type ResourcesMetricsCollector struct {
+	logr.Logger
+	etc.Config
+	client.Client
+}
+
+func (c *ResourcesMetricsCollector) SetupWithManager(mgr ctrl.Manager) error {
+	return mgr.Add(c)
+}
+
+func (c ResourcesMetricsCollector) Collect(metrics chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	targetNamespaces := c.Config.GetTargetNamespaces()
+	if len(targetNamespaces) == 0 {
+		targetNamespaces = append(targetNamespaces, "")
+	}
+	c.collectVulnerabilityReports(ctx, metrics, targetNamespaces)
+}
+
+func (c ResourcesMetricsCollector) collectVulnerabilityReports(ctx context.Context, metrics chan<- prometheus.Metric, targetNamespaces []string) {
+	vrList := &v1alpha1.VulnerabilityReportList{}
+	labelValues := make([]string, 7)
+	for _, n := range targetNamespaces {
+		if err := c.List(ctx, vrList, client.InNamespace(n)); err != nil {
+			c.Logger.Error(err, "failed to list vulnerabilityreports from API", "namespace", n)
+			continue
+		}
+		for _, vr := range vrList.Items {
+			labelValues[0] = vr.Namespace
+			labelValues[1] = vr.Name
+			labelValues[2] = vr.Report.Registry.Server
+			labelValues[3] = vr.Report.Artifact.Repository
+			labelValues[4] = vr.Report.Artifact.Tag
+			labelValues[5] = vr.Report.Artifact.Digest
+			for severity, countFn := range severities {
+				labelValues[6] = severity
+				count := countFn(vr.Report.Summary)
+				metrics <- prometheus.MustNewConstMetric(imageVulnDesc, prometheus.GaugeValue, float64(count), labelValues...)
+			}
+		}
+	}
+}
+
+func (c ResourcesMetricsCollector) Describe(descs chan<- *prometheus.Desc) {
+	descs <- imageVulnDesc
+}
+
+func (c ResourcesMetricsCollector) Start(ctx context.Context) error {
+	c.Logger.Info("Registering resources metrics collector")
+	if err := k8smetrics.Registry.Register(c); err != nil {
+		return err
+	}
+
+	// Block until the context is done.
+	<-ctx.Done()
+
+	c.Logger.Info("Unregistering resources metrics collector")
+	k8smetrics.Registry.Unregister(c)
+	return nil
+}
+
+func (c ResourcesMetricsCollector) NeedLeaderElection() bool {
+	return true
+}
+
+// Ensure ResourcesMetricsCollector is leader-election aware
+var _ manager.LeaderElectionRunnable = &ResourcesMetricsCollector{}

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ResourcesMetricsCollector", func() {
+	var collector ResourcesMetricsCollector
+
+	BeforeEach(func() {
+		vr1 := &v1alpha1.VulnerabilityReport{}
+		vr1.Namespace = "default"
+		vr1.Name = "replicaset-nginx-6d4cf56db6-nginx"
+		vr1.Report.Registry.Server = "index.docker.io"
+		vr1.Report.Artifact.Repository = "library/nginx"
+		vr1.Report.Artifact.Tag = "1.16"
+		vr1.Report.Summary.CriticalCount = 2
+
+		vr2 := &v1alpha1.VulnerabilityReport{}
+		vr2.Namespace = "some-ns"
+		vr2.Name = "replicaset-app-d327abe3c4-proxy"
+		vr2.Report.Registry.Server = "quay.io"
+		vr2.Report.Artifact.Repository = "oauth2-proxy/oauth2-proxy"
+		vr2.Report.Artifact.Tag = "v7.2.1"
+		vr2.Report.Summary.CriticalCount = 4
+		vr2.Report.Summary.HighCount = 7
+
+		vr3 := &v1alpha1.VulnerabilityReport{}
+		vr3.Namespace = "ingress-nginx"
+		vr3.Name = "daemonset-ingress-nginx-controller-controller"
+		vr3.Report.Registry.Server = "k8s.gcr.io"
+		vr3.Report.Artifact.Repository = "ingress-nginx/controller"
+		vr3.Report.Artifact.Digest = "sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8"
+
+		scheme := runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(vr1, vr2, vr3).
+			Build()
+		collector = ResourcesMetricsCollector{
+			Client: client,
+		}
+	})
+
+	It("should not have lint issues", func() {
+		problems, err := testutil.CollectAndLint(collector)
+		Expect(err).To(Succeed())
+		Expect(problems).To(BeEmpty())
+	})
+
+	It("should produce correct metrics with cluster scope", func() {
+		const expected = `
+		  # HELP trivy_vulnerabilityreport_image_vulnerabilities Number of container image vulnerabilities
+		  # TYPE trivy_vulnerabilityreport_image_vulnerabilities gauge
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Critical"} 2
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="High"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Low"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Medium"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Unknown"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Critical"} 4
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="High"} 7
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Low"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Medium"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Unknown"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8",image_registry="k8s.gcr.io",image_repository="ingress-nginx/controller",image_tag="",name="daemonset-ingress-nginx-controller-controller",namespace="ingress-nginx",severity="Critical"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8",image_registry="k8s.gcr.io",image_repository="ingress-nginx/controller",image_tag="",name="daemonset-ingress-nginx-controller-controller",namespace="ingress-nginx",severity="High"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8",image_registry="k8s.gcr.io",image_repository="ingress-nginx/controller",image_tag="",name="daemonset-ingress-nginx-controller-controller",namespace="ingress-nginx",severity="Low"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8",image_registry="k8s.gcr.io",image_repository="ingress-nginx/controller",image_tag="",name="daemonset-ingress-nginx-controller-controller",namespace="ingress-nginx",severity="Medium"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8",image_registry="k8s.gcr.io",image_repository="ingress-nginx/controller",image_tag="",name="daemonset-ingress-nginx-controller-controller",namespace="ingress-nginx",severity="Unknown"} 0
+		`
+		Expect(testutil.CollectAndCompare(collector, strings.NewReader(expected), "trivy_vulnerabilityreport_image_vulnerabilities")).
+			To(Succeed())
+	})
+
+	It("should produce correct metrics from target namespaces", func() {
+		collector.TargetNamespaces = "default,some-ns"
+		const expected = `
+		  # HELP trivy_vulnerabilityreport_image_vulnerabilities Number of container image vulnerabilities
+		  # TYPE trivy_vulnerabilityreport_image_vulnerabilities gauge
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Critical"} 2
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="High"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Low"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Medium"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="index.docker.io",image_repository="library/nginx",image_tag="1.16",name="replicaset-nginx-6d4cf56db6-nginx",namespace="default",severity="Unknown"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Critical"} 4
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="High"} 7
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Low"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Medium"} 0
+		  trivy_vulnerabilityreport_image_vulnerabilities{image_digest="",image_registry="quay.io",image_repository="oauth2-proxy/oauth2-proxy",image_tag="v7.2.1",name="replicaset-app-d327abe3c4-proxy",namespace="some-ns",severity="Unknown"} 0
+		`
+		Expect(testutil.CollectAndCompare(collector, strings.NewReader(expected), "trivy_vulnerabilityreport_image_vulnerabilities")).
+			To(Succeed())
+	})
+})

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BatchDeleteLimit                             int            `env:"OPERATOR_BATCH_DELETE_LIMIT" envDefault:"10"`
 	BatchDeleteDelay                             time.Duration  `env:"OPERATOR_BATCH_DELETE_DELAY" envDefault:"10s"`
 	MetricsBindAddress                           string         `env:"OPERATOR_METRICS_BIND_ADDRESS" envDefault:":8080"`
+	MetricsFindingsEnabled                       bool           `env:"OPERATOR_METRICS_FINDINGS_ENABLED" envDefault:"true"`
 	HealthProbeBindAddress                       string         `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
 	CISKubernetesBenchmarkEnabled                bool           `env:"OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED" envDefault:"false"`
 	VulnerabilityScannerEnabled                  bool           `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport"
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/metrics"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/controller"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/plugin"
@@ -194,6 +195,19 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 			return fmt.Errorf("unable to setup clustercompliancereport reconciler: %w", err)
 		}
 	}
+
+	if operatorConfig.MetricsFindingsEnabled {
+		logger := ctrl.Log.WithName("metrics")
+		rmc := &metrics.ResourcesMetricsCollector{
+			Logger: logger,
+			Config: operatorConfig,
+			Client: mgr.GetClient(),
+		}
+		if err := rmc.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup resources metrics collector: %w", err)
+		}
+	}
+
 	setupLog.Info("Starting controllers manager")
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("starting controllers manager: %w", err)


### PR DESCRIPTION
## Description

This adds a leader-election aware custom Prometheus collector. This collector produces metrics from `VulnerabilityReport` summary, but can easily be extended to produce other metrics from trivy-operator custom resources.

## Related issues
- related to (but doesn't close) #78 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
