### PR TITLE
feat: ability to add additional labels to serviceMonitor

### DIFF
--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.serviceMonitor.namespace }}
   namespaceSelector:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -80,6 +80,8 @@ serviceMonitor:
   # The namespace where Prometheus expects to find service monitors
   # namespace: ""
   interval: ""
+  # Additional labels for the serviceMonitor
+  labels: {}
   # honorLabels: true
 
 trivyOperator:


### PR DESCRIPTION
Signed-off-by: David <davidcalvertfr@gmail.com>

## Description

Added the ability to add additional labels to the serviceMonitor in the helm chart.
This is required if you use a custom serviceMonitorSelector in kube-prometheus-stack : 

```
    serviceMonitorSelector:
      matchLabels:
        mycustomlabel: somevalue
```

Source: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L2394

I didn't created an associated issue because I consider this to be a trivial fix, but can create one if needed.
As I'm not sure about the release process, I didn't increase the chart version.
Let me know if I need to increment the semver or do something else.

David

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
