### PR TITLE
chore: remove nodes RBAC permissions from clusterrole

### DIFF
--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -36,14 +36,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
   # Permissions required to read workload image pull secrets and create scan job image pull secrets
   - apiGroups:
       - ""

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -36,14 +36,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
   # Permissions required to read workload image pull secrets and create scan job image pull secrets
   - apiGroups:
       - ""

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1191,14 +1191,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
   # Permissions required to read workload image pull secrets and create scan job image pull secrets
   - apiGroups:
       - ""


### PR DESCRIPTION
## Description

While working on https://github.com/aquasecurity/trivy-operator/pull/276, I noticed that trivy-operator is granted permissions to read nodes, which it does not need - at least not atm. It might be required when reintroducing CIS Benchmarks ( https://github.com/aquasecurity/trivy-operator/issues/141), but I suggest to remove it for now.

## Related issues
- Relates to #187 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
