### PR TITLE
add plural to configauditreport crd

### DIFF
--- a/deploy/crd/configauditreports.crd.yaml
+++ b/deploy/crd/configauditreports.crd.yaml
@@ -53,3 +53,4 @@ spec:
     listKind: ConfigAuditReportList
     shortNames:
       - configaudit
+      - configaudits      

--- a/deploy/crd/configauditreports.crd.yaml
+++ b/deploy/crd/configauditreports.crd.yaml
@@ -53,4 +53,4 @@ spec:
     listKind: ConfigAuditReportList
     shortNames:
       - configaudit
-      - configaudits      
+      - configaudits

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -295,6 +295,7 @@ spec:
     listKind: ConfigAuditReportList
     shortNames:
       - configaudit
+      - configaudits
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
## Description

Add plural to configauditreport crd.

Before:
```
configauditreports                configaudit                    aquasecurity.github.io/v1alpha1        true         ConfigAuditReport
```

After:
```
configauditreports                configaudit,configaudits   aquasecurity.github.io/v1alpha1        true         ConfigAuditReport
```

## Related issues
- Close #112 

Remove this section if you don't have related PRs.

## Checklist
- [x ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
