### PR TITLE
sort the yaml files alphabetically

### DIFF
--- a/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
@@ -2,40 +2,40 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clustercompliancedetailreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: clustercompliancedetailreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.failCount
-          type: integer
-          name: Fail
-          priority: 1
-          description: The number of checks that failed with Danger status
-        - jsonPath: .report.summary.passCount
-          type: integer
-          name: Pass
-          priority: 1
-          description: The number of checks that passed
-      schema:
-        openAPIV3Schema:
-          x-kubernetes-preserve-unknown-fields: true
-          type: object
-  scope: Cluster
   names:
-    singular: clustercompliancedetailreport
-    plural: clustercompliancedetailreports
     kind: ClusterComplianceDetailReport
     listKind: ClusterComplianceDetailReportList
+    plural: clustercompliancedetailreports
     shortNames:
       - compliancedetail
+    singular: clustercompliancedetailreport
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of checks that failed with Danger status
+          jsonPath: .report.summary.failCount
+          name: Fail
+          priority: 1
+          type: integer
+        - description: The number of checks that passed
+          jsonPath: .report.summary.passCount
+          name: Pass
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
@@ -2,40 +2,39 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clustercompliancereports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: clustercompliancereports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
+  names:
+    kind: ClusterComplianceReport
+    listKind: ClusterComplianceReportList
+    plural: clustercompliancereports
+    shortNames:
+      - compliance
+    singular: clustercompliancereport
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          type: date
+    - additionalPrinterColumns:
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
           name: Age
-          description: The age of the report
-        - jsonPath: .status.summary.failCount
-          type: integer
+          type: date
+        - description: The number of checks that failed with Danger status
+          jsonPath: .status.summary.failCount
           name: Fail
           priority: 1
-          description: The number of checks that failed with Danger status
-        - jsonPath: .status.summary.passCount
           type: integer
+        - description: The number of checks that passed
+          jsonPath: .status.summary.passCount
           name: Pass
           priority: 1
-          description: The number of checks that passed
+          type: integer
+      name: v1alpha1
       schema:
         openAPIV3Schema:
-          type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - spec
           properties:
             apiVersion:
               type: string
@@ -44,93 +43,95 @@ spec:
             metadata:
               type: object
             spec:
-              type: object
-              required:
-                - name
-                - description
-                - version
-                - cron
-                - controls
               properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                version:
-                  type: string
-                cron:
-                  type: string
-                  pattern: '^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec)) ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$'
-                  description: 'cron define the intervals for report generation'
                 controls:
-                  type: array
                   items:
-                    type: object
-                    required:
-                      - name
-                      - id
-                      - kinds
-                      - mapping
-                      - severity
                     properties:
-                      name:
+                      defaultStatus:
+                        description: define the default value for check status in case resource not found
+                        enum:
+                          - PASS
+                          - WARN
+                          - FAIL
                         type: string
                       description:
                         type: string
                       id:
+                        description: id define the control check id
                         type: string
-                        description: 'id define the control check id'
                       kinds:
-                        type: array
                         items:
-                          type: string
                           description: 'kinds define the list of kinds control check apply on , example: Node,Workload '
+                          type: string
+                        type: array
                       mapping:
-                        type: object
+                        properties:
+                          checks:
+                            items:
+                              properties:
+                                id:
+                                  description: id define the check id as produced by scanner
+                                  type: string
+                              required:
+                                - id
+                              type: object
+                            type: array
+                          scanner:
+                            description: scanner define the name of the scanner which produce data, currently only config-audit is supported
+                            pattern: ^config-audit$
+                            type: string
                         required:
                           - scanner
                           - checks
-                        properties:
-                          scanner:
-                            type: string
-                            pattern: '^config-audit$'
-                            description: 'scanner define the name of the scanner which produce data, currently only config-audit is supported'
-                          checks:
-                            type: array
-                            items:
-                              type: object
-                              required:
-                                - id
-                              properties:
-                                id:
-                                  type: string
-                                  description: 'id define the check id as produced by scanner'
-                      severity:
+                        type: object
+                      name:
                         type: string
