### PR TITLE
docs: trivy client/serverurl and standalon urls are broken

### DIFF
--- a/docs/vulnerability-scanning/trivy.md
+++ b/docs/vulnerability-scanning/trivy.md
@@ -104,7 +104,7 @@ EOF
 | `trivy.serverToken`| The token to authenticate Trivy client with Trivy server. Only applicable in `ClientServer` mode.|
 | `trivy.serverCustomHeaders`| A comma separated list of custom HTTP headers sent by Trivy client to Trivy server. Only applicable in `ClientServer` mode.|
 
-[trivy-standalone]: https://aquasecurity.github.io/trivy/latest/modes/standalone/
+[trivy-standalone]: https://aquasecurity.github.io/trivy/latest/docs/references/modes/standalone/
 [emptyDir volume]: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
 [rate limiting]: https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
-[trivy-clientserver]: https://aquasecurity.github.io/trivy/latest/advanced/modes/client-server/
+[trivy-clientserver]: https://aquasecurity.github.io/trivy/latest/docs/references/modes/client-server/


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
trivy client/serverurl and standalon urls are broken

## Related issues
- Close #189 
- 
## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant 