### PR TITLE
refactor: format CRDs with controller-gen list style

### DIFF
--- a/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
@@ -13,29 +13,29 @@ spec:
     listKind: ClusterComplianceDetailReportList
     plural: clustercompliancedetailreports
     shortNames:
-      - compliancedetail
+    - compliancedetail
     singular: clustercompliancedetailreport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of checks that failed with Danger status
-          jsonPath: .report.summary.failCount
-          name: Fail
-          priority: 1
-          type: integer
-        - description: The number of checks that passed
-          jsonPath: .report.summary.passCount
-          name: Pass
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of checks that failed with Danger status
+      jsonPath: .report.summary.failCount
+      name: Fail
+      priority: 1
+      type: integer
+    - description: The number of checks that passed
+      jsonPath: .report.summary.passCount
+      name: Pass
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true

--- a/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
@@ -13,125 +13,125 @@ spec:
     listKind: ClusterComplianceReportList
     plural: clustercompliancereports
     shortNames:
-      - compliance
+    - compliance
     singular: clustercompliancereport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of checks that failed with Danger status
-          jsonPath: .status.summary.failCount
-          name: Fail
-          priority: 1
-          type: integer
-        - description: The number of checks that passed
-          jsonPath: .status.summary.passCount
-          name: Pass
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                controls:
-                  items:
-                    properties:
-                      defaultStatus:
-                        description: define the default value for check status in case resource not found
-                        enum:
-                          - PASS
-                          - WARN
-                          - FAIL
+  - additionalPrinterColumns:
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of checks that failed with Danger status
+      jsonPath: .status.summary.failCount
+      name: Fail
+      priority: 1
+      type: integer
+    - description: The number of checks that passed
+      jsonPath: .status.summary.passCount
+      name: Pass
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              controls:
+                items:
+                  properties:
+                    defaultStatus:
+                      description: define the default value for check status in case resource not found
+                      enum:
+                      - PASS
+                      - WARN
+                      - FAIL
+                      type: string
+                    description:
+                      type: string
+                    id:
+                      description: id define the control check id
+                      type: string
+                    kinds:
+                      items:
+                        description: 'kinds define the list of kinds control check apply on , example: Node,Workload '
                         type: string
-                      description:
-                        type: string
-                      id:
-                        description: id define the control check id
-                        type: string
-                      kinds:
-                        items:
-                          description: 'kinds define the list of kinds control check apply on , example: Node,Workload '
+                      type: array
+                    mapping:
+                      properties:
+                        checks:
+                          items:
+                            properties:
+                              id:
+                                description: id define the check id as produced by scanner
+                                type: string
+                            required:
+                            - id
+                            type: object
+                          type: array
+                        scanner:
+                          description: scanner define the name of the scanner which produce data, currently only config-audit is supported
+                          pattern: ^config-audit$
                           type: string
-                        type: array
-                      mapping:
-                        properties:
-                          checks:
-                            items:
-                              properties:
-                                id:
-                                  description: id define the check id as produced by scanner
-                                  type: string
-                              required:
-                                - id
-                              type: object
-                            type: array
-                          scanner:
-                            description: scanner define the name of the scanner which produce data, currently only config-audit is supported
-                            pattern: ^config-audit$
-                            type: string
-                        required:
-                          - scanner
-                          - checks
-                        type: object
-                      name:
-                        type: string
-                      severity:
-                        description: define the severity of the control
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                          - UNKNOWN
-                        type: string
-                    required:
-                      - name
-                      - id
-                      - kinds
-                      - mapping
-                      - severity
-                    type: object
-                  type: array
-                cron:
-                  description: cron define the intervals for report generation
-                  pattern: >-
-                    ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec))
-                    ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$
-                  type: string
-                description:
-                  type: string
-                name:
-                  type: string
-                version:
-                  type: string
-              required:
-                - name
-                - description
-                - version
-                - cron
-                - controls
-              type: object
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      required:
+                      - scanner
+                      - checks
+                      type: object
+                    name:
+                      type: string
+                    severity:
+                      description: define the severity of the control
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      - UNKNOWN
+                      type: string
+                  required:
+                  - name
+                  - id
+                  - kinds
+                  - mapping
+                  - severity
+                  type: object
+                type: array
+              cron:
+                description: cron define the intervals for report generation
+                pattern: >-
+                  ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec))
+                  ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$
+                type: string
+              description:
+                type: string
+              name:
+                type: string
+              version:
+                type: string
+            required:
+            - name
+            - description
+            - version
+            - cron
+            - controls
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -13,43 +13,43 @@ spec:
     listKind: ClusterConfigAuditReportList
     plural: clusterconfigauditreports
     shortNames:
