### PR TITLE
Add missing GHCR template in goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,7 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-amd64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
+      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
     use: buildx
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi8


### PR DESCRIPTION
## Description

the `-ubi8-amd64` template was missing from the original inclusion of
GHCR to the list of registries we push to. This is now fixed.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
