### PR TITLE
fix: make OPERATOR_METRICS_FINDINGS_ENABLED configurable in Helm chart

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.operator.batchDeleteDelay | quote }}
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: ":8080"
+            - name: OPERATOR_METRICS_FINDINGS_ENABLED
+              value: {{ .Values.operator.metricsFindingsEnabled | quote }}
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -55,6 +55,9 @@ operator:
   configAuditScannerScanOnlyCurrentRevisions: false
   # batchDeleteDelay the duration to wait before deleting another batch of config audit reports.
   batchDeleteDelay: 10s
+  
+  # metricsFindingsEnabled the flag to enable metrics for findings
+  metricsFindingsEnabled: true
 image:
   repository: "docker.io/aquasec/trivy-operator"
   # tag is an override of the image tag, which is by default set by the


### PR DESCRIPTION
## Description

This makes `OPERATOR_METRICS_FINDINGS_ENABLED` configurable from the Helm chart. Leftover from https://github.com/aquasecurity/trivy-operator/pull/96, where this operator flag was introduced.

Extracted from https://github.com/aquasecurity/trivy-operator/pull/176 to avoid unrelated changes in the same PR.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
