### PR TITLE
feat: add flag to disable secret scan

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
               value: {{ .Values.operator.clusterComplianceEnabled | quote }}
+            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
+              value: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
             {{- if gt (int .Values.operator.replicas) 1 }}
             - name: OPERATOR_LEADER_ELECTION_ENABLED
               value: "true"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -60,6 +60,9 @@ operator:
 
   # metricsFindingsEnabled the flag to enable metrics for findings
   metricsFindingsEnabled: true
+
+  # exposedSecretScannerEnabled the flag to enable exposed secret scanner
+  exposedSecretScannerEnabled: true
 image:
   repository: "ghcr.io/aquasecurity/trivy-operator"
   # tag is an override of the image tag, which is by default set by the

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1286,6 +1286,8 @@ spec:
               value: "true"
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
               value: "false"
+            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
+              value: "true"
           ports:
             - name: metrics
               containerPort: 8080

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -27,6 +27,7 @@ You can configure Trivy-Operator to control it's behavior and adapt it to your n
 | `OPERATOR_VULNERABILITY_SCANNER_REPORT_TTL`| `"24h"`                  | The flag to set how long a vulnerability report should exist. When a old report is deleted a new one will be created by the controller. It can be set to `""` to disabled the TTL for vulnerability scanner. |
 | `OPERATOR_LEADER_ELECTION_ENABLED`| `false`               | The flag to enable operator replica leader election                                                                                                                                                         |
 | `OPERATOR_LEADER_ELECTION_ID`| `trivy-operator-lock` | The name of the resource lock for leader election                                                                                                                                                           |
+| `OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED`| `true`| The flag to enable exposed secret scanner|
 
 The values of the `OPERATOR_NAMESPACE` and `OPERATOR_TARGET_NAMESPACES` determine the install mode, which in turn determines the multitenancy support of the operator.
 

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ConfigAuditScannerScanOnlyCurrentRevisions   bool           `env:"OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS" envDefault:"true"`
 	LeaderElectionEnabled                        bool           `env:"OPERATOR_LEADER_ELECTION_ENABLED" envDefault:"false"`
 	LeaderElectionID                             string         `env:"OPERATOR_LEADER_ELECTION_ID" envDefault:"trivyoperator-lock"`
+	ExposedSecretScannerEnabled                  bool           `env:"OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED" envDefault:"true"`
 }
 
 // GetOperatorConfig loads Config from environment variables.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/aquasecurity/trivy-operator/pkg/compliance"
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport"
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport/controller"
@@ -136,7 +138,11 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	logsReader := kube.NewLogsReader(kubeClientset)
 	secretsReader := kube.NewSecretsReader(mgr.GetClient())
 
