### PR TITLE
fix: getting imagePullSecrets should fail only if not exist in pod spec and service account

### DIFF
--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -187,13 +187,13 @@ func (r *secretsReader) ListImagePullSecretsByPodSpec(ctx context.Context, spec 
 		return nil, err
 	}
 	// if image pull secret define in either service account or pod spec and no secrets found
-	if r.impactPullSecretDefineAndNoSecretsFound(sa.ImagePullSecrets, serviceAccountSecrets, spec.ImagePullSecrets, secrets) {
+	if r.imagePullSecretDefineAndNoSecretsFound(sa.ImagePullSecrets, serviceAccountSecrets, spec.ImagePullSecrets, secrets) {
 		return nil, fmt.Errorf("failed to list secrets by imagePullSecrets ref %v and service account %s", spec.ImagePullSecrets, serviceAccountName)
 	}
 	return append(secrets, serviceAccountSecrets...), nil
 }
 
-func (r *secretsReader) impactPullSecretDefineAndNoSecretsFound(saImagePullSecretRef []corev1.LocalObjectReference, serviceAccountSecrets []corev1.Secret, imagePullSecretRef []corev1.LocalObjectReference, secrets []corev1.Secret) bool {
+func (r *secretsReader) imagePullSecretDefineAndNoSecretsFound(saImagePullSecretRef []corev1.LocalObjectReference, serviceAccountSecrets []corev1.Secret, imagePullSecretRef []corev1.LocalObjectReference, secrets []corev1.Secret) bool {
 	return len(saImagePullSecretRef) > 0 && len(serviceAccountSecrets) == 0 && len(imagePullSecretRef) > 0 && len(secrets) == 0
 }
 

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquasecurity/trivy-operator/pkg/docker"
 	corev1 "k8s.io/api/core/v1"
+	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -132,7 +133,6 @@ const (
 // SecretsReader defines methods for reading Secrets.
 type SecretsReader interface {
 	ListByLocalObjectReferences(ctx context.Context, refs []corev1.LocalObjectReference, ns string) ([]corev1.Secret, error)
-	ListByServiceAccount(ctx context.Context, name string, ns string) ([]corev1.Secret, error)
 	ListImagePullSecretsByPodSpec(ctx context.Context, spec corev1.PodSpec, ns string) ([]corev1.Secret, error)
 	CredentialsByWorkload(ctx context.Context, workload client.Object) (map[string]docker.Auth, error)
 }
@@ -155,26 +155,18 @@ func (r *secretsReader) ListByLocalObjectReferences(ctx context.Context, refs []
 		var secret corev1.Secret
 		err := r.client.Get(ctx, client.ObjectKey{Name: secretRef.Name, Namespace: ns}, &secret)
 		if err != nil {
+			if k8sapierror.IsNotFound(err) {
+				continue
+			}
 			return nil, fmt.Errorf("getting secret by name: %s/%s: %w", ns, secretRef.Name, err)
 		}
 		secrets = append(secrets, secret)
 	}
-
 	return secrets, nil
 }
 
-func (r *secretsReader) ListByServiceAccount(ctx context.Context, name string, ns string) ([]corev1.Secret, error) {
-	var sa corev1.ServiceAccount
-
-	err := r.client.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, &sa)
-	if err != nil {
-		return nil, fmt.Errorf("getting service account by name: %s/%s: %w", ns, name, err)
-	}
-
-	return r.ListByLocalObjectReferences(ctx, sa.ImagePullSecrets, ns)
-}
-
 func (r *secretsReader) ListImagePullSecretsByPodSpec(ctx context.Context, spec corev1.PodSpec, ns string) ([]corev1.Secret, error) {
+	// try to fetch image pull secret from pod spec
 	secrets, err := r.ListByLocalObjectReferences(ctx, spec.ImagePullSecrets, ns)
 	if err != nil {
 		return nil, err
@@ -184,13 +176,25 @@ func (r *secretsReader) ListImagePullSecretsByPodSpec(ctx context.Context, spec 
 	if serviceAccountName == "" {
 		serviceAccountName = serviceAccountDefault
 	}
-
-	serviceAccountSecrets, err := r.ListByServiceAccount(ctx, serviceAccountName, ns)
+	// try to fetch image pull secret from service account
+	var sa corev1.ServiceAccount
+	err = r.client.Get(ctx, client.ObjectKey{Name: serviceAccountName, Namespace: ns}, &sa)
+	if err != nil {
+		return nil, fmt.Errorf("getting service account by name: %s/%s: %w", ns, serviceAccountName, err)
+	}
+	serviceAccountSecrets, err := r.ListByLocalObjectReferences(ctx, sa.ImagePullSecrets, ns)
 	if err != nil {
 		return nil, err
 	}
-
+	// if image pull secret define in either service account or pod spec and no secrets found
+	if r.impactPullSecretDefineAndNoSecretsFound(sa.ImagePullSecrets, serviceAccountSecrets, spec.ImagePullSecrets, secrets) {
+		return nil, fmt.Errorf("failed to list secrets by imagePullSecrets ref %v and service account %s", spec.ImagePullSecrets, serviceAccountName)
+	}
 	return append(secrets, serviceAccountSecrets...), nil
+}
+
+func (r *secretsReader) impactPullSecretDefineAndNoSecretsFound(saImagePullSecretRef []corev1.LocalObjectReference, serviceAccountSecrets []corev1.Secret, imagePullSecretRef []corev1.LocalObjectReference, secrets []corev1.Secret) bool {
+	return len(saImagePullSecretRef) > 0 && len(serviceAccountSecrets) == 0 && len(imagePullSecretRef) > 0 && len(secrets) == 0
 }
 
 func (r *secretsReader) CredentialsByWorkload(ctx context.Context, workload client.Object) (map[string]docker.Auth, error) {

--- a/pkg/kube/testdata/fixture/sa_secret.json
+++ b/pkg/kube/testdata/fixture/sa_secret.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    ".dockerconfigjson": "ewoJImF1dGhzIjogewoJCSIqLmpmcm9nLmlvIjogeyJ1c2VybmFtZSI6Imhlbi5fdgfgfgluYW5AZ21haWwuY29tIiwicGFzc3dvcmQiOiJBS0NwOG1aSHFLTWR2eUtKRnJdsdsdsN3ODRQQ1hxYXRHaFlhV0R2Nnhycml0QVFGOHZvVDFBVmZ0QTQxajRtbm9yRURmTFRqd05EIiwiZW1haWwiOiJoZW4ua2VpbmFuQGdtYWlsLmNvbSJ9LAoJCSJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOiB7fQoJfSwKCSJjcmVkc1N0b3JlIjogIm9zeGtleWNoYWluIiwKCSJjcmVkSGVscGVycyI6IHsKCQkiZXVyb3BlLXdlc3QxLWRvY2tlci5wa2cuZGV2IjogImdjbG91ZCIKCX0KfQo="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2022-07-10T08:36:58Z",
+    "name": "myregistrykey",
+    "namespace": "default",
+    "resourceVersion": "317629",
+    "uid": "ab0f9c59-dab8-4c2d-98f6-a6fac0e9a35d"
+  },
+  "type": "kubernetes.io/dockerconfigjson"
+}

--- a/pkg/kube/testdata/fixture/sa_with_image_pull_secret.json
+++ b/pkg/kube/testdata/fixture/sa_with_image_pull_secret.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "ServiceAccount",
+  "metadata": {
+    "creationTimestamp": "2022-07-05T09:28:13Z",
+    "name": "default",
+    "namespace": "default",
+    "resourceVersion": "390",
+    "uid": "c5af80da-d909-44be-851c-8f68278d59f5"
+  },
+  "secrets": [
+    {
+      "name": "default-token-uudge"
+    }
+  ],
+  "imagePullSecrets": [
+    {
+      "name": "myregistrykey"
+    }
+  ]
+}

