### PR TITLE
Enable gosec for security linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
     - errorlint
     - govet
+    - gosec
   disable:
     - gosimple
     - ineffassign

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -511,8 +511,8 @@ func (r *ResourceController) reconcileClusterConfig(kind kube.Kind) reconcile.Fu
 func clusterRbacReportItems(crar v1alpha1.ClusterRbacAssessmentReportList) func() (client.ObjectList, []client.Object) {
 	return func() (client.ObjectList, []client.Object) {
 		objlist := make([]client.Object, 0)
-		for _, item := range crar.Items {
-			objlist = append(objlist, &item)
+		for idx := range crar.Items {
+			objlist = append(objlist, &crar.Items[idx])
 		}
 		return &crar, objlist
 	}
@@ -521,8 +521,8 @@ func clusterRbacReportItems(crar v1alpha1.ClusterRbacAssessmentReportList) func(
 func rbacReportItems(rar v1alpha1.RbacAssessmentReportList) func() (client.ObjectList, []client.Object) {
 	return func() (client.ObjectList, []client.Object) {
 		objlist := make([]client.Object, 0)
-		for _, item := range rar.Items {
-			objlist = append(objlist, &item)
+		for idx := range rar.Items {
+			objlist = append(objlist, &rar.Items[idx])
 		}
 		return &rar, objlist
 	}
@@ -531,8 +531,8 @@ func rbacReportItems(rar v1alpha1.RbacAssessmentReportList) func() (client.Objec
 func clusterAuditConfigReportItems(ccar v1alpha1.ClusterConfigAuditReportList) func() (client.ObjectList, []client.Object) {
 	return func() (client.ObjectList, []client.Object) {
 		objlist := make([]client.Object, 0)
-		for _, item := range ccar.Items {
-			objlist = append(objlist, &item)
+		for idx := range ccar.Items {
+			objlist = append(objlist, &ccar.Items[idx])
 		}
 		return &ccar, objlist
 	}
@@ -540,8 +540,8 @@ func clusterAuditConfigReportItems(ccar v1alpha1.ClusterConfigAuditReportList) f
 func auditConfigReportItems(car v1alpha1.ConfigAuditReportList) func() (client.ObjectList, []client.Object) {
 	return func() (client.ObjectList, []client.Object) {
 		objlist := make([]client.Object, 0)
-		for _, item := range car.Items {
-			objlist = append(objlist, &item)
+		for idx := range car.Items {
+			objlist = append(objlist, &car.Items[idx])
 		}
 		return &car, objlist
 	}

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -51,18 +51,21 @@ const (
 	keyTrivyHTTPProxy              = "trivy.httpProxy"
 	keyTrivyHTTPSProxy             = "trivy.httpsProxy"
 	keyTrivyNoProxy                = "trivy.noProxy"
-	keyTrivyGitHubToken            = "trivy.githubToken"
-	keyTrivySkipFiles              = "trivy.skipFiles"
-	keyTrivySkipDirs               = "trivy.skipDirs"
-	keyTrivyDBRepository           = "trivy.dbRepository"
-	keyTrivyDBRepositoryInsecure   = "trivy.dbRepositoryInsecure"
+	// nolint:gosec // This is not a secret, but a configuration value.
+	keyTrivyGitHubToken          = "trivy.githubToken"
+	keyTrivySkipFiles            = "trivy.skipFiles"
+	keyTrivySkipDirs             = "trivy.skipDirs"
+	keyTrivyDBRepository         = "trivy.dbRepository"
+	keyTrivyDBRepositoryInsecure = "trivy.dbRepositoryInsecure"
 
 	keyTrivyUseBuiltinRegoPolicies    = "trivy.useBuiltinRegoPolicies"
 	keyTrivySupportedConfigAuditKinds = "trivy.supportedConfigAuditKinds"
 
-	keyTrivyServerURL           = "trivy.serverURL"
-	keyTrivyServerTokenHeader   = "trivy.serverTokenHeader"
-	keyTrivyServerInsecure      = "trivy.serverInsecure"
+	keyTrivyServerURL = "trivy.serverURL"
+	// nolint:gosec // This is not a secret, but a configuration value.
+	keyTrivyServerTokenHeader = "trivy.serverTokenHeader"
+	keyTrivyServerInsecure    = "trivy.serverInsecure"
+	// nolint:gosec // This is not a secret, but a configuration value.
 	keyTrivyServerToken         = "trivy.serverToken"
 	keyTrivyServerCustomHeaders = "trivy.serverCustomHeaders"
 


### PR DESCRIPTION
## Description

gosec does static analysis on the go code-base. it's already a linter in
golangci-lint, so enabling it is quite simple.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