-                        description: 'define the severity of the control'
+                      severity:
+                        description: define the severity of the control
                         enum:
                           - CRITICAL
                           - HIGH
                           - MEDIUM
                           - LOW
                           - UNKNOWN
-                      defaultStatus:
                         type: string
-                        description: 'define the default value for check status in case resource not found'
-                        enum:
-                          - PASS
-                          - WARN
-                          - FAIL
-            status:
-              x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                      - id
+                      - kinds
+                      - mapping
+                      - severity
+                    type: object
+                  type: array
+                cron:
+                  description: cron define the intervals for report generation
+                  pattern: >-
+                    ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec))
+                    ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$
+                  type: string
+                description:
+                  type: string
+                name:
+                  type: string
+                version:
+                  type: string
+              required:
+                - name
+                - description
+                - version
+                - cron
+                - controls
               type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - apiVersion
+            - kind
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
       subresources:
-        # status enables the status subresource.
-        status: { }
-  names:
-    singular: clustercompliancereport
-    plural: clustercompliancereports
-    kind: ClusterComplianceReport
-    listKind: ClusterComplianceReportList
-    shortNames:
-      - compliance
+        status: {}

--- a/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -2,54 +2,54 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterconfigauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: clusterconfigauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the config audit scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          priority: 1
-          description: The number of failed checks with critical severity
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          priority: 1
-          description: The number of failed checks with high severity
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          priority: 1
-          description: The number of failed checks with medium severity
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          priority: 1
-          description: The number of failed checks with low severity
-      schema:
-        openAPIV3Schema:
-          x-kubernetes-preserve-unknown-fields: true
-          type: object
-  scope: Cluster
   names:
-    singular: clusterconfigauditreport
-    plural: clusterconfigauditreports
     kind: ClusterConfigAuditReport
     listKind: ClusterConfigAuditReportList
+    plural: clusterconfigauditreports
     shortNames:
       - clusterconfigaudit
+    singular: clusterconfigauditreport
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: The name of the config audit scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of failed checks with critical severity
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of failed checks with high severity
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of failed checks with medium severity
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of failed checks with low severity
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -2,54 +2,54 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterrbacassessmentreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: clusterrbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the rbac assessment scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          priority: 1
-          description: The number of failed checks with critical severity
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          priority: 1
-          description: The number of failed checks with high severity
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          priority: 1
-          description: The number of failed checks with medium severity
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          priority: 1
-          description: The number of failed checks with low severity
-      schema:
-        openAPIV3Schema:
-          x-kubernetes-preserve-unknown-fields: true
-          type: object
-  scope: Cluster
   names:
-    singular: clusterrbacassessmentreport
-    plural: clusterrbacassessmentreports
     kind: ClusterRbacAssessmentReport
     listKind: ClusterRbacAssessmentReportList
+    plural: clusterrbacassessmentreports
     shortNames:
       - clusterrbacassessmentreport
+    singular: clusterrbacassessmentreport
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: The name of the rbac assessment scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of failed checks with critical severity
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of failed checks with high severity
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of failed checks with medium severity
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of failed checks with low severity
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/deploy/crd/aquasecurity.github.io_configauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_configauditreports.yaml
@@ -2,55 +2,55 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: configauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the config audit scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          priority: 1
-          description: The number of failed checks with critical severity
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          priority: 1
-          description: The number of failed checks with high severity
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          priority: 1
-          description: The number of failed checks with medium severity
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          priority: 1
-          description: The number of failed checks with low severity
-      schema:
-        openAPIV3Schema:
-          x-kubernetes-preserve-unknown-fields: true
-          type: object
-  scope: Namespaced
   names:
-    singular: configauditreport
-    plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
+    plural: configauditreports
     shortNames:
       - configaudit
       - configaudits
