### PR TITLE
chore: remove unused Helm chart values

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -212,17 +212,6 @@ compliance:
   # failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report
   failEntriesLimit: 10
 
-aqua:
-  # imageRef Aqua scanner image reference. The tag determines the version of the scanner binary executable and it must
-  # be compatible with version of Aqua server.
-  imageRef: docker.io/aquasec/scanner:5.3
-  # serverURL the endpoint URL of Aqua management console
-  serverURL:
-  # username the Aqua management console username
-  username:
-  # password the Aqua management console password
-  password:
-
 rbac:
   create: true
 serviceAccount:


### PR DESCRIPTION
## Description

This removes some values from the Helm chart that seems not in use, and might be confusing to users. In particular the image reference referring to an image that haven't been updated for a year or so: https://hub.docker.com/r/aquasec/scanner

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