-      - clusterconfigaudit
+    - clusterconfigaudit
     singular: clusterconfigauditreport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the config audit scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true

--- a/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -13,43 +13,43 @@ spec:
     listKind: ClusterRbacAssessmentReportList
     plural: clusterrbacassessmentreports
     shortNames:
-      - clusterrbacassessmentreport
+    - clusterrbacassessmentreport
     singular: clusterrbacassessmentreport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the rbac assessment scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true

--- a/deploy/crd/aquasecurity.github.io_configauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_configauditreports.yaml
@@ -13,44 +13,44 @@ spec:
     listKind: ConfigAuditReportList
     plural: configauditreports
     shortNames:
-      - configaudit
-      - configaudits
+    - configaudit
+    - configaudits
     singular: configauditreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the config audit scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true

--- a/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
@@ -13,200 +13,200 @@ spec:
     listKind: ExposedSecretReportList
     plural: exposedsecretreports
     shortNames:
-      - exposedsecret
-      - exposedsecrets
+    - exposedsecret
+    - exposedsecrets
     singular: exposedsecretreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of image repository
-          jsonPath: .report.artifact.repository
-          name: Repository
-          type: string
-        - description: The name of image tag
-          jsonPath: .report.artifact.tag
-          name: Tag
-          type: string
-        - description: The name of the exposed secret scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of critical exposed secrets
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of high exposed secrets
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of medium exposed secrets
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of low exposed secrets
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            report:
-              description: |
-                Report is the actual exposed secret report data.
-              properties:
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the exposed secret scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical exposed secrets
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high exposed secrets
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium exposed secrets
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low exposed secrets
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |
+          ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          report:
+            description: |
+              Report is the actual exposed secret report data.
+            properties:
+              artifact:
+                description: |
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
+                properties:
+                  digest:
+                    description: |
+                      Digest is a unique and immutable identifier of an Artifact.
+                    type: string
+                  mimeType:
+                    description: |
+                      MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: |
+                      Repository is the name of the repository in the Artifact registry.
+                    type: string
+                  tag:
+                    description: |
+                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: |
+                  Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: |
+                      Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: |
+                  Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: |
+                      Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: |
+                      Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: |
+                      Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              secrets:
+                description: |
+                  Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
+                items:
                   properties:
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
+                    category:
                       type: string
-                    mimeType:
+                    match:
                       description: |
-                        MimeType represents a type and format of an Artifact.
+                        Match where the exposed rule matched.
                       type: string
-                    repository:
+                    ruleID:
                       description: |
-                        Repository is the name of the repository in the Artifact registry.
+                        RuleID is rule the identifier.
                       type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
+                    severity:
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
                       type: string
-                  type: object
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
-                  properties:
-                    server:
+                    target:
                       description: |
-                        Server the FQDN of registry server.
+                        Target is where the exposed secret was found.
                       type: string
-                  type: object
-                scanner:
-                  description: |
-                    Scanner is the scanner that generated this report.
-                  properties:
-                    name:
-                      description: |
-                        Name the name of the scanner.
-                      type: string
-                    vendor:
-                      description: |
-                        Vendor the name of the vendor providing the scanner.
-                      type: string
-                    version:
-                      description: |
-                        Version the version of the scanner.
+                    title:
                       type: string
                   required:
