### PR TITLE
fix: use correct env name in update-static.yaml.sh

### DIFF
--- a/hack/update-static.yaml.sh
+++ b/hack/update-static.yaml.sh
@@ -12,12 +12,12 @@ trap "rm -rf $HELM_TMPDIR" EXIT
 helm template trivy-operator $HELM_DIR \
   --namespace trivy-system \
   --set="managedBy=kubectl" \
-  --output-dir=$TMPDIR/trivy-operator-helm-template
+  --output-dir=$HELM_TMPDIR/trivy-operator-helm-template
 
-cp $TMPDIR/trivy-operator-helm-template/trivy-operator/templates/rbac.yaml $STATIC_DIR/02-trivy-operator.rbac.yaml
-cp $TMPDIR/trivy-operator-helm-template/trivy-operator/templates/config.yaml $STATIC_DIR/03-trivy-operator.config.yaml
-cp $TMPDIR/trivy-operator-helm-template/trivy-operator/templates/policies.yaml $STATIC_DIR/04-trivy-operator.policies.yaml
-cp $TMPDIR/trivy-operator-helm-template/trivy-operator/templates/deployment.yaml $STATIC_DIR/05-trivy-operator.deployment.yaml
+cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/rbac.yaml $STATIC_DIR/02-trivy-operator.rbac.yaml
+cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/config.yaml $STATIC_DIR/03-trivy-operator.config.yaml
+cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/policies.yaml $STATIC_DIR/04-trivy-operator.policies.yaml
+cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/deployment.yaml $STATIC_DIR/05-trivy-operator.deployment.yaml
 
 cat $CRD_DIR/vulnerabilityreports.crd.yaml \
   $CRD_DIR/configauditreports.crd.yaml \


### PR DESCRIPTION
## Description

Sadly there was a bug in the script add in https://github.com/aquasecurity/trivy-operator/pull/176. Sorry for that! This fixes the script to use the correct environment variable name.


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
