### PR TITLE
chore: add .gitattributes with linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Make GitHub keep certain files from displaying in diffs by default
+
+deploy/static/02-trivy-operator.rbac.yaml linguist-generated=true
+deploy/static/03-trivy-operator.config.yaml linguist-generated=true
+deploy/static/04-trivy-operator.policies.yaml linguist-generated=true
+deploy/static/05-trivy-operator.deployment.yaml linguist-generated=true
+deploy/static/06-trivy-operator.service.yaml linguist-generated=true
+deploy/static/trivy-operator.yaml linguist-generated=true


### PR DESCRIPTION
## Description

This adds a `.gitattributes` file containing `linguist-generated` attributes making [GitHub keep certain files from displaying in diffs by default](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github).

Motivation: Ease the review process with focus on source files (by default) and improve the repository's language statistics.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
