### PR TITLE
feat: pull scan job image from ghcr by default

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -110,7 +110,7 @@ trivy:
   createConfig: true
 
   # imageRef the Trivy image reference.
-  imageRef: docker.io/aquasec/trivy:0.29.1
+  imageRef: ghcr.io/aquasecurity/trivy:0.29.1
 
   # mode is the Trivy client mode. Either Standalone or ClientServer. Depending
   # on the active mode other settings might be applicable or required.

--- a/deploy/static/03-trivy-operator.config.yaml
+++ b/deploy/static/03-trivy-operator.config.yaml
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: kubectl
 data:
-  trivy.imageRef: "docker.io/aquasec/trivy:0.29.1"
+  trivy.imageRef: "ghcr.io/aquasecurity/trivy:0.29.1"
   trivy.mode: "Standalone"
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.dbRepository: "ghcr.io/aquasecurity/trivy-db"

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: kubectl
 data:
-  trivy.imageRef: "docker.io/aquasec/trivy:0.29.1"
+  trivy.imageRef: "ghcr.io/aquasecurity/trivy:0.29.1"
   trivy.mode: "Standalone"
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.dbRepository: "ghcr.io/aquasecurity/trivy-db"

--- a/docs/vulnerability-scanning/trivy.md
+++ b/docs/vulnerability-scanning/trivy.md
@@ -74,7 +74,7 @@ EOF
 
 | CONFIGMAP KEY                      | DEFAULT                            | DESCRIPTION                                                                                                                                                         |
 |------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `trivy.imageRef`                   | `docker.io/aquasec/trivy:0.29.1`   | Trivy image reference                                                                                                                                               |
+| `trivy.imageRef`                   | `ghcr.io/aquasecurity/trivy:0.29.1`   | Trivy image reference                                                                                                                                               |
 | `trivy.dbRepository`               | `ghcr.io/aquasecurity/trivy-db`    | External OCI Registry to download the vulnerability database                                                                                                        |
 | `trivy.dbRepositoryInsecure`       | `false`                            | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)                                                                           |
 | `trivy.mode`                       | `Standalone`                       | Trivy client mode. Either `Standalone` or `ClientServer`. Depending on the active mode other settings might be applicable or required.                              |

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -300,7 +300,7 @@ func NewTrivyConfigAuditPlugin(clock ext.Clock, idGenerator ext.IDGenerator, cli
 func (p *plugin) Init(ctx trivyoperator.PluginContext) error {
 	return ctx.EnsureConfig(trivyoperator.PluginConfig{
 		Data: map[string]string{
-			keyTrivyImageRef:                  "docker.io/aquasec/trivy:0.29.1",
+			keyTrivyImageRef:                  "ghcr.io/aquasecurity/trivy:0.29.1",
 			keyTrivySeverity:                  "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 			keyTrivyMode:                      string(Standalone),
 			keyTrivyTimeout:                   "5m0s",

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -525,7 +525,7 @@ func TestPlugin_Init(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Data: map[string]string{
-				"trivy.imageRef":                  "docker.io/aquasec/trivy:0.29.1",
+				"trivy.imageRef":                  "ghcr.io/aquasecurity/trivy:0.29.1",
 				"trivy.severity":                  "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 				"trivy.mode":                      "Standalone",
 				"trivy.timeout":                   "5m0s",
@@ -553,7 +553,7 @@ func TestPlugin_Init(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Data: map[string]string{
-					"trivy.imageRef": "docker.io/aquasec/trivy:0.29.1",
+					"trivy.imageRef": "ghcr.io/aquasecurity/trivy:0.29.1",
 					"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 					"trivy.mode":     "Standalone",
 				},
@@ -587,7 +587,7 @@ func TestPlugin_Init(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Data: map[string]string{
-				"trivy.imageRef": "docker.io/aquasec/trivy:0.29.1",
+				"trivy.imageRef": "ghcr.io/aquasecurity/trivy:0.29.1",
 				"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 				"trivy.mode":     "Standalone",
 			},


### PR DESCRIPTION
## Description

This changes the scan job image to be pulled from ghcr.io by default (was docker.io)

## Related issues
- Close #263 
- Close #251

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
