### PR TITLE
Add signature generation to goreleaser configuration

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -39,11 +39,15 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2.4.1
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v3
         with:
           version: v1.7.0
           args: release --snapshot --skip-publish --rm-dist
+        env:
+          COSIGN_EXPERIMENTAL: 1
       - name: Scan Trivy Operator image for vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2.4.1
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -127,3 +129,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -220,3 +220,25 @@ docker_manifests:
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: all
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - "sign"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "${artifact}"
+    artifacts: all
+    output: true


### PR DESCRIPTION
## Description

This uses cosign to generate artifact signatures.

The proposed configuration will use the GitHub Actions token to sign the
generated artifacts (from goreleaser's artifacts pipeline), as well as
any generated containers.

Once a container is published, verification can be done with the
following command:

```bash
$ COSIGN_EXPERIMENTAL=1 cosign verify <container name>
```

Note that the current setup limits running goreleaser in GitHub Actions (or at
least with a GitHub token available)

## Related issues
- Close #XXX

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
