### PR TITLE
fix: support insecure flag for download trivy-db

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -64,6 +64,9 @@ data:
   {{- end }}
   trivy.severity: {{ .severity | quote }}
   trivy.dbRepository: {{ .dbRepository | quote }}
+  {{- if .dbRepositoryInsecure }}
+  trivy.dbRepositoryInsecure: {{ .dbRepositoryInsecure | quote }}
+  {{- end }}
   {{- if .ignoreUnfixed }}
   trivy.ignoreUnfixed: {{ .ignoreUnfixed | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -184,6 +184,10 @@ trivy:
   # serverCustomHeaders: "foo=bar"
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
+
+  # dbRepositoryInsecure is the flag to use to set insecure connection
+  # during the download Trivy-DB mainly to be used in air-gaped env. where Trivy-DB is downloaded via proxy
+  #
   dbRepositoryInsecure: "false"
 
 compliance:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -184,6 +184,7 @@ trivy:
   # serverCustomHeaders: "foo=bar"
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
+  dbRepositoryInsecure: "false"
 
 compliance:
   # failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -185,8 +185,7 @@ trivy:
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
 
-  # dbRepositoryInsecure is the flag to use to set insecure connection
-  # during the download Trivy-DB mainly to be used in air-gaped env. where Trivy-DB is downloaded via proxy
+  # The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)
   #
   dbRepositoryInsecure: "false"
 

--- a/docs/vulnerability-scanning/trivy.md
+++ b/docs/vulnerability-scanning/trivy.md
@@ -72,30 +72,31 @@ EOF
 
 ## Settings
 
-| CONFIGMAP KEY| DEFAULT                            | DESCRIPTION|
-|---|------------------------------------|---|
-| `trivy.imageRef`| `docker.io/aquasec/trivy:0.29.1`   | Trivy image reference|
-| `trivy.dbRepository`| `ghcr.io/aquasecurity/trivy-db`    | External OCI Registry to download the vulnerability database|
-| `trivy.mode`| `Standalone`                       | Trivy client mode. Either `Standalone` or `ClientServer`. Depending on the active mode other settings might be applicable or required.                              |
-| `trivy.severity`| `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | A comma separated list of severity levels reported by Trivy|
-| `trivy.ignoreUnfixed`| N/A                                | Whether to show only fixed vulnerabilities in vulnerabilities reported by Trivy. Set to `"true"` to enable it.|
-| `trivy.skipFiles`| N/A                                | A comma separated list of file paths for Trivy to skip traversal.|
-| `trivy.skipDirs`| N/A                                | A comma separated list of directories for Trivy to skip traversal.|
-| `trivy.ignoreFile`| N/A                                | It specifies the `.trivyignore` file which contains a list of vulnerability IDs to be ignored from vulnerabilities reported by Trivy.|
-| `trivy.timeout`| `5m0s`                             | The duration to wait for scan completion|
-| `trivy.serverURL`| N/A                                | The endpoint URL of the Trivy server. Required in `ClientServer` mode.|
-| `trivy.serverTokenHeader`| `Trivy-Token`                      | The name of the HTTP header to send the authentication token to Trivy server. Only application in `ClientServer` mode when `trivy.serverToken` is specified.|
-| `trivy.serverInsecure`| N/A                                | The Flag to enable insecure connection to the Trivy server.|
-| `trivy.insecureRegistry.<id>`| N/A                                | The registry to which insecure connections are allowed. There can be multiple registries with different registry `<id>`.|
-| `trivy.nonSslRegistry.<id>`| N/A                                | A registry without SSL. There can be multiple registries with different registry `<id>`.|
+| CONFIGMAP KEY                      | DEFAULT                            | DESCRIPTION                                                                                                                                                         |
+|------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `trivy.imageRef`                   | `docker.io/aquasec/trivy:0.29.1`   | Trivy image reference                                                                                                                                               |
+| `trivy.dbRepository`               | `ghcr.io/aquasecurity/trivy-db`    | External OCI Registry to download the vulnerability database                                                                                                        |
+| `trivy.dbRepositoryInsecure`       | `false`                            | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)                                                                           |
+| `trivy.mode`                       | `Standalone`                       | Trivy client mode. Either `Standalone` or `ClientServer`. Depending on the active mode other settings might be applicable or required.                              |
+| `trivy.severity`                   | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | A comma separated list of severity levels reported by Trivy                                                                                                         |
+| `trivy.ignoreUnfixed`              | N/A                                | Whether to show only fixed vulnerabilities in vulnerabilities reported by Trivy. Set to `"true"` to enable it.                                                      |
+| `trivy.skipFiles`                  | N/A                                | A comma separated list of file paths for Trivy to skip traversal.                                                                                                   |
+| `trivy.skipDirs`                   | N/A                                | A comma separated list of directories for Trivy to skip traversal.                                                                                                  |
+| `trivy.ignoreFile`                 | N/A                                | It specifies the `.trivyignore` file which contains a list of vulnerability IDs to be ignored from vulnerabilities reported by Trivy.                               |
+| `trivy.timeout`                    | `5m0s`                             | The duration to wait for scan completion                                                                                                                            |
+| `trivy.serverURL`                  | N/A                                | The endpoint URL of the Trivy server. Required in `ClientServer` mode.                                                                                              |
+| `trivy.serverTokenHeader`          | `Trivy-Token`                      | The name of the HTTP header to send the authentication token to Trivy server. Only application in `ClientServer` mode when `trivy.serverToken` is specified.        |
+| `trivy.serverInsecure`             | N/A                                | The Flag to enable insecure connection to the Trivy server.                                                                                                         |
+| `trivy.insecureRegistry.<id>`      | N/A                                | The registry to which insecure connections are allowed. There can be multiple registries with different registry `<id>`.                                            |
+| `trivy.nonSslRegistry.<id>`        | N/A                                | A registry without SSL. There can be multiple registries with different registry `<id>`.                                                                            |
 | `trivy.registry.mirror.<registry>` | N/A                                | Mirror for the registry `<registry>`, e.g. `trivy.registry.mirror.index.docker.io: mirror.io` would use `mirror.io` to get images originated from `index.docker.io` |
-| `trivy.httpProxy`| N/A                                | The HTTP proxy used by Trivy to download the vulnerabilities database from GitHub.|
-| `trivy.httpsProxy`| N/A                                | The HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub.|
-| `trivy.noProxy`| N/A                                | A comma separated list of IPs and domain names that are not subject to proxy settings.|
-| `trivy.resources.requests.cpu`| `100m`                             | The minimum amount of CPU required to run Trivy scanner pod.|
-| `trivy.resources.requests.memory`| `100M`                             | The minimum amount of memory required to run Trivy scanner pod.|
-| `trivy.resources.limits.cpu`| `500m`                             | The maximum amount of CPU allowed to run Trivy scanner pod.|
-| `trivy.resources.limits.memory`| `500M`                             | The maximum amount of memory allowed to run Trivy scanner pod.|
+| `trivy.httpProxy`                  | N/A                                | The HTTP proxy used by Trivy to download the vulnerabilities database from GitHub.                                                                                  |
+| `trivy.httpsProxy`                 | N/A                                | The HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub.                                                                                 |
+| `trivy.noProxy`                    | N/A                                | A comma separated list of IPs and domain names that are not subject to proxy settings.                                                                              |
+| `trivy.resources.requests.cpu`     | `100m`                             | The minimum amount of CPU required to run Trivy scanner pod.                                                                                                        |
+| `trivy.resources.requests.memory`  | `100M`                             | The minimum amount of memory required to run Trivy scanner pod.                                                                                                     |
+| `trivy.resources.limits.cpu`       | `500m`                             | The maximum amount of CPU allowed to run Trivy scanner pod.                                                                                                         |
+| `trivy.resources.limits.memory`    | `500M`                             | The maximum amount of memory allowed to run Trivy scanner pod.                                                                                                      |
 
 | SECRET KEY| DESCRIPTION|
 |---|---|


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
    support insecure flag for download trivy-db

## Related issues
- Close #127 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant 
