### PR TITLE
chore: make CI verify all generated is up-to-date

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
       - name: Vendor Go modules
         run: go mod vendor
-      - name: Verify generated code
+      - name: Verify all generated
         run: make verify-generated
   unit-tests:
     name: Run unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,8 +225,8 @@ install the operator.
 To avoid maintaining resources in multiple places, we have a created a script
 to (re)generate the static resources from the Helm chart.
 
-So if modifying the operator resource, please do so by modifying the Helm
-chart, then run `./hack/update-static.yaml.sh` to ensure the static
+So if modifying the operator resources, please do so by modifying the Helm
+chart, then run `make manifests` to ensure the static
 resources are up-to-date.
 
 ## Operator Lifecycle Manager (OLM)

--- a/Makefile
+++ b/Makefile
@@ -130,12 +130,19 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: verify-generated
-verify-generated: generate
+verify-generated: generate-all
 	./hack/verify-generated.sh
 
 .PHONY: generate
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/apis/..."
+
+.PHONY: manifests
+manifests:
+	./hack/update-static.yaml.sh
+
+.PHONY: generate-all
+generate-all: generate manifests
 
 .PHONY: \
 	clean \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,9 +29,9 @@
       8. [`deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml`]
       9. [`deploy/static/01-trivy-operator.ns.yaml`]
       10. [`deploy/specs/nsa-1.0.yaml`]
-   3. Update [`deploy/static/trivy-operator.yaml`] by running the following script:
+   3. Update static resources from Helm chart by running the make target:
       ```
-      ./hack/update-static.yaml.sh
+      make manifests
       ```
    4. In [`mkdocs.yml`]
       1. Update the `extra.var.prev_git_tag` property


### PR DESCRIPTION
## Description

This adds new Makefile targets to generate manifests (currently just a wrapper around the `./hack/update-static.yaml.sh`) and to regenerate all checked in generated resources. I've tested that CI picks up outdated static resources now. I was a bit surprised to see that Helm already was installed in the CI image. 😉 

Also updating the contributor and releasing docs.

## Related issues
- Close #207 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