-                    - name
-                    - vendor
-                    - version
+                  - target
+                  - ruleID
+                  - title
+                  - category
+                  - severity
+                  - match
                   type: object
-                secrets:
-                  description: |
-                    Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
-                  items:
-                    properties:
-                      category:
-                        type: string
-                      match:
-                        description: |
-                          Match where the exposed rule matched.
-                        type: string
-                      ruleID:
-                        description: |
-                          RuleID is rule the identifier.
-                        type: string
-                      severity:
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                        type: string
-                      target:
-                        description: |
-                          Target is where the exposed secret was found.
-                        type: string
-                      title:
-                        type: string
-                    required:
-                      - target
-                      - ruleID
-                      - title
-                      - category
-                      - severity
-                      - match
-                    type: object
-                  type: array
-                summary:
-                  description: |
-                    Summary is the exposed secrets counts grouped by Severity.
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of exposed secrets with Critical Severity.
-                      minimum: 0
-                      type: integer
-                    highCount:
-                      description: |
-                        HighCount is the number of exposed secrets with High Severity.
-                      minimum: 0
-                      type: integer
-                    lowCount:
-                      description: |
-                        LowCount is the number of exposed secrets with Low Severity.
-                      minimum: 0
-                      type: integer
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of exposed secrets with Medium Severity.
-                      minimum: 0
-                      type: integer
-                  required:
-                    - criticalCount
-                    - highCount
-                    - mediumCount
-                    - lowCount
-                  type: object
-                updateTimestamp:
-                  description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  format: date-time
-                  type: string
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - secrets
-              type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
-          type: object
-      served: true
-      storage: true
+                type: array
+              summary:
+                description: |
+                  Summary is the exposed secrets counts grouped by Severity.
+                properties:
+                  criticalCount:
+                    description: |
+                      CriticalCount is the number of exposed secrets with Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: |
+                      HighCount is the number of exposed secrets with High Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: |
+                      LowCount is the number of exposed secrets with Low Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: |
+                      MediumCount is the number of exposed secrets with Medium Severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - mediumCount
+                - lowCount
+                type: object
+              updateTimestamp:
+                description: |
+                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                format: date-time
+                type: string
+            required:
+            - updateTimestamp
+            - scanner
+            - artifact
+            - summary
+            - secrets
+            type: object
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - report
+        type: object
+    served: true
+    storage: true

--- a/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -13,44 +13,44 @@ spec:
     listKind: RbacAssessmentReportList
     plural: rbacassessmentreports
     shortNames:
-      - rbacassessment
-      - rbacassessments
+    - rbacassessment
+    - rbacassessments
     singular: rbacassessmentreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the rbac assessment scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true

--- a/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -13,232 +13,232 @@ spec:
     listKind: VulnerabilityReportList
     plural: vulnerabilityreports
     shortNames:
-      - vuln
-      - vulns
+    - vuln
+    - vulns
     singular: vulnerabilityreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of image repository