+    singular: configauditreport
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The name of the config audit scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of failed checks with critical severity
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of failed checks with high severity
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of failed checks with medium severity
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of failed checks with low severity
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
@@ -2,26 +2,64 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: exposedsecretreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: exposedsecretreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
+  names:
+    kind: ExposedSecretReport
+    listKind: ExposedSecretReportList
+    plural: exposedsecretreports
+    shortNames:
+      - exposedsecret
+      - exposedsecrets
+    singular: exposedsecretreport
+  scope: Namespaced
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+    - additionalPrinterColumns:
+        - description: The name of image repository
+          jsonPath: .report.artifact.repository
+          name: Repository
+          type: string
+        - description: The name of image tag
+          jsonPath: .report.artifact.tag
+          name: Tag
+          type: string
+        - description: The name of the exposed secret scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of critical exposed secrets
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of high exposed secrets
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of medium exposed secrets
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of low exposed secrets
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: |
             ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
-          type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
           properties:
             apiVersion:
               type: string
@@ -32,27 +70,41 @@ spec:
             report:
               description: |
                 Report is the actual exposed secret report data.
-              type: object
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - secrets 
               properties:
-                updateTimestamp:
+                artifact:
                   description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  type: string
-                  format: date-time
+                    Artifact represents a standalone, executable package of software that includes everything needed to
+                    run an application.
+                  properties:
+                    digest:
+                      description: |
+                        Digest is a unique and immutable identifier of an Artifact.
+                      type: string
+                    mimeType:
+                      description: |
+                        MimeType represents a type and format of an Artifact.
+                      type: string
+                    repository:
+                      description: |
+                        Repository is the name of the repository in the Artifact registry.
+                      type: string
+                    tag:
+                      description: |
+                        Tag is a mutable, human-readable string used to identify an Artifact.
+                      type: string
+                  type: object
+                registry:
+                  description: |
+                    Registry is the registry the Artifact was pulled from.
+                  properties:
+                    server:
+                      description: |
+                        Server the FQDN of registry server.
+                      type: string
+                  type: object
                 scanner:
                   description: |
                     Scanner is the scanner that generated this report.
-                  type: object
-                  required:
-                    - name
-                    - vendor
-                    - version
                   properties:
                     name:
                       description: |
@@ -66,147 +118,95 @@ spec:
                       description: |
                         Version the version of the scanner.
                       type: string
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
-                  type: object
-                  properties:
-                    server:
-                      description: |
-                        Server the FQDN of registry server.
-                      type: string
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
-                  type: object
-                  properties:
-                    repository:
-                      description: |
-                        Repository is the name of the repository in the Artifact registry.
-                      type: string
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
-                      type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
-                      type: string
-                    mimeType:
-                      description: |
-                        MimeType represents a type and format of an Artifact.
-                      type: string
-                summary:
-                  description: |
-                    Summary is the exposed secrets counts grouped by Severity.
-                  type: object
                   required:
-                    - criticalCount
-                    - highCount
-                    - mediumCount
-                    - lowCount
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of exposed secrets with Critical Severity.
-                      type: integer
-                      minimum: 0
-                    highCount:
-                      description: |
-                        HighCount is the number of exposed secrets with High Severity.
-                      type: integer
-                      minimum: 0
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of exposed secrets with Medium Severity.
-                      type: integer
-                      minimum: 0
-                    lowCount:
-                      description: |
-                        LowCount is the number of exposed secrets with Low Severity.
-                      type: integer
-                      minimum: 0
+                    - name
+                    - vendor
+                    - version
+                  type: object
                 secrets:
                   description: |
                     Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
-                  type: array
                   items:
-                    type: object
-                    required:
-                      - target
-                      - ruleID
-                      - title 
-                      - category 
-                      - severity
-                      - match
                     properties:
-                      target:
+                      category:
+                        type: string
+                      match:
                         description: |
-                          Target is where the exposed secret was found.
+                          Match where the exposed rule matched.
                         type: string
                       ruleID:
                         description: |
                           RuleID is rule the identifier.
                         type: string
-                      title:
-                        type: string
-                      category:
-                        type: string
                       severity:
-                        type: string
                         enum:
                           - CRITICAL
                           - HIGH
                           - MEDIUM
                           - LOW
-                      match:
-                        description: |
-                          Match where the exposed rule matched.
                         type: string
