### PR TITLE
Use explicit permissions for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,10 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## Description

This trims down the permissions for the release GitHub workflow. Thus,
now only adding to the OIDC token the needed permissions.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
