### PR TITLE
Pass GitHub token to snapshot workflow's goreleaser action

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+    permissions:
+      id-token: write
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -47,6 +47,7 @@ jobs:
           version: v1.7.0
           args: release --snapshot --skip-publish --rm-dist
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1
       - name: Scan Trivy Operator image for vulnerabilities
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
## Description

The token is required for cosign to retrieve a certificate for the
signature. Even if this job won't actually publish anything, it still
does the signing part (which is good to test).

This is fixed by passing the GitHub token to the goreleaser action as an
environment variable.

This also explicitly adds permissions for the job to use OIDC tokens.

## Related issues
- Close #291

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