-      additionalPrinterColumns:
-        - jsonPath: .report.artifact.repository
-          type: string
-          name: Repository
-          description: The name of image repository
-        - jsonPath: .report.artifact.tag
-          type: string
-          name: Tag
-          description: The name of image tag
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the exposed secret scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          description: The number of critical exposed secrets
-          priority: 1
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          description: The number of high exposed secrets
-          priority: 1
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          description: The number of medium exposed secrets
-          priority: 1
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          description: The number of low exposed secrets
-          priority: 1
-  scope: Namespaced
-  names:
-    singular: exposedsecretreport
-    plural: exposedsecretreports
-    kind: ExposedSecretReport
-    listKind: ExposedSecretReportList
-    shortNames:
-      - exposedsecret 
-      - exposedsecrets
+                      target:
+                        description: |
+                          Target is where the exposed secret was found.
+                        type: string
+                      title:
+                        type: string
+                    required:
+                      - target
+                      - ruleID
+                      - title
+                      - category
+                      - severity
+                      - match
+                    type: object
+                  type: array
+                summary:
+                  description: |
+                    Summary is the exposed secrets counts grouped by Severity.
+                  properties:
+                    criticalCount:
+                      description: |
+                        CriticalCount is the number of exposed secrets with Critical Severity.
+                      minimum: 0
+                      type: integer
+                    highCount:
+                      description: |
+                        HighCount is the number of exposed secrets with High Severity.
+                      minimum: 0
+                      type: integer
+                    lowCount:
+                      description: |
+                        LowCount is the number of exposed secrets with Low Severity.
+                      minimum: 0
+                      type: integer
+                    mediumCount:
+                      description: |
+                        MediumCount is the number of exposed secrets with Medium Severity.
+                      minimum: 0
+                      type: integer
+                  required:
+                    - criticalCount
+                    - highCount
+                    - mediumCount
+                    - lowCount
+                  type: object
+                updateTimestamp:
+                  description: |
+                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                  format: date-time
+                  type: string
+              required:
+                - updateTimestamp
+                - scanner
+                - artifact
+                - summary
+                - secrets
+              type: object
+          required:
+            - apiVersion
+            - kind
+            - metadata
+            - report
+          type: object
+      served: true
+      storage: true

--- a/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -2,55 +2,55 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: rbacassessmentreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: rbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the rbac assessment scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          priority: 1
-          description: The number of failed checks with critical severity
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          priority: 1
-          description: The number of failed checks with high severity
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          priority: 1
-          description: The number of failed checks with medium severity
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          priority: 1
-          description: The number of failed checks with low severity
-      schema:
-        openAPIV3Schema:
-          x-kubernetes-preserve-unknown-fields: true
-          type: object
-  scope: Namespaced
   names:
-    singular: rbacassessmentreport
-    plural: rbacassessmentreports
     kind: RbacAssessmentReport
     listKind: RbacAssessmentReportList
+    plural: rbacassessmentreports
     shortNames:
       - rbacassessment
       - rbacassessments
+    singular: rbacassessmentreport
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The name of the rbac assessment scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of failed checks with critical severity
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of failed checks with high severity
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of failed checks with medium severity
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of failed checks with low severity
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -2,27 +2,70 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: vulnerabilityreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: 0.1.0
+  name: vulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
+  names:
+    kind: VulnerabilityReport
+    listKind: VulnerabilityReportList
+    plural: vulnerabilityreports
+    shortNames:
+      - vuln
+      - vulns
+    singular: vulnerabilityreport
+  scope: Namespaced
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+    - additionalPrinterColumns:
+        - description: The name of image repository
+          jsonPath: .report.artifact.repository
+          name: Repository
+          type: string
+        - description: The name of image tag
+          jsonPath: .report.artifact.tag
+          name: Tag
+          type: string
+        - description: The name of the vulnerability scanner
+          jsonPath: .report.scanner.name
+          name: Scanner
+          type: string
+        - description: The age of the report
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The number of critical vulnerabilities
+          jsonPath: .report.summary.criticalCount
+          name: Critical
+          priority: 1
+          type: integer
+        - description: The number of high vulnerabilities
+          jsonPath: .report.summary.highCount
+          name: High
+          priority: 1
+          type: integer
+        - description: The number of medium vulnerabilities
+          jsonPath: .report.summary.mediumCount
+          name: Medium
+          priority: 1
+          type: integer
+        - description: The number of low vulnerabilities
+          jsonPath: .report.summary.lowCount
+          name: Low
+          priority: 1
+          type: integer
+        - description: The number of unknown vulnerabilities
+          jsonPath: .report.summary.unknownCount
+          name: Unknown
+          priority: 1
+          type: integer
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: |
             VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
             built into container images.