-          jsonPath: .report.artifact.repository
-          name: Repository
-          type: string
-        - description: The name of image tag
-          jsonPath: .report.artifact.tag
-          name: Tag
-          type: string
-        - description: The name of the vulnerability scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of critical vulnerabilities
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of high vulnerabilities
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of medium vulnerabilities
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of low vulnerabilities
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-        - description: The number of unknown vulnerabilities
-          jsonPath: .report.summary.unknownCount
-          name: Unknown
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
-            built into container images.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            report:
-              description: |
-                Report is the actual vulnerability report data.
-              properties:
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the vulnerability scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical vulnerabilities
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high vulnerabilities
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium vulnerabilities
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low vulnerabilities
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    - description: The number of unknown vulnerabilities
+      jsonPath: .report.summary.unknownCount
+      name: Unknown
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |
+          VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
+          built into container images.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          report:
+            description: |
+              Report is the actual vulnerability report data.
+            properties:
+              artifact:
+                description: |
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
+                properties:
+                  digest:
+                    description: |
+                      Digest is a unique and immutable identifier of an Artifact.
+                    type: string
+                  mimeType:
+                    description: |
+                      MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: |
+                      Repository is the name of the repository in the Artifact registry.
+                    type: string
+                  tag:
+                    description: |
+                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: |
+                  Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: |
+                      Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: |
+                  Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: |
+                      Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: |
+                      Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: |
+                      Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: |
+                  Summary is a summary of Vulnerability counts grouped by Severity.
+                properties:
+                  criticalCount:
+                    description: |
+                      CriticalCount is the number of vulnerabilities with Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: |
+                      HighCount is the number of vulnerabilities with High Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: |
+                      LowCount is the number of vulnerabilities with Low Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: |
+                      MediumCount is the number of vulnerabilities with Medium Severity.
+                    minimum: 0
+                    type: integer
+                  noneCount:
+                    description: |
+                      NoneCount is the number of packages without any vulnerability.
+                    minimum: 0
+                    type: integer
+                  unknownCount:
+                    description: |
+                      UnknownCount is the number of vulnerabilities with unknown severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - mediumCount
+                - lowCount
+                - unknownCount
+                type: object
+              updateTimestamp:
+                description: |
+                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                format: date-time
+                type: string
+              vulnerabilities:
+                description: |
+                  Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
+                items:
                   properties:
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
+                    description:
                       type: string
-                    mimeType:
+                    fixedVersion:
                       description: |
-                        MimeType represents a type and format of an Artifact.
+                        FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
                       type: string
-                    repository:
+                    installedVersion:
                       description: |
-                        Repository is the name of the repository in the Artifact registry.
+                        InstalledVersion indicates the installed version of the Resource.
                       type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
+                    links:
+                      items:
+                        type: string
+                      type: array
+                    primaryLink:
                       type: string
-                  type: object
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
-                  properties:
-                    server:
+                    resource:
                       description: |
-                        Server the FQDN of registry server.
+                        Resource is a vulnerable package, application, or library.
                       type: string
-                  type: object
-                scanner:
-                  description: |
-                    Scanner is the scanner that generated this report.
-                  properties:
-                    name:
-                      description: |
-                        Name the name of the scanner.
+                    score:
+                      type: number
+                    severity:
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      - UNKNOWN
                       type: string
-                    vendor:
-                      description: |
-                        Vendor the name of the vendor providing the scanner.
+                    target:
                       type: string
-                    version:
+                    title:
+                      type: string
+                    vulnerabilityID:
                       description: |
-                        Version the version of the scanner.
+                        VulnerabilityID the vulnerability identifier.
                       type: string
                   required:
-                    - name
-                    - vendor
-                    - version
+                  - vulnerabilityID
+                  - resource
+                  - installedVersion
+                  - fixedVersion
+                  - severity
+                  - title
                   type: object
