### PR TITLE
chore: use controller-gen to generate CRDs from Go markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,11 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/apis/..."
 
 .PHONY: manifests
-manifests:
+manifests: controller-gen
+# We must "allow dangerous types" because the API currently includes fields using floating point data types
+	$(CONTROLLER_GEN) crd:allowDangerousTypes=true paths="./pkg/apis/..." output:crd:artifacts:config=deploy/crd
+	mv deploy/crd/aquasecurity.github.io_clustercompliancedetailreports.yaml deploy/compliance
+	mv deploy/crd/aquasecurity.github.io_clustercompliancereports.yaml deploy/compliance
 	./hack/update-static.yaml.sh
 
 .PHONY: generate-all

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,16 +19,8 @@
       1. Update the `version` property
       2. Update the `appVersion` property
    2. Update the `app.kubernetes.io/version` labels in the following files:
-      1. [`deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml`]
-      2. [`deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml`]
-      3. [`deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml`]
-      4. [`deploy/crd/aquasecurity.github.io_configauditreports.yaml`]
-      5. [`deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml`]
-      6. [`deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml`]
-      7. [`deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml`]
-      8. [`deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml`]
-      9. [`deploy/static/01-trivy-operator.ns.yaml`]
-      10. [`deploy/specs/nsa-1.0.yaml`]
+      1. [`deploy/static/01-trivy-operator.ns.yaml`]
+      2. [`deploy/specs/nsa-1.0.yaml`]
    3. Update static resources from Helm chart by running the make target:
       ```
       make manifests

--- a/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancedetailreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clustercompliancedetailreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -35,7 +35,119 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterComplianceDetailReport is a specification for the ClusterComplianceDetailReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              controlCheck:
+                items:
+                  description: ControlCheckDetails provides the result of conducting
+                    a single audit step.
+                  properties:
+                    checkResults:
+                      items:
+                        properties:
+                          details:
+                            items:
+                              properties:
+                                msg:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                status:
+                                  type: string
+                              required:
+                              - msg
+                              - status
+                              type: object
+                            type: array
+                          id:
+                            type: string
+                          objectType:
+                            type: string
+                          remediation:
+                            type: string
+                        required:
+                        - details
+                        - objectType
+                        type: object
+                      type: array
+                    description:
+                      type: string
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      type: string
+                  required:
+                  - checkResults
+                  - id
+                  - name
+                  - severity
+                  type: object
+                type: array
+              summary:
+                properties:
+                  failCount:
+                    type: integer
+                  passCount:
+                    type: integer
+                required:
+                - failCount
+                - passCount
+                type: object
+              type:
+                description: Compliance is the specs for a security assessment report.
+                properties:
+                  description:
+                    description: Description of the compliance report.
+                    type: string
+                  name:
+                    description: Name the name of the compliance report.
+                    type: string
+                  version:
+                    description: Version the compliance report.
+                    type: string
+                required:
+                - description
+                - name
+                - version
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - controlCheck
+            - summary
+            - type
+            - updateTimestamp
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}

--- a/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
+++ b/deploy/compliance/aquasecurity.github.io_clustercompliancereports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clustercompliancereports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -35,20 +35,33 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterComplianceReport is a specification for the ClusterComplianceReport
+          resource.
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
+            description: ReportSpec represent the compliance specification
             properties:
               controls:
+                description: Control represent the cps controls data and mapping checks
                 items:
+                  description: Control represent the cps controls data and mapping
+                    checks
                   properties:
                     defaultStatus:
-                      description: define the default value for check status in case resource not found
+                      description: define the default value for check status in case
+                        resource not found
                       enum:
                       - PASS
                       - WARN
@@ -60,29 +73,36 @@ spec:
                       description: id define the control check id
                       type: string
                     kinds:
+                      description: 'kinds define the list of kinds control check apply
+                        on, example: Node,Workload'
                       items:
-                        description: 'kinds define the list of kinds control check apply on , example: Node,Workload '
                         type: string
                       type: array
                     mapping:
+                      description: Mapping represent the scanner who perform the control
+                        check
                       properties:
                         checks:
                           items:
+                            description: SpecCheck represent the scanner who perform
+                              the control check
                             properties:
                               id:
-                                description: id define the check id as produced by scanner
+                                description: id define the check id as produced by
+                                  scanner
                                 type: string
                             required:
                             - id
                             type: object
                           type: array
                         scanner:
-                          description: scanner define the name of the scanner which produce data, currently only config-audit is supported
+                          description: scanner define the name of the scanner which
+                            produce data, currently only config-audit is supported
                           pattern: ^config-audit$
                           type: string
                       required:
-                      - scanner
                       - checks
+                      - scanner
                       type: object
                     name:
                       type: string
@@ -96,17 +116,19 @@ spec:
                       - UNKNOWN
                       type: string
                   required:
-                  - name
                   - id
                   - kinds
                   - mapping
+                  - name
                   - severity
                   type: object
                 type: array
               cron:
                 description: cron define the intervals for report generation
-                pattern: >-
-                  ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec))
+                pattern: ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1})))
+                  ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1})))
+                  ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1})))
+                  ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec))
                   ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$
                 type: string
               description:
@@ -116,20 +138,59 @@ spec:
               version:
                 type: string
             required:
-            - name
-            - description
-            - version
-            - cron
             - controls
+            - cron
+            - description
+            - name
+            - version
             type: object
           status:
+            properties:
+              controlCheck:
+                items:
+                  description: ControlCheck provides the result of conducting a single
+                    audit step.
+                  properties:
+                    description:
+                      type: string
+                    failTotal:
+                      type: integer
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    passTotal:
+                      type: integer
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                  required:
+                  - failTotal
+                  - id
+                  - name
+                  - passTotal
+                  - severity
+                  type: object
+                type: array
+              summary:
+                properties:
+                  failCount:
+                    type: integer
+                  passCount:
+                    type: integer
+                required:
+                - failCount
+                - passCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - controlCheck
+            - summary
+            - updateTimestamp
             type: object
-            x-kubernetes-preserve-unknown-fields: true
-        required:
-        - apiVersion
-        - kind
-        - metadata
-        - spec
         type: object
     served: true
     storage: true

--- a/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clusterconfigauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -49,7 +49,125 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterConfigAuditReport is a specification for the ClusterConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clusterrbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -49,7 +49,128 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterRbacAssessmentReport is a specification for the ClusterRbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            - scanner
+            - summary
+            - updateTimestamp
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crd/aquasecurity.github.io_configauditreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_configauditreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: configauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -50,7 +50,125 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ConfigAuditReport is a specification for the ConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_exposedsecretreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: exposedsecretreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -58,65 +58,62 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |
-          ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
+        description: ExposedSecretReport summarizes exposed secrets in plaintext files
+          built into container images.
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           report:
-            description: |
-              Report is the actual exposed secret report data.
+            description: Report is the actual exposed secret report data.
             properties:
               artifact:
-                description: |
-                  Artifact represents a standalone, executable package of software that includes everything needed to
-                  run an application.
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
                 properties:
                   digest:
-                    description: |
-                      Digest is a unique and immutable identifier of an Artifact.
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
                     type: string
                   mimeType:
-                    description: |
-                      MimeType represents a type and format of an Artifact.
+                    description: MimeType represents a type and format of an Artifact.
                     type: string
                   repository:
-                    description: |
-                      Repository is the name of the repository in the Artifact registry.
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
                     type: string
                   tag:
-                    description: |
-                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
                     type: string
                 type: object
               registry:
-                description: |
-                  Registry is the registry the Artifact was pulled from.
+                description: Registry is the registry the Artifact was pulled from.
                 properties:
                   server:
-                    description: |
-                      Server the FQDN of registry server.
+                    description: Server the FQDN of registry server.
                     type: string
                 type: object
               scanner:
-                description: |
-                  Scanner is the scanner that generated this report.
+                description: Scanner is the scanner that generated this report.
                 properties:
                   name:
-                    description: |
-                      Name the name of the scanner.
+                    description: Name the name of the scanner.
                     type: string
                   vendor:
-                    description: |
-                      Vendor the name of the vendor providing the scanner.
+                    description: Vendor the name of the vendor providing the scanner.
                     type: string
                   version:
-                    description: |
-                      Version the version of the scanner.
+                    description: Version the version of the scanner.
                     type: string
                 required:
                 - name
@@ -124,21 +121,22 @@ spec:
                 - version
                 type: object
               secrets:
-                description: |
-                  Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
+                description: Exposed secrets is a list of passwords, api keys, tokens
+                  and others items found in the Artifact.
                 items:
+                  description: ExposedSecret is the spec for a exposed secret record.
                   properties:
                     category:
                       type: string
                     match:
-                      description: |
-                        Match where the exposed rule matched.
+                      description: Match where the exposed rule matched.
                       type: string
                     ruleID:
-                      description: |
-                        RuleID is rule the identifier.
+                      description: RuleID is rule the identifier.
                       type: string
                     severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
                       enum:
                       - CRITICAL
                       - HIGH
@@ -146,67 +144,63 @@ spec:
                       - LOW
                       type: string
                     target:
-                      description: |
-                        Target is where the exposed secret was found.
+                      description: Target is where the exposed secret was found.
                       type: string
                     title:
                       type: string
                   required:
-                  - target
-                  - ruleID
-                  - title
                   - category
-                  - severity
                   - match
+                  - ruleID
+                  - severity
+                  - target
+                  - title
                   type: object
                 type: array
               summary:
-                description: |
-                  Summary is the exposed secrets counts grouped by Severity.
+                description: Summary is the exposed secrets counts grouped by Severity.
                 properties:
                   criticalCount:
-                    description: |
-                      CriticalCount is the number of exposed secrets with Critical Severity.
+                    description: CriticalCount is the number of exposed secrets with
+                      Critical Severity.
                     minimum: 0
                     type: integer
                   highCount:
-                    description: |
-                      HighCount is the number of exposed secrets with High Severity.
+                    description: HighCount is the number of exposed secrets with High
+                      Severity.
                     minimum: 0
                     type: integer
                   lowCount:
-                    description: |
-                      LowCount is the number of exposed secrets with Low Severity.
+                    description: LowCount is the number of exposed secrets with Low
+                      Severity.
                     minimum: 0
                     type: integer
                   mediumCount:
-                    description: |
-                      MediumCount is the number of exposed secrets with Medium Severity.
+                    description: MediumCount is the number of exposed secrets with
+                      Medium Severity.
                     minimum: 0
                     type: integer
                 required:
                 - criticalCount
                 - highCount
-                - mediumCount
                 - lowCount
+                - mediumCount
                 type: object
               updateTimestamp:
-                description: |
-                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
                 format: date-time
                 type: string
             required:
-            - updateTimestamp
-            - scanner
             - artifact
-            - summary
+            - scanner
             - secrets
+            - summary
+            - updateTimestamp
             type: object
         required:
-        - apiVersion
-        - kind
-        - metadata
         - report
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: rbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -50,7 +50,128 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: RbacAssessmentReport is a specification for the RbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            - scanner
+            - summary
+            - updateTimestamp
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/deploy/crd/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: vulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -63,66 +63,62 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |
-          VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
-          built into container images.
+        description: VulnerabilityReport summarizes vulnerabilities in application
+          dependencies and operating system packages built into container images.
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           report:
-            description: |
-              Report is the actual vulnerability report data.
+            description: Report is the actual vulnerability report data.
             properties:
               artifact:
-                description: |
-                  Artifact represents a standalone, executable package of software that includes everything needed to
-                  run an application.
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
                 properties:
                   digest:
-                    description: |
-                      Digest is a unique and immutable identifier of an Artifact.
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
                     type: string
                   mimeType:
-                    description: |
-                      MimeType represents a type and format of an Artifact.
+                    description: MimeType represents a type and format of an Artifact.
                     type: string
                   repository:
-                    description: |
-                      Repository is the name of the repository in the Artifact registry.
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
                     type: string
                   tag:
-                    description: |
-                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
                     type: string
                 type: object
               registry:
-                description: |
-                  Registry is the registry the Artifact was pulled from.
+                description: Registry is the registry the Artifact was pulled from.
                 properties:
                   server:
-                    description: |
-                      Server the FQDN of registry server.
+                    description: Server the FQDN of registry server.
                     type: string
                 type: object
               scanner:
-                description: |
-                  Scanner is the scanner that generated this report.
+                description: Scanner is the scanner that generated this report.
                 properties:
                   name:
-                    description: |
-                      Name the name of the scanner.
+                    description: Name the name of the scanner.
                     type: string
                   vendor:
-                    description: |
-                      Vendor the name of the vendor providing the scanner.
+                    description: Vendor the name of the vendor providing the scanner.
                     type: string
                   version:
-                    description: |
-                      Version the version of the scanner.
+                    description: Version the version of the scanner.
                     type: string
                 required:
                 - name
@@ -130,65 +126,65 @@ spec:
                 - version
                 type: object
               summary:
-                description: |
-                  Summary is a summary of Vulnerability counts grouped by Severity.
+                description: Summary is a summary of Vulnerability counts grouped
+                  by Severity.
                 properties:
                   criticalCount:
-                    description: |
-                      CriticalCount is the number of vulnerabilities with Critical Severity.
+                    description: CriticalCount is the number of vulnerabilities with
+                      Critical Severity.
                     minimum: 0
                     type: integer
                   highCount:
-                    description: |
-                      HighCount is the number of vulnerabilities with High Severity.
+                    description: HighCount is the number of vulnerabilities with High
+                      Severity.
                     minimum: 0
                     type: integer
                   lowCount:
-                    description: |
-                      LowCount is the number of vulnerabilities with Low Severity.
+                    description: LowCount is the number of vulnerabilities with Low
+                      Severity.
                     minimum: 0
                     type: integer
                   mediumCount:
-                    description: |
-                      MediumCount is the number of vulnerabilities with Medium Severity.
+                    description: MediumCount is the number of vulnerabilities with
+                      Medium Severity.
                     minimum: 0
                     type: integer
                   noneCount:
-                    description: |
-                      NoneCount is the number of packages without any vulnerability.
+                    description: NoneCount is the number of packages without any vulnerability.
                     minimum: 0
                     type: integer
                   unknownCount:
-                    description: |
-                      UnknownCount is the number of vulnerabilities with unknown severity.
+                    description: UnknownCount is the number of vulnerabilities with
+                      unknown severity.
                     minimum: 0
                     type: integer
                 required:
                 - criticalCount
                 - highCount
-                - mediumCount
                 - lowCount
+                - mediumCount
                 - unknownCount
                 type: object
               updateTimestamp:
-                description: |
-                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
                 format: date-time
                 type: string
               vulnerabilities:
-                description: |
-                  Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
+                description: Vulnerabilities is a list of operating system (OS) or
+                  application software Vulnerability items found in the Artifact.
                 items:
+                  description: Vulnerability is the spec for a vulnerability record.
                   properties:
                     description:
                       type: string
                     fixedVersion:
-                      description: |
-                        FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
+                      description: FixedVersion indicates the version of the Resource
+                        in which this vulnerability has been fixed.
                       type: string
                     installedVersion:
-                      description: |
-                        InstalledVersion indicates the installed version of the Resource.
+                      description: InstalledVersion indicates the installed version
+                        of the Resource.
                       type: string
                     links:
                       items:
@@ -197,12 +193,14 @@ spec:
                     primaryLink:
                       type: string
                     resource:
-                      description: |
-                        Resource is a vulnerable package, application, or library.
+                      description: Resource is a vulnerable package, application,
+                        or library.
                       type: string
                     score:
                       type: number
                     severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
                       enum:
                       - CRITICAL
                       - HIGH
@@ -215,30 +213,27 @@ spec:
                     title:
                       type: string
                     vulnerabilityID:
-                      description: |
-                        VulnerabilityID the vulnerability identifier.
+                      description: VulnerabilityID the vulnerability identifier.
                       type: string
                   required:
-                  - vulnerabilityID
-                  - resource
-                  - installedVersion
                   - fixedVersion
+                  - installedVersion
+                  - resource
                   - severity
                   - title
+                  - vulnerabilityID
                   type: object
                 type: array
             required:
-            - updateTimestamp
-            - scanner
             - artifact
+            - scanner
             - summary
+            - updateTimestamp
             - vulnerabilities
             type: object
         required:
-        - apiVersion
-        - kind
-        - metadata
         - report
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: vulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -63,66 +63,62 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |
-          VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
-          built into container images.
+        description: VulnerabilityReport summarizes vulnerabilities in application
+          dependencies and operating system packages built into container images.
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           report:
-            description: |
-              Report is the actual vulnerability report data.
+            description: Report is the actual vulnerability report data.
             properties:
               artifact:
-                description: |
-                  Artifact represents a standalone, executable package of software that includes everything needed to
-                  run an application.
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
                 properties:
                   digest:
-                    description: |
-                      Digest is a unique and immutable identifier of an Artifact.
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
                     type: string
                   mimeType:
-                    description: |
-                      MimeType represents a type and format of an Artifact.
+                    description: MimeType represents a type and format of an Artifact.
                     type: string
                   repository:
-                    description: |
-                      Repository is the name of the repository in the Artifact registry.
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
                     type: string
                   tag:
-                    description: |
-                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
                     type: string
                 type: object
               registry:
-                description: |
-                  Registry is the registry the Artifact was pulled from.
+                description: Registry is the registry the Artifact was pulled from.
                 properties:
                   server:
-                    description: |
-                      Server the FQDN of registry server.
+                    description: Server the FQDN of registry server.
                     type: string
                 type: object
               scanner:
-                description: |
-                  Scanner is the scanner that generated this report.
+                description: Scanner is the scanner that generated this report.
                 properties:
                   name:
-                    description: |
-                      Name the name of the scanner.
+                    description: Name the name of the scanner.
                     type: string
                   vendor:
-                    description: |
-                      Vendor the name of the vendor providing the scanner.
+                    description: Vendor the name of the vendor providing the scanner.
                     type: string
                   version:
-                    description: |
-                      Version the version of the scanner.
+                    description: Version the version of the scanner.
                     type: string
                 required:
                 - name
@@ -130,65 +126,65 @@ spec:
                 - version
                 type: object
               summary:
-                description: |
-                  Summary is a summary of Vulnerability counts grouped by Severity.
+                description: Summary is a summary of Vulnerability counts grouped
+                  by Severity.
                 properties:
                   criticalCount:
-                    description: |
-                      CriticalCount is the number of vulnerabilities with Critical Severity.
+                    description: CriticalCount is the number of vulnerabilities with
+                      Critical Severity.
                     minimum: 0
                     type: integer
                   highCount:
-                    description: |
-                      HighCount is the number of vulnerabilities with High Severity.
+                    description: HighCount is the number of vulnerabilities with High
+                      Severity.
                     minimum: 0
                     type: integer
                   lowCount:
-                    description: |
-                      LowCount is the number of vulnerabilities with Low Severity.
+                    description: LowCount is the number of vulnerabilities with Low
+                      Severity.
                     minimum: 0
                     type: integer
                   mediumCount:
-                    description: |
-                      MediumCount is the number of vulnerabilities with Medium Severity.
+                    description: MediumCount is the number of vulnerabilities with
+                      Medium Severity.
                     minimum: 0
                     type: integer
                   noneCount:
-                    description: |
-                      NoneCount is the number of packages without any vulnerability.
+                    description: NoneCount is the number of packages without any vulnerability.
                     minimum: 0
                     type: integer
                   unknownCount:
-                    description: |
-                      UnknownCount is the number of vulnerabilities with unknown severity.
+                    description: UnknownCount is the number of vulnerabilities with
+                      unknown severity.
                     minimum: 0
                     type: integer
                 required:
                 - criticalCount
                 - highCount
-                - mediumCount
                 - lowCount
+                - mediumCount
                 - unknownCount
                 type: object
               updateTimestamp:
-                description: |
-                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
                 format: date-time
                 type: string
               vulnerabilities:
-                description: |
-                  Vulnerabilities is a list of operating system (OS) or application software Vulnerability items found in the Artifact.
+                description: Vulnerabilities is a list of operating system (OS) or
+                  application software Vulnerability items found in the Artifact.
                 items:
+                  description: Vulnerability is the spec for a vulnerability record.
                   properties:
                     description:
                       type: string
                     fixedVersion:
-                      description: |
-                        FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
+                      description: FixedVersion indicates the version of the Resource
+                        in which this vulnerability has been fixed.
                       type: string
                     installedVersion:
-                      description: |
-                        InstalledVersion indicates the installed version of the Resource.
+                      description: InstalledVersion indicates the installed version
+                        of the Resource.
                       type: string
                     links:
                       items:
@@ -197,12 +193,14 @@ spec:
                     primaryLink:
                       type: string
                     resource:
-                      description: |
-                        Resource is a vulnerable package, application, or library.
+                      description: Resource is a vulnerable package, application,
+                        or library.
                       type: string
                     score:
                       type: number
                     severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
                       enum:
                       - CRITICAL
                       - HIGH
@@ -215,40 +213,37 @@ spec:
                     title:
                       type: string
                     vulnerabilityID:
-                      description: |
-                        VulnerabilityID the vulnerability identifier.
+                      description: VulnerabilityID the vulnerability identifier.
                       type: string
                   required:
-                  - vulnerabilityID
-                  - resource
-                  - installedVersion
                   - fixedVersion
+                  - installedVersion
+                  - resource
                   - severity
                   - title
+                  - vulnerabilityID
                   type: object
                 type: array
             required:
-            - updateTimestamp
-            - scanner
             - artifact
+            - scanner
             - summary
+            - updateTimestamp
             - vulnerabilities
             type: object
         required:
-        - apiVersion
-        - kind
-        - metadata
         - report
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: configauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -294,17 +289,135 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ConfigAuditReport is a specification for the ConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: exposedsecretreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -358,65 +471,62 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |
-          ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
+        description: ExposedSecretReport summarizes exposed secrets in plaintext files
+          built into container images.
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           report:
-            description: |
-              Report is the actual exposed secret report data.
+            description: Report is the actual exposed secret report data.
             properties:
               artifact:
-                description: |
-                  Artifact represents a standalone, executable package of software that includes everything needed to
-                  run an application.
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
                 properties:
                   digest:
-                    description: |
-                      Digest is a unique and immutable identifier of an Artifact.
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
                     type: string
                   mimeType:
-                    description: |
-                      MimeType represents a type and format of an Artifact.
+                    description: MimeType represents a type and format of an Artifact.
                     type: string
                   repository:
-                    description: |
-                      Repository is the name of the repository in the Artifact registry.
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
                     type: string
                   tag:
-                    description: |
-                      Tag is a mutable, human-readable string used to identify an Artifact.
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
                     type: string
                 type: object
               registry:
-                description: |
-                  Registry is the registry the Artifact was pulled from.
+                description: Registry is the registry the Artifact was pulled from.
                 properties:
                   server:
-                    description: |
-                      Server the FQDN of registry server.
+                    description: Server the FQDN of registry server.
                     type: string
                 type: object
               scanner:
-                description: |
-                  Scanner is the scanner that generated this report.
+                description: Scanner is the scanner that generated this report.
                 properties:
                   name:
-                    description: |
-                      Name the name of the scanner.
+                    description: Name the name of the scanner.
                     type: string
                   vendor:
-                    description: |
-                      Vendor the name of the vendor providing the scanner.
+                    description: Vendor the name of the vendor providing the scanner.
                     type: string
                   version:
-                    description: |
-                      Version the version of the scanner.
+                    description: Version the version of the scanner.
                     type: string
                 required:
                 - name
@@ -424,21 +534,22 @@ spec:
                 - version
                 type: object
               secrets:
-                description: |
-                  Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
+                description: Exposed secrets is a list of passwords, api keys, tokens
+                  and others items found in the Artifact.
                 items:
+                  description: ExposedSecret is the spec for a exposed secret record.
                   properties:
                     category:
                       type: string
                     match:
-                      description: |
-                        Match where the exposed rule matched.
+                      description: Match where the exposed rule matched.
                       type: string
                     ruleID:
-                      description: |
-                        RuleID is rule the identifier.
+                      description: RuleID is rule the identifier.
                       type: string
                     severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
                       enum:
                       - CRITICAL
                       - HIGH
@@ -446,77 +557,73 @@ spec:
                       - LOW
                       type: string
                     target:
-                      description: |
-                        Target is where the exposed secret was found.
+                      description: Target is where the exposed secret was found.
                       type: string
                     title:
                       type: string
                   required:
-                  - target
-                  - ruleID
-                  - title
                   - category
-                  - severity
                   - match
+                  - ruleID
+                  - severity
+                  - target
+                  - title
                   type: object
                 type: array
               summary:
-                description: |
-                  Summary is the exposed secrets counts grouped by Severity.
+                description: Summary is the exposed secrets counts grouped by Severity.
                 properties:
                   criticalCount:
-                    description: |
-                      CriticalCount is the number of exposed secrets with Critical Severity.
+                    description: CriticalCount is the number of exposed secrets with
+                      Critical Severity.
                     minimum: 0
                     type: integer
                   highCount:
-                    description: |
-                      HighCount is the number of exposed secrets with High Severity.
+                    description: HighCount is the number of exposed secrets with High
+                      Severity.
                     minimum: 0
                     type: integer
                   lowCount:
-                    description: |
-                      LowCount is the number of exposed secrets with Low Severity.
+                    description: LowCount is the number of exposed secrets with Low
+                      Severity.
                     minimum: 0
                     type: integer
                   mediumCount:
-                    description: |
-                      MediumCount is the number of exposed secrets with Medium Severity.
+                    description: MediumCount is the number of exposed secrets with
+                      Medium Severity.
                     minimum: 0
                     type: integer
                 required:
                 - criticalCount
                 - highCount
-                - mediumCount
                 - lowCount
+                - mediumCount
                 type: object
               updateTimestamp:
-                description: |
-                  UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
                 format: date-time
                 type: string
             required:
-            - updateTimestamp
-            - scanner
             - artifact
-            - summary
+            - scanner
             - secrets
+            - summary
+            - updateTimestamp
             type: object
         required:
-        - apiVersion
-        - kind
-        - metadata
         - report
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clusterconfigauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -561,17 +668,135 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterConfigAuditReport is a specification for the ClusterConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: clusterrbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -616,17 +841,138 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterRbacAssessmentReport is a specification for the ClusterRbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            - scanner
+            - summary
+            - updateTimestamp
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: trivy-operator
-    app.kubernetes.io/version: 0.1.3
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: rbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -672,10 +1018,131 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: RbacAssessmentReport is a specification for the RbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            - scanner
+            - summary
+            - updateTimestamp
+            type: object
+        required:
+        - report
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: v1
 kind: Namespace

--- a/pkg/apis/aquasecurity/v1alpha1/compliance_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/compliance_types.go
@@ -10,6 +10,11 @@ type ClusterComplianceSummary struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster,shortName={compliance}
+//+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Fail",type=integer,JSONPath=`.status.summary.failCount`,priority=1,description="The number of checks that failed with Danger status"
+//+kubebuilder:printcolumn:name="Pass",type=integer,JSONPath=`.status.summary.passCount`,priority=1,description="The number of checks that passed"
 
 // ClusterComplianceReport is a specification for the ClusterComplianceReport resource.
 type ClusterComplianceReport struct {
@@ -21,31 +26,43 @@ type ClusterComplianceReport struct {
 
 //ReportSpec represent the compliance specification
 type ReportSpec struct {
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Cron        string    `json:"cron"`
-	Version     string    `json:"version"`
-	Controls    []Control `json:"controls"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// cron define the intervals for report generation
+	//+kubebuilder:validation:Pattern=`^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec)) ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$`
+	Cron    string `json:"cron"`
+	Version string `json:"version"`
+	// Control represent the cps controls data and mapping checks
+	Controls []Control `json:"controls"`
 }
 
 //Control represent the cps controls data and mapping checks
 type Control struct {
-	ID            string        `json:"id"`
-	Name          string        `json:"name"`
-	Description   string        `json:"description,omitempty"`
-	Kinds         []string      `json:"kinds"`
-	Mapping       Mapping       `json:"mapping"`
-	Severity      Severity      `json:"severity"`
+	// id define the control check id
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// kinds define the list of kinds control check apply on, example: Node,Workload
+	Kinds   []string `json:"kinds"`
+	Mapping Mapping  `json:"mapping"`
+	// define the severity of the control
+	//+kubebuilder:validation:Enum={CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN}
+	Severity Severity `json:"severity"`
+	// define the default value for check status in case resource not found
+	//+kubebuilder:validation:Enum={PASS,WARN,FAIL}
 	DefaultStatus ControlStatus `json:"defaultStatus,omitempty"`
 }
 
 //SpecCheck represent the scanner who perform the control check
 type SpecCheck struct {
+	// id define the check id as produced by scanner
 	ID string `json:"id"`
 }
 
 //Mapping represent the scanner who perform the control check
 type Mapping struct {
+	// scanner define the name of the scanner which produce data, currently only config-audit is supported
+	//+kubebuilder:validation:Pattern=`^config-audit$`
 	Scanner string      `json:"scanner"`
 	Checks  []SpecCheck `json:"checks"`
 }

