### PR TITLE
feat: add scan target to vulnerabilities

### DIFF
--- a/deploy/crd/vulnerabilityreports.crd.yaml
+++ b/deploy/crd/vulnerabilityreports.crd.yaml
@@ -189,6 +189,8 @@ spec:
                         type: array
                         items:
                           type: string
+                      target:
+                        type: string
       additionalPrinterColumns:
         - jsonPath: .report.artifact.repository
           type: string

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -189,6 +189,8 @@ spec:
                         type: array
                         items:
                           type: string
+                      target:
+                        type: string
       additionalPrinterColumns:
         - jsonPath: .report.artifact.repository
           type: string

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -74,6 +74,7 @@ type Vulnerability struct {
 	PrimaryLink string   `json:"primaryLink,omitempty"`
 	Links       []string `json:"links"`
 	Score       *float64 `json:"score,omitempty"`
+	Target      string   `json:"target"`
 }
 
 // +genclient

--- a/pkg/plugin/trivy/model.go
+++ b/pkg/plugin/trivy/model.go
@@ -25,6 +25,7 @@ type Vulnerability struct {
 	PrimaryURL       string            `json:"PrimaryURL"`
 	References       []string          `json:"References"`
 	Cvss             map[string]*CVSS  `json:"CVSS"`
+	Target           string            `json:"Target"`
 }
 
 type CVSS struct {

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -1255,6 +1255,7 @@ func (p *plugin) ParseVulnerabilityReportData(ctx trivyoperator.PluginContext, i
 				PrimaryLink:      sr.PrimaryURL,
 				Links:            []string{},
 				Score:            GetScoreFromCVSS(sr.Cvss),
+				Target:           report.Target,
 			})
 		}
 	}

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -3555,6 +3555,7 @@ var (
 				Title:            "openssl: information disclosure in fork()",
 				PrimaryLink:      "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1549",
 				Links:            []string{},
+				Target:           "alpine:3.10.2 (alpine 3.10.2)",
 			},
 			{
 				VulnerabilityID:  "CVE-2019-1547",
@@ -3565,6 +3566,7 @@ var (
 				Title:            "openssl: side-channel weak encryption vulnerability",
 				PrimaryLink:      "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547",
 				Links:            []string{},
+				Target:           "alpine:3.10.2 (alpine 3.10.2)",
 			},
 		},
 	}


### PR DESCRIPTION
## Description

This PR aims to add the target scan field from trivy to the vulnerabilities in the `vulnerabilityreport`

If I've forgotten anything, I'd love to hear about it

Example

![image](https://user-images.githubusercontent.com/8344949/174147056-ca8975e3-c3df-473a-9993-449f286cca3b.png)


## Related issues
- Close #106 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