-                summary:
-                  description: |
-                    Summary is a summary of Vulnerability counts grouped by Severity.
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of vulnerabilities with Critical Severity.
-                      minimum: 0
-                      type: integer
-                    highCount:
-                      description: |
-                        HighCount is the number of vulnerabilities with High Severity.
-                      minimum: 0
-                      type: integer
-                    lowCount:
-                      description: |
-                        LowCount is the number of vulnerabilities with Low Severity.
-                      minimum: 0
-                      type: integer
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of vulnerabilities with Medium Severity.
-                      minimum: 0
-                      type: integer
-                    noneCount:
-                      description: |
-                        NoneCount is the number of packages without any vulnerability.
-                      minimum: 0
-                      type: integer
-                    unknownCount:
-                      description: |
-                        UnknownCount is the number of vulnerabilities with unknown severity.
-                      minimum: 0
-                      type: integer
-                  required:
-                    - criticalCount
-                    - highCount
-                    - mediumCount
-                    - lowCount
-                    - unknownCount
-                  type: object
-                updateTimestamp:
-                  description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  format: date-time
-                  type: string
-                vulnerabilities:
-                  description: |
-                    Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
-                  items:
-                    properties:
-                      description:
-                        type: string
-                      fixedVersion:
-                        description: |
-                          FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
-                        type: string
-                      installedVersion:
-                        description: |
-                          InstalledVersion indicates the installed version of the Resource.
-                        type: string
-                      links:
-                        items:
-                          type: string
-                        type: array
-                      primaryLink:
-                        type: string
-                      resource:
-                        description: |
-                          Resource is a vulnerable package, application, or library.
-                        type: string
-                      score:
-                        type: number
-                      severity:
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                          - UNKNOWN
-                        type: string
-                      target:
-                        type: string
-                      title:
-                        type: string
-                      vulnerabilityID:
-                        description: |
-                          VulnerabilityID the vulnerability identifier.
-                        type: string
-                    required:
-                      - vulnerabilityID
-                      - resource
-                      - installedVersion
-                      - fixedVersion
-                      - severity
-                      - title
-                    type: object
-                  type: array
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - vulnerabilities
-              type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
-          type: object
-      served: true
-      storage: true
+                type: array
+            required:
+            - updateTimestamp
+            - scanner
+            - artifact
+            - summary
+            - vulnerabilities
+            type: object
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - report
+        type: object
+    served: true
+    storage: true

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -13,235 +13,235 @@ spec:
     listKind: VulnerabilityReportList
     plural: vulnerabilityreports
     shortNames:
-      - vuln
-      - vulns
+    - vuln
+    - vulns
     singular: vulnerabilityreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of image repository
-          jsonPath: .report.artifact.repository
-          name: Repository
-          type: string
-        - description: The name of image tag
-          jsonPath: .report.artifact.tag
-          name: Tag
-          type: string
-        - description: The name of the vulnerability scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of critical vulnerabilities
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of high vulnerabilities
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of medium vulnerabilities
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of low vulnerabilities
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-        - description: The number of unknown vulnerabilities
-          jsonPath: .report.summary.unknownCount
-          name: Unknown
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
-            built into container images.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            report:
-              description: |
-                Report is the actual vulnerability report data.
-              properties:
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the vulnerability scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical vulnerabilities
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high vulnerabilities
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium vulnerabilities
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low vulnerabilities
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    - description: The number of unknown vulnerabilities
+      jsonPath: .report.summary.unknownCount
+      name: Unknown
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |
+          VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
+          built into container images.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          report:
+            description: |
+              Report is the actual vulnerability report data.
+            properties:
+              artifact:
+                description: |
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
+                properties:
+                  digest:
+                    description: |
+                      Digest is a unique and immutable identifier of an Artifact.
+                    type: string
+                  mimeType:
+                    description: |
+                      MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: |
+                      Repository is the name of the repository in the Artifact registry.
+                    type: string
+                  tag:
+                    description: |
+                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: |
+                  Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: |
+                      Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: |
+                  Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: |
+                      Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: |
+                      Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: |
+                      Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: |
+                  Summary is a summary of Vulnerability counts grouped by Severity.
+                properties:
+                  criticalCount:
+                    description: |
+                      CriticalCount is the number of vulnerabilities with Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: |
+                      HighCount is the number of vulnerabilities with High Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: |
+                      LowCount is the number of vulnerabilities with Low Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: |
+                      MediumCount is the number of vulnerabilities with Medium Severity.
+                    minimum: 0
+                    type: integer
+                  noneCount:
+                    description: |
+                      NoneCount is the number of packages without any vulnerability.
+                    minimum: 0
+                    type: integer
+                  unknownCount:
+                    description: |
+                      UnknownCount is the number of vulnerabilities with unknown severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - mediumCount
+                - lowCount
+                - unknownCount
+                type: object
+              updateTimestamp:
+                description: |
+                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                format: date-time
+                type: string
+              vulnerabilities:
+                description: |
+                  Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
+                items:
                   properties:
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
+                    description:
                       type: string
