### PR TITLE
refactor: sort ClusterRole rules by apiGroups, resources

### DIFF
--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -7,6 +7,22 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods
     verbs:
       - get
@@ -31,31 +47,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - resourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - limitranges
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
     verbs:
       - get
       - list
@@ -76,17 +68,17 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
+      - ""
     resources:
-      - replicasets
+      - services
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - apps
+      - apiextensions.k8s.io
     resources:
-      - statefulsets
+      - customresourcedefinitions
     verbs:
       - get
       - list
@@ -108,83 +100,17 @@ rules:
       - list
       - watch
   - apiGroups:
-      - batch
+      - apps
     resources:
-      - jobs
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
+      - replicasets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - apps
     resources:
-      - roles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
+      - statefulsets
     verbs:
       - get
       - list
@@ -192,7 +118,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - vulnerabilityreports
+      - clustercompliancedetailreports
     verbs:
       - get
       - list
@@ -203,7 +129,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - exposedsecretreports
+      - clustercompliancereports
     verbs:
       - get
       - list
@@ -214,14 +140,9 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - configauditreports
+      - clustercompliancereports/status
     verbs:
-      - get
-      - list
-      - watch
-      - create
       - update
-      - delete
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -247,6 +168,28 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
+      - configauditreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - exposedsecretreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
       - rbacassessmentreports
     verbs:
       - get
@@ -258,7 +201,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - clustercompliancereports
+      - vulnerabilityreports
     verbs:
       - get
       - list
@@ -267,19 +210,76 @@ rules:
       - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - batch
     resources:
-      - clustercompliancedetailreports
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - get
       - list
       - watch
       - create
-      - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - networking.k8s.io
     resources:
-      - clustercompliancereports/status
+      - ingresses
     verbs:
-      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -20,6 +20,22 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods
     verbs:
       - get
@@ -44,31 +60,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - resourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - limitranges
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
     verbs:
       - get
       - list
@@ -89,17 +81,17 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
+      - ""
     resources:
-      - replicasets
+      - services
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - apps
+      - apiextensions.k8s.io
     resources:
-      - statefulsets
+      - customresourcedefinitions
     verbs:
       - get
       - list
@@ -121,83 +113,17 @@ rules:
       - list
       - watch
   - apiGroups:
-      - batch
+      - apps
     resources:
-      - jobs
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
+      - replicasets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - apps
     resources:
-      - roles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
+      - statefulsets
     verbs:
       - get
       - list
@@ -205,7 +131,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - vulnerabilityreports
+      - clustercompliancedetailreports
     verbs:
       - get
       - list
@@ -216,7 +142,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - exposedsecretreports
+      - clustercompliancereports
     verbs:
       - get
       - list
@@ -227,14 +153,9 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - configauditreports
+      - clustercompliancereports/status
     verbs:
-      - get
-      - list
-      - watch
-      - create
       - update
-      - delete
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -260,6 +181,28 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
+      - configauditreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - exposedsecretreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
       - rbacassessmentreports
     verbs:
       - get
@@ -271,7 +214,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - clustercompliancereports
+      - vulnerabilityreports
     verbs:
       - get
       - list
@@ -280,22 +223,79 @@ rules:
       - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - batch
     resources:
-      - clustercompliancedetailreports
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - get
       - list
       - watch
       - create
-      - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - networking.k8s.io
     resources:
-      - clustercompliancereports/status
+      - ingresses
     verbs:
-      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: trivy-operator/templates/rbac.yaml
 # permissions for end users to view configauditreports

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1175,6 +1175,22 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods
     verbs:
       - get
@@ -1199,31 +1215,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - resourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - limitranges
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
     verbs:
       - get
       - list
@@ -1244,17 +1236,17 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
+      - ""
     resources:
-      - replicasets
+      - services
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - apps
+      - apiextensions.k8s.io
     resources:
-      - statefulsets
+      - customresourcedefinitions
     verbs:
       - get
       - list
@@ -1276,83 +1268,17 @@ rules:
       - list
       - watch
   - apiGroups:
-      - batch
+      - apps
     resources:
-      - jobs
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
+      - replicasets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - apps
     resources:
-      - roles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
+      - statefulsets
     verbs:
       - get
       - list
@@ -1360,7 +1286,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - vulnerabilityreports
+      - clustercompliancedetailreports
     verbs:
       - get
       - list
@@ -1371,7 +1297,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - exposedsecretreports
+      - clustercompliancereports
     verbs:
       - get
       - list
@@ -1382,14 +1308,9 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - configauditreports
+      - clustercompliancereports/status
     verbs:
-      - get
-      - list
-      - watch
-      - create
       - update
-      - delete
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -1415,6 +1336,28 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
+      - configauditreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - exposedsecretreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
       - rbacassessmentreports
     verbs:
       - get
@@ -1426,7 +1369,7 @@ rules:
   - apiGroups:
       - aquasecurity.github.io
     resources:
-      - clustercompliancereports
+      - vulnerabilityreports
     verbs:
       - get
       - list
@@ -1435,22 +1378,79 @@ rules:
       - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - batch
     resources:
-      - clustercompliancedetailreports
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - get
       - list
       - watch
       - create
-      - update
       - delete
   - apiGroups:
-      - aquasecurity.github.io
+      - networking.k8s.io
     resources:
-      - clustercompliancereports/status
+      - ingresses
     verbs:
-      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: trivy-operator/templates/rbac.yaml
 # permissions for end users to view configauditreports


### PR DESCRIPTION
## Description

This is the next in line towards resolving https://github.com/aquasecurity/trivy-operator/issues/204. Since controller-gen is sorting the RBAC rules by `apiGroups`, then `resources`, I think it is safest if we do the sorting as a pre-PR before migrating to generating the clusterrole. Please let me know if you can think of a more review-friendly approach...

Next PR before migrating to generating will be yaml lists formatting.

## Related issues
- Relates to #204 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