--- a/pkg/kube/testdata/fixture/sa_without_image_pull_secret.json
+++ b/pkg/kube/testdata/fixture/sa_without_image_pull_secret.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "v1",
+  "kind": "ServiceAccount",
+  "metadata": {
+    "creationTimestamp": "2022-07-05T09:28:13Z",
+    "name": "default",
+    "namespace": "default",
+    "resourceVersion": "390",
+    "uid": "c5af80da-d909-44be-851c-8f68278d59f5"
+  },
+  "secrets": [
+    {
+      "name": "default-token-uudge"
+    }
+  ]
+}

--- a/pkg/kube/testdata/fixture/secret.json
+++ b/pkg/kube/testdata/fixture/secret.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    ".dockerconfigjson": "ewoJImF1dGhzIjogewoJCSIqLmpmcm9nLmlvIjogeyJ1c2VybmFtZSI6Imhlbi5fdgfgfgluYW5AZ21haWwuY29tIiwicGFzc3dvcmQiOiJBS0NwOG1aSHFLTWR2eUtKRnJdsdsdsN3ODRQQ1hxYXRHaFlhV0R2Nnhycml0QVFGOHZvVDFBVmZ0QTQxajRtbm9yRURmTFRqd05EIiwiZW1haWwiOiJoZW4ua2VpbmFuQGdtYWlsLmNvbSJ9LAoJCSJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOiB7fQoJfSwKCSJjcmVkc1N0b3JlIjogIm9zeGtleWNoYWluIiwKCSJjcmVkSGVscGVycyI6IHsKCQkiZXVyb3BlLXdlc3QxLWRvY2tlci5wa2cuZGV2IjogImdjbG91ZCIKCX0KfQo="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2022-07-10T08:36:58Z",
+    "name": "regcred",
+    "namespace": "default",
+    "resourceVersion": "317629",
+    "uid": "ab0f9c59-dab8-4c2d-98f6-a6fac0e9a35d"
+  },
+  "type": "kubernetes.io/dockerconfigjson"
+}


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>
## Description
Getting imagePullSecrets should fail only if not exist in pod spec and service account

## Related issues
- Close #266 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