-                    mimeType:
+                    fixedVersion:
                       description: |
-                        MimeType represents a type and format of an Artifact.
+                        FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
                       type: string
-                    repository:
+                    installedVersion:
                       description: |
-                        Repository is the name of the repository in the Artifact registry.
+                        InstalledVersion indicates the installed version of the Resource.
                       type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
+                    links:
+                      items:
+                        type: string
+                      type: array
+                    primaryLink:
                       type: string
-                  type: object
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
-                  properties:
-                    server:
+                    resource:
                       description: |
-                        Server the FQDN of registry server.
+                        Resource is a vulnerable package, application, or library.
                       type: string
-                  type: object
-                scanner:
-                  description: |
-                    Scanner is the scanner that generated this report.
-                  properties:
-                    name:
-                      description: |
-                        Name the name of the scanner.
+                    score:
+                      type: number
+                    severity:
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      - UNKNOWN
                       type: string
-                    vendor:
-                      description: |
-                        Vendor the name of the vendor providing the scanner.
+                    target:
                       type: string
-                    version:
+                    title:
+                      type: string
+                    vulnerabilityID:
                       description: |
-                        Version the version of the scanner.
+                        VulnerabilityID the vulnerability identifier.
                       type: string
                   required:
-                    - name
-                    - vendor
-                    - version
+                  - vulnerabilityID
+                  - resource
+                  - installedVersion
+                  - fixedVersion
+                  - severity
+                  - title
                   type: object
-                summary:
-                  description: |
-                    Summary is a summary of Vulnerability counts grouped by Severity.
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of vulnerabilities with Critical Severity.
-                      minimum: 0
-                      type: integer
-                    highCount:
-                      description: |
-                        HighCount is the number of vulnerabilities with High Severity.
-                      minimum: 0
-                      type: integer
-                    lowCount:
-                      description: |
-                        LowCount is the number of vulnerabilities with Low Severity.
-                      minimum: 0
-                      type: integer
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of vulnerabilities with Medium Severity.
-                      minimum: 0
-                      type: integer
-                    noneCount:
-                      description: |
-                        NoneCount is the number of packages without any vulnerability.
-                      minimum: 0
-                      type: integer
-                    unknownCount:
-                      description: |
-                        UnknownCount is the number of vulnerabilities with unknown severity.
-                      minimum: 0
-                      type: integer
-                  required:
-                    - criticalCount
-                    - highCount
-                    - mediumCount
-                    - lowCount
-                    - unknownCount
-                  type: object
-                updateTimestamp:
-                  description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  format: date-time
-                  type: string
-                vulnerabilities:
-                  description: |
-                    Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
-                  items:
-                    properties:
-                      description:
-                        type: string
-                      fixedVersion:
-                        description: |
-                          FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
-                        type: string
-                      installedVersion:
-                        description: |
-                          InstalledVersion indicates the installed version of the Resource.
-                        type: string
-                      links:
-                        items:
-                          type: string
-                        type: array
-                      primaryLink:
-                        type: string
-                      resource:
-                        description: |
-                          Resource is a vulnerable package, application, or library.
-                        type: string
-                      score:
-                        type: number
-                      severity:
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                          - UNKNOWN
-                        type: string
-                      target:
-                        type: string
-                      title:
-                        type: string
-                      vulnerabilityID:
-                        description: |
-                          VulnerabilityID the vulnerability identifier.
-                        type: string
-                    required:
-                      - vulnerabilityID
-                      - resource
-                      - installedVersion
-                      - fixedVersion
-                      - severity
-                      - title
-                    type: object
-                  type: array
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - vulnerabilities
-              type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
-          type: object
-      served: true
-      storage: true
+                type: array
+            required:
+            - updateTimestamp
+            - scanner
+            - artifact
+            - summary
+            - vulnerabilities
+            type: object
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - report
+        type: object
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -257,47 +257,47 @@ spec:
     listKind: ConfigAuditReportList
     plural: configauditreports
     shortNames:
