### PR TITLE
fix: exposedsecretreports are missing from trivy-operator clusterrole

### DIFF
--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -134,6 +134,7 @@ rules:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
+      - exposedsecretreports
       - configauditreports
       - clusterconfigauditreports
       - clustercompliancereports

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -134,6 +134,7 @@ rules:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
+      - exposedsecretreports
       - configauditreports
       - clusterconfigauditreports
       - clustercompliancereports

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -711,6 +711,7 @@ rules:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
+      - exposedsecretreports
       - configauditreports
       - clusterconfigauditreports
       - clustercompliancereports


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
exposedsecretreports are missing from trivy-operator clusterrole

## Related issues
- Close #197 