### PR TITLE
fix: dbRepositoryInsecure param always return true

### DIFF
--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -149,10 +149,7 @@ func (c Config) GetDBRepositoryInsecure() bool {
 	if !ok {
 		return false
 	}
-	boolVal, err := strconv.ParseBool(val)
-	if err != nil {
-		return false
-	}
+	boolVal, _ := strconv.ParseBool(val)
 	return boolVal
 }
 func (c Config) GetUseBuiltinRegoPolicies() bool {

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -145,8 +145,15 @@ func (c Config) GetServerInsecure() bool {
 }
 
 func (c Config) GetDBRepositoryInsecure() bool {
-	_, ok := c.Data[keyTrivyDBRepositoryInsecure]
-	return ok
+	val, ok := c.Data[keyTrivyDBRepositoryInsecure]
+	if !ok {
+		return false
+	}
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return boolVal
 }
 func (c Config) GetUseBuiltinRegoPolicies() bool {
 	val, ok := c.Data[keyTrivyUseBuiltinRegoPolicies]

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -329,6 +329,55 @@ func TestConfig_IgnoreUnfixed(t *testing.T) {
 	}
 }
 
+func TestConfig_dbRepositoryInsecure(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configData     trivy.Config
+		expectedOutput bool
+	}{
+		{
+			name: "good value Should return false",
+			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
+				Data: map[string]string{
+					"trivy.dbRepositoryInsecure": "false",
+				},
+			}},
+			expectedOutput: false,
+		},
+		{
+			name: "good value Should return true",
+			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
+				Data: map[string]string{
+					"trivy.dbRepositoryInsecure": "true",
+				},
+			}},
+			expectedOutput: true,
+		},
+		{
+			name: "bad value Should return false",
+			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
+				Data: map[string]string{
+					"trivy.dbRepositoryInsecure": "true1",
+				},
+			}},
+			expectedOutput: false,
+		},
+		{
+			name: "no value Should return false",
+			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
+				Data: map[string]string{},
+			}},
+			expectedOutput: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists := tc.configData.GetDBRepositoryInsecure()
+			assert.Equal(t, tc.expectedOutput, exists)
+		})
+	}
+}
+
 func TestConfig_GetInsecureRegistries(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
dbRepositoryInsecure param always return true

## Related issues
- Close #245 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