-      - configaudit
-      - configaudits
+    - configaudit
+    - configaudits
     singular: configauditreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the config audit scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -313,203 +313,203 @@ spec:
     listKind: ExposedSecretReportList
     plural: exposedsecretreports
     shortNames:
-      - exposedsecret
-      - exposedsecrets
+    - exposedsecret
+    - exposedsecrets
     singular: exposedsecretreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of image repository
-          jsonPath: .report.artifact.repository
-          name: Repository
-          type: string
-        - description: The name of image tag
-          jsonPath: .report.artifact.tag
-          name: Tag
-          type: string
-        - description: The name of the exposed secret scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of critical exposed secrets
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of high exposed secrets
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of medium exposed secrets
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of low exposed secrets
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            report:
-              description: |
-                Report is the actual exposed secret report data.
-              properties:
-                artifact:
-                  description: |
-                    Artifact represents a standalone, executable package of software that includes everything needed to
-                    run an application.
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the exposed secret scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical exposed secrets
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high exposed secrets
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium exposed secrets
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low exposed secrets
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |
+          ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          report:
+            description: |
+              Report is the actual exposed secret report data.
+            properties:
+              artifact:
+                description: |
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
+                properties:
+                  digest:
+                    description: |
+                      Digest is a unique and immutable identifier of an Artifact.
+                    type: string
+                  mimeType:
+                    description: |
+                      MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: |
+                      Repository is the name of the repository in the Artifact registry.
+                    type: string
+                  tag:
+                    description: |
+                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: |
+                  Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: |
+                      Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: |
+                  Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: |
+                      Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: |
+                      Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: |
+                      Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              secrets:
+                description: |
+                  Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
+                items:
                   properties:
-                    digest:
-                      description: |
-                        Digest is a unique and immutable identifier of an Artifact.
+                    category:
                       type: string
-                    mimeType:
+                    match:
                       description: |
-                        MimeType represents a type and format of an Artifact.
+                        Match where the exposed rule matched.
                       type: string
-                    repository:
+                    ruleID:
                       description: |
-                        Repository is the name of the repository in the Artifact registry.
+                        RuleID is rule the identifier.
                       type: string
-                    tag:
-                      description: |
-                        Tag is a mutable, human-readable string used to identify an Artifact.
+                    severity:
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
                       type: string
-                  type: object
-                registry:
-                  description: |
-                    Registry is the registry the Artifact was pulled from.
-                  properties:
-                    server:
+                    target:
                       description: |
-                        Server the FQDN of registry server.
+                        Target is where the exposed secret was found.
                       type: string
-                  type: object
-                scanner:
-                  description: |
-                    Scanner is the scanner that generated this report.
-                  properties:
-                    name:
-                      description: |
-                        Name the name of the scanner.
-                      type: string
-                    vendor:
-                      description: |
-                        Vendor the name of the vendor providing the scanner.
-                      type: string
-                    version:
-                      description: |
-                        Version the version of the scanner.
+                    title:
                       type: string
                   required:
-                    - name
-                    - vendor
-                    - version
+                  - target
+                  - ruleID
+                  - title
+                  - category
+                  - severity
+                  - match
                   type: object
