### PR TITLE
refactor: move TTL controller to where it is used

### DIFF
--- a/pkg/operator/jobs/jobs_suite_test.go
+++ b/pkg/operator/jobs/jobs_suite_test.go
@@ -1,4 +1,4 @@
-package controller
+package jobs
 
 import (
 	"testing"
@@ -9,6 +9,6 @@ import (
 
 func TestPredicate(t *testing.T) {
 	RegisterFailHandler(Fail)
-	suiteName := "Controller Suite"
+	suiteName := "Jobs Suite"
 	RunSpecs(t, suiteName)
 }

--- a/pkg/operator/jobs/limit_checker.go
+++ b/pkg/operator/jobs/limit_checker.go
@@ -1,4 +1,4 @@
-package controller
+package jobs
 
 import (
 	"context"

--- a/pkg/operator/jobs/limit_checker_test.go
+++ b/pkg/operator/jobs/limit_checker_test.go
@@ -1,4 +1,4 @@
-package controller_test
+package jobs_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -6,8 +6,8 @@ import (
 
 	"context"
 
-	"github.com/aquasecurity/trivy-operator/pkg/operator/controller"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/jobs"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := controller.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
+			instance := jobs.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeTrue())
@@ -80,7 +80,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := controller.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
+			instance := jobs.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeFalse())
@@ -121,7 +121,7 @@ var _ = Describe("LimitChecker", func() {
 			).Build()
 			trivyOperatorConfig := defaultTrivyOperatorConfig
 			trivyOperatorConfig[trivyoperator.KeyVulnerabilityScansInSameNamespace] = "true"
-			instance := controller.NewLimitChecker(config, client, trivyOperatorConfig)
+			instance := jobs.NewLimitChecker(config, client, trivyOperatorConfig)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeTrue())

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/controller"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/jobs"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,7 +37,7 @@ type WorkloadController struct {
 	etc.Config
 	client.Client
 	kube.ObjectResolver
-	controller.LimitChecker
+	jobs.LimitChecker
 	kube.LogsReader
 	kube.SecretsReader
 	Plugin

--- a/pkg/vulnerabilityreport/ttl_report.go
+++ b/pkg/vulnerabilityreport/ttl_report.go
@@ -1,4 +1,4 @@
-package controller
+package vulnerabilityreport
 
 import (
 	"context"


### PR DESCRIPTION
## Description

This is a small refactoring, mainly to move the `VulnerabilityScannerReport` TTL controller to where it is actually used. Also renamed the `controller` package to `jobs`, since it now only contains the code to check job count limits. Keeping it separate from `VulnerabilityScannerReport`, since it eventually can be reused later.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
