### PR TITLE
Also publish container images to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,11 +121,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to ECR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.0.0
         with:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-amd64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-amd64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-amd64"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile
@@ -84,6 +85,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-arm64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-arm64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-arm64"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile
@@ -103,6 +105,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-arm64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi8
@@ -122,6 +125,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-s390x"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-s390x"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-s390x"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile
@@ -141,6 +145,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-ppc64le"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ppc64le"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ppc64le"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile
@@ -160,6 +165,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-s390x"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi8
@@ -179,6 +185,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-ppc64le"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi8
@@ -220,6 +227,18 @@ docker_manifests:
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+  - name_template: "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-amd64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-arm64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-s390x"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ppc64le"
+  - name_template: "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8"
+    image_templates:
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
 
 signs:
   - cmd: cosign

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,6 +54,8 @@
        `docker.io/aquasec/trivy-operator:0.13.1`
    2. Trivy-operator container images published to Amazon ECR Public Gallery
        `public.ecr.aws/aquasecurity/trivy-operator:0.13.1`
+   2. Trivy-operator container images published to GitHub Container Registry
+       `ghcr.io/aquasecurity/trivy-operator:0.13.1`
  7. Publish the Helm chart by manually triggering the [`.github/workflows/publish-helm-chart.yaml`] workflow
 8. Publish docs on https://aquasecurity.github.io/trivy-operator/ by manually triggering the [`.github/workflows/publish-docs.yaml`] workflow
 9. Submit trivy-operator Operator to OperatorHub and ArtifactHUB by opening the PR to the https://github.com/k8s-operatorhub/community-operators repository.


### PR DESCRIPTION
## Description

This uses the existing workflow token to publish container images to
GHCR. The advante of using this is that it's already hosted in the same
infrastructure as the jobs that are building the containers, and it uses
existing tokens for authentication; so there's no need to store or
manage secrets for this registry.

## Related issues
- Close #261

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