--- a/pkg/apis/aquasecurity/v1alpha1/compliancedetail_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/compliancedetail_types.go
@@ -9,6 +9,10 @@ const (
 )
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster,shortName={compliancedetail}
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Fail",type=integer,JSONPath=`.report.summary.failCount`,priority=1,description="The number of checks that failed with Danger status"
+//+kubebuilder:printcolumn:name="Pass",type=integer,JSONPath=`.report.summary.passCount`,priority=1,description="The number of checks that passed"
 
 // ClusterComplianceDetailReport is a specification for the ClusterComplianceDetailReport resource.
 type ClusterComplianceDetailReport struct {
@@ -27,6 +31,8 @@ type ClusterComplianceDetailReportList struct {
 }
 
 type ClusterComplianceDetailReportData struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
 	UpdateTimestamp metav1.Time              `json:"updateTimestamp"`
 	Type            Compliance               `json:"type"`
 	Summary         ClusterComplianceSummary `json:"summary"`
@@ -35,9 +41,10 @@ type ClusterComplianceDetailReportData struct {
 
 // ControlCheckDetails provides the result of conducting a single audit step.
 type ControlCheckDetails struct {
-	ID                 string               `json:"id"`
-	Name               string               `json:"name"`
-	Description        string               `json:"description,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	//+kubebuilder:validation:Enum={CRITICAL,HIGH,MEDIUM,LOW}
 	Severity           Severity             `json:"severity"`
 	ScannerCheckResult []ScannerCheckResult `json:"checkResults"`
 }

--- a/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
@@ -21,6 +21,13 @@ type ConfigAuditSummary struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName={configaudit,configaudits}
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the config audit scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of failed checks with critical severity"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of failed checks with high severity"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of failed checks with medium severity"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of failed checks with low severity"
 
 // ConfigAuditReport is a specification for the ConfigAuditReport resource.
 type ConfigAuditReport struct {
@@ -41,6 +48,13 @@ type ConfigAuditReportList struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster,shortName={clusterconfigaudit}
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the config audit scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of failed checks with critical severity"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of failed checks with high severity"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of failed checks with medium severity"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of failed checks with low severity"
 
 // ClusterConfigAuditReport is a specification for the ClusterConfigAuditReport resource.
 type ClusterConfigAuditReport struct {
@@ -61,9 +75,12 @@ type ClusterConfigAuditReportList struct {
 }
 
 type ConfigAuditReportData struct {
-	UpdateTimestamp metav1.Time        `json:"updateTimestamp"`
-	Scanner         Scanner            `json:"scanner"`
-	Summary         ConfigAuditSummary `json:"summary"`
+	// +optional
+	UpdateTimestamp metav1.Time `json:"updateTimestamp"`
+	// +optional
+	Scanner Scanner `json:"scanner"`
+	// +optional
+	Summary ConfigAuditSummary `json:"summary"`
 
 	// Checks provides results of conducting audit steps.
 	Checks []Check `json:"checks"`

--- a/pkg/apis/aquasecurity/v1alpha1/exposed_secrets_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/exposed_secrets_types.go
@@ -7,15 +7,19 @@ import (
 // ExposedSecretSummary is a summary of ExposedSecret counts grouped by Severity.
 type ExposedSecretSummary struct {
 	// CriticalCount is the number of exposed secrets with Critical Severity.
+	//+kubebuilder:validation:Minimum=0
 	CriticalCount int `json:"criticalCount"`
 
 	// HighCount is the number of exposed secrets with High Severity.
+	//+kubebuilder:validation:Minimum=0
 	HighCount int `json:"highCount"`
 
 	// MediumCount is the number of exposed secrets with Medium Severity.
+	//+kubebuilder:validation:Minimum=0
 	MediumCount int `json:"mediumCount"`
 
 	// LowCount is the number of exposed secrets with Low Severity.
+	//+kubebuilder:validation:Minimum=0
 	LowCount int `json:"lowCount"`
 }
 
@@ -27,15 +31,26 @@ type ExposedSecret struct {
 	// RuleID is rule the identifier.
 	RuleID string `json:"ruleID"`
 
-	Title    string   `json:"title"`
-	Category string   `json:"category"`
+	Title    string `json:"title"`
+	Category string `json:"category"`
+	//+kubebuilder:validation:Enum={CRITICAL,HIGH,MEDIUM,LOW}
 	Severity Severity `json:"severity"`
-	Match    string   `json:"match"`
+	// Match where the exposed rule matched.
+	Match string `json:"match"`
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName={exposedsecret,exposedsecrets}
+//+kubebuilder:printcolumn:name="Repository",type=string,JSONPath=`.report.artifact.repository`,description="The name of image repository"
+//+kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.report.artifact.tag`,description="The name of image tag"
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the exposed secret scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of critical exposed secrets"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of high exposed secrets"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of medium exposed secrets"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of low exposed secrets"
 
-// ExposedSecretReport is a specification for the ExposedSecretReport resource.
+// ExposedSecretReport summarizes exposed secrets in plaintext files built into container images.
 type ExposedSecretReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,21 +65,25 @@ type ExposedSecretReport struct {
 // @see https://github.com/goharbor/pluggable-scanner-spec/blob/master/api/spec/scanner-adapter-openapi-v1.0.yaml
 type ExposedSecretReportData struct {
 	// UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
 	UpdateTimestamp metav1.Time `json:"updateTimestamp"`
 
 	// Scanner is the scanner that generated this report.
 	Scanner Scanner `json:"scanner"`
 
 	// Registry is the registry the Artifact was pulled from.
+	//+optional
 	Registry Registry `json:"registry"`
 
-	// Artifact is a container image scanned for exposed secrets.
+	// Artifact represents a standalone, executable package of software that includes everything needed to
+	// run an application.
 	Artifact Artifact `json:"artifact"`
 
-	// Summary is a summary of ExposedSecret counts grouped by Severity.
+	// Summary is the exposed secrets counts grouped by Severity.
 	Summary ExposedSecretSummary `json:"summary"`
 
-	// Secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
+	// Exposed secrets is a list of passwords, api keys, tokens and others items found in the Artifact.
 	Secrets []ExposedSecret `json:"secrets"`
 }
 

--- a/pkg/apis/aquasecurity/v1alpha1/rbac_assessment_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/rbac_assessment_types.go
@@ -21,6 +21,13 @@ type RbacAssessmentSummary struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName={rbacassessment,rbacassessments}
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the rbac assessment scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of failed checks with critical severity"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of failed checks with high severity"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of failed checks with medium severity"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of failed checks with low severity"
 
 // RbacAssessmentReport is a specification for the RbacAssessmentReport resource.
 type RbacAssessmentReport struct {
@@ -41,6 +48,13 @@ type RbacAssessmentReportList struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster,shortName={clusterrbacassessmentreport}
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the rbac assessment scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of failed checks with critical severity"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of failed checks with high severity"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of failed checks with medium severity"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of failed checks with low severity"
 
 // ClusterRbacAssessmentReport is a specification for the ClusterRbacAssessmentReport resource.
 type ClusterRbacAssessmentReport struct {

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -7,27 +7,35 @@ import (
 // VulnerabilitySummary is a summary of Vulnerability counts grouped by Severity.
 type VulnerabilitySummary struct {
 	// CriticalCount is the number of vulnerabilities with Critical Severity.
+	//+kubebuilder:validation:Minimum=0
 	CriticalCount int `json:"criticalCount"`
 
 	// HighCount is the number of vulnerabilities with High Severity.
+	//+kubebuilder:validation:Minimum=0
 	HighCount int `json:"highCount"`
 
 	// MediumCount is the number of vulnerabilities with Medium Severity.
+	//+kubebuilder:validation:Minimum=0
 	MediumCount int `json:"mediumCount"`
 
 	// LowCount is the number of vulnerabilities with Low Severity.
+	//+kubebuilder:validation:Minimum=0
 	LowCount int `json:"lowCount"`
 
 	// UnknownCount is the number of vulnerabilities with unknown severity.
+	//+kubebuilder:validation:Minimum=0
 	UnknownCount int `json:"unknownCount"`
 
 	// NoneCount is the number of packages without any vulnerability.
+	//+kubebuilder:validation:Minimum=0
+	//+optional
 	NoneCount int `json:"noneCount"`
 }
 
 // Registry is a collection of repositories used to store Artifacts.
 type Registry struct {
 	// Server the FQDN of registry server.
+	//+optional
 	Server string `json:"server"`
 }
 
@@ -35,15 +43,19 @@ type Registry struct {
 // includes everything needed to run an application.
 type Artifact struct {
 	// Repository is the name of the repository in the Artifact registry.
+	//+optional
 	Repository string `json:"repository"`
 
 	// Digest is a unique and immutable identifier of an Artifact.
+	//+optional
 	Digest string `json:"digest,omitempty"`
 
 	// Tag is a mutable, human-readable string used to identify an Artifact.
+	//+optional
 	Tag string `json:"tag,omitempty"`
 
 	// MimeType represents a type and format of an Artifact.
+	//+optional
 	MimeType string `json:"mimeType,omitempty"`
 }
 
@@ -61,18 +73,33 @@ type Vulnerability struct {
 	// FixedVersion indicates the version of the Resource in which this vulnerability has been fixed.
 	FixedVersion string `json:"fixedVersion"`
 
+	// Severity level of a vulnerability or a configuration audit check.
+	//+kubebuilder:validation:Enum={CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN}
 	Severity    Severity `json:"severity"`
 	Title       string   `json:"title"`
 	Description string   `json:"description,omitempty"`
 	PrimaryLink string   `json:"primaryLink,omitempty"`
-	Links       []string `json:"links"`
-	Score       *float64 `json:"score,omitempty"`
-	Target      string   `json:"target"`
+	//+optional
+	Links []string `json:"links"`
+	Score *float64 `json:"score,omitempty"`
+	//+optional
+	Target string `json:"target"`
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName={vuln,vulns}
+//+kubebuilder:printcolumn:name="Repository",type=string,JSONPath=`.report.artifact.repository`,description="The name of image repository"
+//+kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.report.artifact.tag`,description="The name of image tag"
+//+kubebuilder:printcolumn:name="Scanner",type=string,JSONPath=`.report.scanner.name`,description="The name of the vulnerability scanner"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of the report"
+//+kubebuilder:printcolumn:name="Critical",type=integer,JSONPath=`.report.summary.criticalCount`,priority=1,description="The number of critical vulnerabilities"
+//+kubebuilder:printcolumn:name="High",type=integer,JSONPath=`.report.summary.highCount`,priority=1,description="The number of high vulnerabilities"
+//+kubebuilder:printcolumn:name="Medium",type=integer,JSONPath=`.report.summary.mediumCount`,priority=1,description="The number of medium vulnerabilities"
+//+kubebuilder:printcolumn:name="Low",type=integer,JSONPath=`.report.summary.lowCount`,priority=1,description="The number of low vulnerabilities"
+//+kubebuilder:printcolumn:name="Unknown",type=integer,JSONPath=`.report.summary.unknownCount`,priority=1,description="The number of unknown vulnerabilities"
 
-// VulnerabilityReport is a specification for the VulnerabilityReport resource.
+// VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
+// built into container images.
 type VulnerabilityReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -87,15 +114,19 @@ type VulnerabilityReport struct {
 // @see https://github.com/goharbor/pluggable-scanner-spec/blob/master/api/spec/scanner-adapter-openapi-v1.0.yaml
 type VulnerabilityReportData struct {
 	// UpdateTimestamp is a timestamp representing the server time in UTC when this report was updated.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
 	UpdateTimestamp metav1.Time `json:"updateTimestamp"`
 
 	// Scanner is the scanner that generated this report.
 	Scanner Scanner `json:"scanner"`
 
 	// Registry is the registry the Artifact was pulled from.
+	//+optional
 	Registry Registry `json:"registry"`
 
-	// Artifact is a container image scanned for Vulnerabilities.
+	// Artifact represents a standalone, executable package of software that includes everything needed to
+	// run an application.
 	Artifact Artifact `json:"artifact"`
 
 	// Summary is a summary of Vulnerability counts grouped by Severity.
@@ -112,5 +143,6 @@ type VulnerabilityReportList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
 
+	// Vulnerability is the spec for a vulnerability record.
 	Items []VulnerabilityReport `json:"items"`
 }


### PR DESCRIPTION
## Description

Picking up https://github.com/aquasecurity/trivy-operator/pull/232, as @padlar (we are working on the same team) is not available this week, and I want to get this in as soon as possible - as it will allow me/us to suggest improvements to trivy-operator more easily. I have talked to @padlar, and got a confirmation that it's ok to finalize the changes suggested in https://github.com/aquasecurity/trivy-operator/pull/232.

This PR suggests using controller-gen to generate all CRDs from now on. After a couple of pre-PRs, I think this now looks close enough to the currently hand-coded CRDs, and possible to review.

Sadly, the labels currently added to the CRDs (version and managed-by) cannot be sustained with this change, as this is an eschewed feature in controller-gen: https://github.com/kubernetes-sigs/controller-tools/issues/454. We should be able to get them back if https://github.com/aquasecurity/trivy-operator/discussions/239 lands on a migration to kustomize as the master format.

## Related issues
- Addresses pt 2 in https://github.com/aquasecurity/trivy-operator/issues/204
- Close https://github.com/aquasecurity/trivy-operator/pull/232

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