-	if operatorConfig.VulnerabilityScannerEnabled {
+	if operatorConfig.VulnerabilityScannerEnabled || operatorConfig.ExposedSecretScannerEnabled {
+
+		trivyOperatorConfig.Set(trivyoperator.KeyVulnerabilityScannerEnabled, strconv.FormatBool(operatorConfig.VulnerabilityScannerEnabled))
+		trivyOperatorConfig.Set(trivyoperator.KeyExposedSecretsScannerEnabled, strconv.FormatBool(operatorConfig.ExposedSecretScannerEnabled))
+
 		plugin, pluginContext, err := plugins.NewResolver().
 			WithBuildInfo(buildInfo).
 			WithNamespace(operatorNamespace).

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -51,6 +51,8 @@ type BuildInfo struct {
 type Scanner string
 
 const (
+	KeyVulnerabilityScannerEnabled       = "vulnerabilityScannerEnabled"
+	KeyExposedSecretsScannerEnabled      = "exposedSecretsScannerEnabled"
 	keyVulnerabilityReportsScanner       = "vulnerabilityReports.scanner"
 	KeyVulnerabilityScansInSameNamespace = "vulnerabilityReports.scanJobsInSameNamespace"
 	keyConfigAuditReportsScanner         = "configAuditReports.scanner"
@@ -82,6 +84,30 @@ func GetDefaultConfig() ConfigData {
 	}
 }
 
+// Set sets a key on config data
+func (c ConfigData) Set(key, value string) {
+	c[key] = value
+}
+
+// VulnerabilityScannerEnabled returns if the vulnerability scanners is enabled/disablsed
+func (c ConfigData) VulnerabilityScannerEnabled() bool {
+	return c.getBoolKey(KeyVulnerabilityScannerEnabled)
+}
+
+// ExposedSecretsScannerEnabled returns if the vulnerability scanners is enabled/disablsed
+func (c ConfigData) ExposedSecretsScannerEnabled() bool {
+	return c.getBoolKey(KeyExposedSecretsScannerEnabled)
+}
+
+func (c ConfigData) getBoolKey(key string) bool {
+	var ok bool
+	var value string
+	if value, ok = c[key]; !ok {
+		return false
+	}
+	return value == "true"
+}
+
 func (c ConfigData) GetVulnerabilityReportsScanner() (Scanner, error) {
 	var ok bool
 	var value string
@@ -92,12 +118,7 @@ func (c ConfigData) GetVulnerabilityReportsScanner() (Scanner, error) {
 }
 
 func (c ConfigData) VulnerabilityScanJobsInSameNamespace() bool {
-	var ok bool
-	var value string
-	if value, ok = c[KeyVulnerabilityScansInSameNamespace]; !ok {
-		return false
-	}
-	return value == "true"
+	return c.getBoolKey(KeyVulnerabilityScansInSameNamespace)
 }
 
 func (c ConfigData) GetConfigAuditReportsScanner() (Scanner, error) {

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -486,7 +486,6 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 }
 
 func TestConfigManager_Delete(t *testing.T) {
-
 	t.Run("Should not return error when ConfigMap and secret do not exist", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
 		err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).Delete(context.TODO())
@@ -526,4 +525,76 @@ func TestConfigManager_Delete(t *testing.T) {
 			Get(context.TODO(), trivyoperator.SecretName, metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 	})
+}
+
+func TestConfigData_VulnerabilityScannerEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		key      string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "Should return false when key is not set",
+			key:      "lah",
+			value:    "true",
+			expected: false,
+		},
+		{
+			name:     "Should return false when key is set 'false'",
+			key:      trivyoperator.KeyVulnerabilityScannerEnabled,
+			value:    "false",
+			expected: false,
+		},
+		{
+			name:     "Should return true when key is set 'true'",
+			key:      trivyoperator.KeyVulnerabilityScannerEnabled,
+			value:    "true",
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		configData := trivyoperator.ConfigData{}
+		t.Run(tc.name, func(t *testing.T) {
+			configData.Set(tc.key, tc.value)
+			got := configData.VulnerabilityScannerEnabled()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestConfigData_ExposedSecretsScannerEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		key      string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "Should return false when key is not set",
+			key:      "lah",
+			value:    "true",
+			expected: false,
+		},
+		{
+			name:     "Should return false when key is set 'false'",
+			key:      trivyoperator.KeyExposedSecretsScannerEnabled,
+			value:    "false",
+			expected: false,
+		},
+		{
+			name:     "Should return true when key is set 'true'",
+			key:      trivyoperator.KeyExposedSecretsScannerEnabled,
+			value:    "true",
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		configData := trivyoperator.ConfigData{}
+		t.Run(tc.name, func(t *testing.T) {
+			configData.Set(tc.key, tc.value)
+			got := configData.ExposedSecretsScannerEnabled()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
 }

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -442,14 +442,18 @@ func (r *WorkloadController) processCompleteScanJob(ctx context.Context, job *ba
 		return merr
 	}
 
-	err = r.VulnerabilityReadWriter.Write(ctx, vulnerabilityReports)
-	if err != nil {
-		return err
+	if r.Config.VulnerabilityScannerEnabled {
+		err = r.VulnerabilityReadWriter.Write(ctx, vulnerabilityReports)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = r.ExposedSecretReadWriter.Write(ctx, secretReports)
-	if err != nil {
-		return err
+	if r.Config.ExposedSecretScannerEnabled {
+		err = r.ExposedSecretReadWriter.Write(ctx, secretReports)
+		if err != nil {
+			return err
+		}
 	}
 
 	log.V(1).Info("Deleting complete scan job", "owner", owner)

--- a/pkg/vulnerabilityreport/suite_test.go
+++ b/pkg/vulnerabilityreport/suite_test.go
@@ -81,7 +81,12 @@ var _ = BeforeSuite(func() {
 		TargetNamespaces:        "default",
 		ConcurrentScanJobsLimit: 10,
 	}
+
 	trivyOperatorConfig := trivyoperator.GetDefaultConfig()
+
+	trivyOperatorConfig.Set(trivyoperator.KeyVulnerabilityScannerEnabled, "true")
+	trivyOperatorConfig.Set(trivyoperator.KeyExposedSecretsScannerEnabled, "true")
+
 	plugin, pluginContext, err := plugins.NewResolver().
 		WithNamespace(config.Namespace).
 		WithServiceAccountName(config.ServiceAccount).

--- a/pkg/vulnerabilityreport/testdata/fixture/cronjob-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/cronjob-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'busybox:1.28' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'busybox:1.28' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/daemonset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/daemonset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'quay.io/fluentd_elasticsearch/fluentd:v2.5.2' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'quay.io/fluentd_elasticsearch/fluentd:v2.5.2' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/job-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/job-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'perl:5.34' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'perl:5.34' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/pod-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/pod-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'app-image:app-image-tag' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'app-image:app-image-tag' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/replicaset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicaset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'wordpress:4.9' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'wordpress:4.9' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/replicationcontroller-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicationcontroller-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'nginx' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'nginx' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:

--- a/pkg/vulnerabilityreport/testdata/fixture/statefulset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/statefulset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image 'k8s.gcr.io/nginx-slim:0.8' --cache-dir /tmp/trivy/.cache --quiet  --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
+            - trivy image 'k8s.gcr.io/nginx-slim:0.8' --security-checks vuln,secrets --cache-dir /tmp/trivy/.cache --quiet --skip-update --format json > /tmp/scan/result.json &&  bzip2 -c /tmp/scan/result.json | base64
           command:
             - /bin/sh
           env:


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

I chose a design for this feature that I would prefer to refactor later, mostly because of https://github.com/aquasecurity/trivy-operator/issues/415. Configurations to enable/disable scanner are considered `operatorConfig`, and are done through env variables, which are not passed in the context of the scanning plugin. Scanning configurations are configured as a ConfigMap, considered `trivyOperatorConfig`, and passed as context to the plugin. Because of this separation I'm setting the options from `operatorConfig` into `trivyOperatorConfig`.  Preferably I think we should only have one source of configuration, ConfigMap for all options related to the operator, which would be passed in the plugin context.

Note, I'm not talking about the specific scanner configmap (trivy-operator-trivy-config) which is yet another configuration file, specific only for the trivy plugin. 

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/226

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
