### PR TITLE
Remove support for deprecated configmaps leader election lock type

### DIFF
--- a/deploy/helm/templates/leader_election.yaml
+++ b/deploy/helm/templates/leader_election.yaml
@@ -10,16 +10,6 @@ metadata:
     {{- include "trivy-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - list
-      - watch
-      - get
-      - create
-      - update
-  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -27,6 +17,10 @@ rules:
       - create
       - get
       - update
+      - list
+      - watch
+      - patch
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -31,7 +31,6 @@ rules:
       - services
       - resourcequotas
       - limitranges
-      - configmaps
     verbs:
       - get
       - list
@@ -243,16 +242,6 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - list
-      - watch
-      - get
-      - create
-      - update
-  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -260,6 +249,10 @@ rules:
       - create
       - get
       - update
+      - list
+      - watch
+      - patch
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -820,16 +820,6 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - list
-      - watch
-      - get
-      - create
-      - update
-  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -837,6 +827,10 @@ rules:
       - create
       - get
       - update
+      - list
+      - watch
+      - patch
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 var (
@@ -51,6 +52,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		options.LeaderElection = operatorConfig.LeaderElectionEnabled
 		options.LeaderElectionID = operatorConfig.LeaderElectionID
 		options.LeaderElectionNamespace = operatorNamespace
+		options.LeaderElectionResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	switch installMode {


### PR DESCRIPTION
"configmaps" hardcoded type is deprecated from v1.24+ and will be
removed from newer releases of client-go.