-          type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
           properties:
             apiVersion:
               type: string
@@ -33,27 +76,41 @@ spec:
             report:
               description: |
                 Report is the actual vulnerability report data.
-              type: object
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - vulnerabilities
               properties:
-                updateTimestamp:
+                artifact:
                   description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  type: string
-                  format: date-time
+                    Artifact represents a standalone, executable package of software that includes everything needed to
+                    run an application.
+                  properties:
+                    digest:
+                      description: |
+                        Digest is a unique and immutable identifier of an Artifact.
+                      type: string
+                    mimeType:
+                      description: |
+                        MimeType represents a type and format of an Artifact.
+                      type: string
+                    repository:
+                      description: |
+                        Repository is the name of the repository in the Artifact registry.
+                      type: string
+                    tag:
+                      description: |
+                        Tag is a mutable, human-readable string used to identify an Artifact.
+                      type: string
+                  type: object
+                registry:
+                  description: |
+                    Registry is the registry the Artifact was pulled from.
+                  properties:
+                    server:
+                      description: |
+                        Server the FQDN of registry server.
+                      type: string
+                  type: object
                 scanner:
                   description: |
                     Scanner is the scanner that generated this report.
-                  type: object
-                  required:
-                    - name
-                    - vendor
-                    - version
                   properties:
                     name:
                       description: |
@@ -67,84 +124,100 @@ spec:
                       description: |
                         Version the version of the scanner.
                       type: string
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
+                  required:
+                    - name
+                    - vendor
+                    - version
                   type: object
-                  properties:
-                    server:
-                      description: |
-                        Server the FQDN of registry server.
-                      type: string
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
-                  type: object
-                  properties:
-                    repository:
-                      description: |
-                        Repository is the name of the repository in the Artifact registry.
-                      type: string
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
-                      type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
-                      type: string
-                    mimeType:
-                      description: |
-                        MimeType represents a type and format of an Artifact.
-                      type: string
                 summary:
                   description: |
                     Summary is a summary of Vulnerability counts grouped by Severity.
-                  type: object
+                  properties:
+                    criticalCount:
+                      description: |
+                        CriticalCount is the number of vulnerabilities with Critical Severity.
+                      minimum: 0
+                      type: integer
+                    highCount:
+                      description: |
+                        HighCount is the number of vulnerabilities with High Severity.
+                      minimum: 0
+                      type: integer
+                    lowCount:
+                      description: |
+                        LowCount is the number of vulnerabilities with Low Severity.
+                      minimum: 0
+                      type: integer
+                    mediumCount:
+                      description: |
+                        MediumCount is the number of vulnerabilities with Medium Severity.
+                      minimum: 0
+                      type: integer
+                    noneCount:
+                      description: |
+                        NoneCount is the number of packages without any vulnerability.
+                      minimum: 0
+                      type: integer
+                    unknownCount:
+                      description: |
+                        UnknownCount is the number of vulnerabilities with unknown severity.
+                      minimum: 0
+                      type: integer
                   required:
                     - criticalCount
                     - highCount
                     - mediumCount
                     - lowCount
                     - unknownCount
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of vulnerabilities with Critical Severity.
-                      type: integer
-                      minimum: 0
-                    highCount:
-                      description: |
-                        HighCount is the number of vulnerabilities with High Severity.
-                      type: integer
-                      minimum: 0
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of vulnerabilities with Medium Severity.
-                      type: integer
-                      minimum: 0
-                    lowCount:
-                      description: |
-                        LowCount is the number of vulnerabilities with Low Severity.
-                      type: integer
-                      minimum: 0
-                    unknownCount:
-                      description: |
-                        UnknownCount is the number of vulnerabilities with unknown severity.
-                      type: integer
-                      minimum: 0
-                    noneCount:
-                      description: |
-                        NoneCount is the number of packages without any vulnerability.
-                      type: integer
-                      minimum: 0
+                  type: object
+                updateTimestamp:
+                  description: |
+                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                  format: date-time
+                  type: string
                 vulnerabilities:
                   description: |
                     Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
-                  type: array
                   items:
-                    type: object
+                    properties:
+                      description:
+                        type: string
+                      fixedVersion:
+                        description: |
+                          FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
+                        type: string
+                      installedVersion:
+                        description: |
+                          InstalledVersion indicates the installed version of the Resource.
+                        type: string
+                      links:
+                        items:
+                          type: string
+                        type: array
+                      primaryLink:
+                        type: string
+                      resource:
+                        description: |
+                          Resource is a vulnerable package, application, or library.
+                        type: string
+                      score:
+                        type: number
+                      severity:
+                        enum:
+                          - CRITICAL
+                          - HIGH
+                          - MEDIUM
+                          - LOW
+                          - UNKNOWN
+                        type: string
+                      target:
+                        type: string
+                      title:
+                        type: string
+                      vulnerabilityID:
+                        description: |
+                          VulnerabilityID the vulnerability identifier.
+                        type: string
                     required:
                       - vulnerabilityID
                       - resource
@@ -152,93 +225,20 @@ spec:
                       - fixedVersion
                       - severity
                       - title
-                    properties:
-                      vulnerabilityID:
-                        description: |
-                          VulnerabilityID the vulnerability identifier.
-                        type: string
-                      resource:
-                        description: |
-                          Resource is a vulnerable package, application, or library.
-                        type: string
-                      installedVersion:
-                        description: |
-                          InstalledVersion indicates the installed version of the Resource.
-                        type: string
-                      fixedVersion:
-                        description: |
-                          FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
-                        type: string
-                      score:
-                        type: number
-                      severity:
-                        type: string
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                          - UNKNOWN
-                      title:
-                        type: string
-                      description:
-                        type: string
-                      primaryLink:
-                        type: string
-                      links:
-                        type: array
-                        items:
-                          type: string
-                      target:
-                        type: string
-      additionalPrinterColumns:
-        - jsonPath: .report.artifact.repository
-          type: string
-          name: Repository
-          description: The name of image repository
-        - jsonPath: .report.artifact.tag
-          type: string
-          name: Tag
-          description: The name of image tag
-        - jsonPath: .report.scanner.name
-          type: string
-          name: Scanner
-          description: The name of the vulnerability scanner
-        - jsonPath: .metadata.creationTimestamp
-          type: date
-          name: Age
-          description: The age of the report
-        - jsonPath: .report.summary.criticalCount
-          type: integer
-          name: Critical
-          description: The number of critical vulnerabilities
-          priority: 1
-        - jsonPath: .report.summary.highCount
-          type: integer
-          name: High
-          description: The number of high vulnerabilities
-          priority: 1
-        - jsonPath: .report.summary.mediumCount
-          type: integer
-          name: Medium
-          description: The number of medium vulnerabilities
-          priority: 1
-        - jsonPath: .report.summary.lowCount
-          type: integer
-          name: Low
-          description: The number of low vulnerabilities
-          priority: 1
-        - jsonPath: .report.summary.unknownCount
-          type: integer
-          name: Unknown
-          description: The number of unknown vulnerabilities
-          priority: 1
-  scope: Namespaced
-  names:
-    singular: vulnerabilityreport
-    plural: vulnerabilityreports
-    kind: VulnerabilityReport
-    listKind: VulnerabilityReportList
-    shortNames:
-      - vuln
-      - vulns
+                    type: object
+                  type: array
+              required:
+                - updateTimestamp
+                - scanner
+                - artifact
+                - summary
+                - vulnerabilities
+              type: object
+          required:
+            - apiVersion
+            - kind
+            - metadata
+            - report
+          type: object
+      served: true
+      storage: true


### PR DESCRIPTION
diff in 232 is a bit hard to read as the yaml files generated by
controller-gen are sorted alphabetically. This PR makes it a lot easier
to follow the changes introduced by controller-gen in 232.

I used VS Code extension (YAML sort) tool to sort the CRD files.

related to #204