-                secrets:
-                  description: |
-                    Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
-                  items:
-                    properties:
-                      category:
-                        type: string
-                      match:
-                        description: |
-                          Match where the exposed rule matched.
-                        type: string
-                      ruleID:
-                        description: |
-                          RuleID is rule the identifier.
-                        type: string
-                      severity:
-                        enum:
-                          - CRITICAL
-                          - HIGH
-                          - MEDIUM
-                          - LOW
-                        type: string
-                      target:
-                        description: |
-                          Target is where the exposed secret was found.
-                        type: string
-                      title:
-                        type: string
-                    required:
-                      - target
-                      - ruleID
-                      - title
-                      - category
-                      - severity
-                      - match
-                    type: object
-                  type: array
-                summary:
-                  description: |
-                    Summary is the exposed secrets counts grouped by Severity.
-                  properties:
-                    criticalCount:
-                      description: |
-                        CriticalCount is the number of exposed secrets with Critical Severity.
-                      minimum: 0
-                      type: integer
-                    highCount:
-                      description: |
-                        HighCount is the number of exposed secrets with High Severity.
-                      minimum: 0
-                      type: integer
-                    lowCount:
-                      description: |
-                        LowCount is the number of exposed secrets with Low Severity.
-                      minimum: 0
-                      type: integer
-                    mediumCount:
-                      description: |
-                        MediumCount is the number of exposed secrets with Medium Severity.
-                      minimum: 0
-                      type: integer
-                  required:
-                    - criticalCount
-                    - highCount
-                    - mediumCount
-                    - lowCount
-                  type: object
-                updateTimestamp:
-                  description: |
-                    UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
-                  format: date-time
-                  type: string
-              required:
-                - updateTimestamp
-                - scanner
-                - artifact
-                - summary
-                - secrets
-              type: object
-          required:
-            - apiVersion
-            - kind
-            - metadata
-            - report
-          type: object
-      served: true
-      storage: true
+                type: array
+              summary:
+                description: |
+                  Summary is the exposed secrets counts grouped by Severity.
+                properties:
+                  criticalCount:
+                    description: |
+                      CriticalCount is the number of exposed secrets with Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: |
+                      HighCount is the number of exposed secrets with High Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: |
+                      LowCount is the number of exposed secrets with Low Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: |
+                      MediumCount is the number of exposed secrets with Medium Severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - mediumCount
+                - lowCount
+                type: object
+              updateTimestamp:
+                description: |
+                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                format: date-time
+                type: string
+            required:
+            - updateTimestamp
+            - scanner
+            - artifact
+            - summary
+            - secrets
+            type: object
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - report
+        type: object
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -525,46 +525,46 @@ spec:
     listKind: ClusterConfigAuditReportList
     plural: clusterconfigauditreports
     shortNames:
-      - clusterconfigaudit
+    - clusterconfigaudit
     singular: clusterconfigauditreport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the config audit scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -580,46 +580,46 @@ spec:
     listKind: ClusterRbacAssessmentReportList
     plural: clusterrbacassessmentreports
     shortNames:
-      - clusterrbacassessmentreport
+    - clusterrbacassessmentreport
     singular: clusterrbacassessmentreport
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the rbac assessment scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -635,47 +635,47 @@ spec:
     listKind: RbacAssessmentReportList
     plural: rbacassessmentreports
     shortNames:
-      - rbacassessment
-      - rbacassessments
+    - rbacassessment
+    - rbacassessments
     singular: rbacassessmentreport
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The name of the rbac assessment scanner
-          jsonPath: .report.scanner.name
-          name: Scanner
-          type: string
-        - description: The age of the report
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: The number of failed checks with critical severity
-          jsonPath: .report.summary.criticalCount
-          name: Critical
-          priority: 1
-          type: integer
-        - description: The number of failed checks with high severity
-          jsonPath: .report.summary.highCount
-          name: High
-          priority: 1
-          type: integer
-        - description: The number of failed checks with medium severity
-          jsonPath: .report.summary.mediumCount
-          name: Medium
-          priority: 1
-          type: integer
-        - description: The number of failed checks with low severity
-          jsonPath: .report.summary.lowCount
-          name: Low
-          priority: 1
-          type: integer
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
## Description

Formatting the CRDs with controller-gen Yaml list style (same level as the map key). This will make it easier to review https://github.com/aquasecurity/trivy-operator/pull/232 (less changes). It seems to be impossible to control list indentation in controller-gen.

## Related issues
- Related #204 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
