### PR TITLE
fix: ConfigAudit scanner should be Trivy

### DIFF
--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -49,7 +49,7 @@ kubectl get configauditreports -o wide
 
 ```
 NAME                          SCANNER     AGE    CRITICAL  HIGH   MEDIUM   LOW
-replicaset-nginx-78449c65d4   Trivy-Operator   2m7s   0         0      6        7
+replicaset-nginx-78449c65d4   Trivy   2m7s   0         0      6        7
 ```
 </details>
 

--- a/itest/helper/helper.go
+++ b/itest/helper/helper.go
@@ -246,7 +246,7 @@ func (b *DeploymentBuilder) Build() *appsv1.Deployment {
 
 var (
 	trivyScanner = v1alpha1.Scanner{
-		Name:    "Trivy",
+		Name:    v1alpha1.ScannerNameTrivy,
 		Vendor:  "Aqua Security",
 		Version: "0.16.0",
 	}

--- a/itest/matcher/matcher.go
+++ b/itest/matcher/matcher.go
@@ -19,12 +19,12 @@ import (
 
 var (
 	trivyScanner = v1alpha1.Scanner{
-		Name:    "Trivy",
+		Name:    v1alpha1.ScannerNameTrivy,
 		Vendor:  "Aqua Security",
 		Version: "0.28.1",
 	}
 	builtInScanner = v1alpha1.Scanner{
-		Name:    "Trivy-Operator",
+		Name:    v1alpha1.ScannerNameTrivy,
 		Vendor:  "Aqua Security",
 		Version: "dev",
 	}

--- a/itest/matcher/matcher_test.go
+++ b/itest/matcher/matcher_test.go
@@ -55,7 +55,7 @@ func TestVulnerabilityReportMatcher(t *testing.T) {
 			},
 			Report: v1alpha1.VulnerabilityReportData{
 				Scanner: v1alpha1.Scanner{
-					Name:    "Trivy",
+					Name:    v1alpha1.ScannerNameTrivy,
 					Vendor:  "Aqua Security",
 					Version: "0.28.1",
 				},
@@ -107,7 +107,7 @@ func TestConfigAuditReportMatcher(t *testing.T) {
 			},
 			Report: v1alpha1.ConfigAuditReportData{
 				Scanner: v1alpha1.Scanner{
-					Name:    "Trivy-Operator",
+					Name:    v1alpha1.ScannerNameTrivy,
 					Vendor:  "Aqua Security",
 					Version: "dev",
 				},

--- a/pkg/apis/aquasecurity/v1alpha1/common_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/common_types.go
@@ -36,6 +36,8 @@ func StringToSeverity(name string) (Severity, error) {
 	}
 }
 
+const ScannerNameTrivy = "Trivy"
+
 // Scanner is the spec for a scanner generating a security assessment report.
 type Scanner struct {
 	// Name the name of the scanner.

--- a/pkg/compliance/testdata/fixture/configAuditReportList.json
+++ b/pkg/compliance/testdata/fixture/configAuditReportList.json
@@ -153,7 +153,7 @@
           }
         ],
         "scanner": {
-          "name": "Trivy-Operator",
+          "name": "Trivy",
           "vendor": "Aqua Security",
           "version": "v0.0.1"
         },

--- a/pkg/configauditreport/controller.go
+++ b/pkg/configauditreport/controller.go
@@ -304,7 +304,7 @@ func (r *ResourceController) evaluate(ctx context.Context, policies *policy.Poli
 
 	return v1alpha1.ConfigAuditReportData{
 		Scanner: v1alpha1.Scanner{
-			Name:    "Trivy-Operator",
+			Name:    v1alpha1.ScannerNameTrivy,
 			Vendor:  "Aqua Security",
 			Version: r.BuildInfo.Version,
 		},

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -1280,7 +1280,7 @@ func (p *plugin) ParseVulnerabilityReportData(ctx trivyoperator.PluginContext, i
 	return v1alpha1.VulnerabilityReportData{
 		UpdateTimestamp: metav1.NewTime(p.clock.Now()),
 		Scanner: v1alpha1.Scanner{
-			Name:    "Trivy",
+			Name:    v1alpha1.ScannerNameTrivy,
 			Vendor:  "Aqua Security",
 			Version: version,
 		},

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -3526,7 +3526,7 @@ var (
 	sampleReport = v1alpha1.VulnerabilityReportData{
 		UpdateTimestamp: metav1.NewTime(fixedTime),
 		Scanner: v1alpha1.Scanner{
-			Name:    "Trivy",
+			Name:    v1alpha1.ScannerNameTrivy,
 			Vendor:  "Aqua Security",
 			Version: "0.9.1",
 		},
@@ -3602,7 +3602,7 @@ func TestPlugin_ParseVulnerabilityReportData(t *testing.T) {
 			expectedReport: v1alpha1.VulnerabilityReportData{
 				UpdateTimestamp: metav1.NewTime(fixedTime),
 				Scanner: v1alpha1.Scanner{
-					Name:    "Trivy",
+					Name:    v1alpha1.ScannerNameTrivy,
 					Vendor:  "Aqua Security",
 					Version: "0.9.1",
 				},

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func TestConfigData_GetVulnerabilityReportsScanner(t *testing.T) {
 			configData: trivyoperator.ConfigData{
 				"vulnerabilityReports.scanner": "Trivy",
 			},
-			expectedScanner: "Trivy",
+			expectedScanner: v1alpha1.ScannerNameTrivy,
 		},
 		{
 			name:          "Should return error when value is not set",
@@ -60,7 +61,7 @@ func TestConfigData_GetConfigAuditReportsScanner(t *testing.T) {
 			configData: trivyoperator.ConfigData{
 				"configAuditReports.scanner": "Trivy",
 			},
-			expectedScanner: "Trivy",
+			expectedScanner: v1alpha1.ScannerNameTrivy,
 		},
 		{
 			name:          "Should return error when value is not set",


### PR DESCRIPTION
## Description

Change the scanner property on configaudit resources from `Trivy-Operator` to `Trivy`.

## Related issues
- Close #107 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant 