### PR TITLE
fix: tighten RBAC; remove some unneeded cluster-wide permissions

### DIFF
--- a/deploy/helm/templates/leader_election.yaml
+++ b/deploy/helm/templates/leader_election.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.rbac.create}}
+---
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trivy-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
       - services
       - resourcequotas
       - limitranges
+      - configmaps
     verbs:
       - get
       - list
@@ -46,7 +47,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - secrets
       - serviceaccounts
     verbs:
@@ -61,12 +61,6 @@ rules:
       - secrets
     verbs:
       - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
   - apiGroups:
       - apps
     resources:
@@ -151,14 +145,6 @@ rules:
     resources:
       - clustercompliancereports/status
     verbs:
-      - update
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
       - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -31,6 +31,7 @@ rules:
       - services
       - resourcequotas
       - limitranges
+      - configmaps
     verbs:
       - get
       - list
@@ -46,7 +47,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - secrets
       - serviceaccounts
     verbs:
@@ -61,12 +61,6 @@ rules:
       - secrets
     verbs:
       - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
   - apiGroups:
       - apps
     resources:
@@ -152,14 +146,6 @@ rules:
       - clustercompliancereports/status
     verbs:
       - update
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - update
 ---
 # Source: trivy-operator/templates/rbac.yaml
 # permissions for end users to view configauditreports
@@ -238,6 +224,64 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-operator
+    namespace: trivy-system
+---
+# Source: trivy-operator/templates/leader_election.yaml
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trivy-operator-leader-election
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: kubectl
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+---
+# Source: trivy-operator/templates/leader_election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trivy-operator-leader-election
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: kubectl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trivy-operator-leader-election
 subjects:
   - kind: ServiceAccount
     name: trivy-operator

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -608,6 +608,7 @@ rules:
       - services
       - resourcequotas
       - limitranges
+      - configmaps
     verbs:
       - get
       - list
@@ -623,7 +624,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - secrets
       - serviceaccounts
     verbs:
@@ -638,12 +638,6 @@ rules:
       - secrets
     verbs:
       - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
   - apiGroups:
       - apps
     resources:
@@ -729,14 +723,6 @@ rules:
       - clustercompliancereports/status
     verbs:
       - update
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - update
 ---
 # Source: trivy-operator/templates/rbac.yaml
 # permissions for end users to view configauditreports
@@ -815,6 +801,64 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-operator
+    namespace: trivy-system
+---
+# Source: trivy-operator/templates/leader_election.yaml
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trivy-operator-leader-election
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: kubectl
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+---
+# Source: trivy-operator/templates/leader_election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trivy-operator-leader-election
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: kubectl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trivy-operator-leader-election
 subjects:
   - kind: ServiceAccount
     name: trivy-operator

--- a/hack/update-static.yaml.sh
+++ b/hack/update-static.yaml.sh
@@ -14,7 +14,8 @@ helm template trivy-operator $HELM_DIR \
   --set="managedBy=kubectl" \
   --output-dir=$HELM_TMPDIR/trivy-operator-helm-template
 
-cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/rbac.yaml $STATIC_DIR/02-trivy-operator.rbac.yaml
+cat $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/rbac.yaml \
+    $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/leader_election.yaml > $STATIC_DIR/02-trivy-operator.rbac.yaml
 cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/config.yaml $STATIC_DIR/03-trivy-operator.config.yaml
 cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/policies.yaml $STATIC_DIR/04-trivy-operator.policies.yaml
 cp $HELM_TMPDIR/trivy-operator-helm-template/trivy-operator/templates/deployment.yaml $STATIC_DIR/05-trivy-operator.deployment.yaml


### PR DESCRIPTION
## Description

This change withdraws some unneeded cluster-wide RBAC permissions and replaces them with equivalent operator namespace permissions - that are required to perform operator leader-election. To make it more obvious **why** permissions are needed, I put the new Role/RoleBinding in a dedicated file. This is also how kubebuilder scaffolds new projects. I can merge the new resources into the rbac.yaml file if you don't like it, but I prefer what I have suggested.

Technically the operator currently needs permission to create configmaps in the operator namespace, even with no leader election. Ref. https://github.com/aquasecurity/trivy-operator/blob/59452b4b465c1292aa9a763e459cf7f83553fb48/pkg/trivyoperator/plugin.go#L70-L85

But I decided to leave this out for now, since this permission is already covered by the new leader-election role. This can probably be improved when generating some of the RBAC, ref. https://github.com/aquasecurity/trivy-operator/issues/204

## Related issues
- Relates to #187, but doesn't fix it. 
- Relates to #204 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
