### PR TITLE
refactor: sort ClusterRole rules[].verbs

### DIFF
--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -120,23 +120,23 @@ rules:
     resources:
       - clustercompliancedetailreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clustercompliancereports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -148,67 +148,67 @@ rules:
     resources:
       - clusterconfigauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clusterrbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - configauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - exposedsecretreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - rbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - batch
     resources:
@@ -222,11 +222,11 @@ rules:
     resources:
       - jobs
     verbs:
+      - create
+      - delete
       - get
       - list
       - watch
-      - create
-      - delete
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -133,23 +133,23 @@ rules:
     resources:
       - clustercompliancedetailreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clustercompliancereports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -161,67 +161,67 @@ rules:
     resources:
       - clusterconfigauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clusterrbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - configauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - exposedsecretreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - rbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - batch
     resources:
@@ -235,11 +235,11 @@ rules:
     resources:
       - jobs
     verbs:
+      - create
+      - delete
       - get
       - list
       - watch
-      - create
-      - delete
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1288,23 +1288,23 @@ rules:
     resources:
       - clustercompliancedetailreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clustercompliancereports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
@@ -1316,67 +1316,67 @@ rules:
     resources:
       - clusterconfigauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - clusterrbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - configauditreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - exposedsecretreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - rbacassessmentreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
       - update
-      - delete
+      - watch
   - apiGroups:
       - batch
     resources:
@@ -1390,11 +1390,11 @@ rules:
     resources:
       - jobs
     verbs:
+      - create
+      - delete
       - get
       - list
       - watch
-      - create
-      - delete
   - apiGroups:
       - networking.k8s.io
     resources:


### PR DESCRIPTION
## Description

This is the next in line towards resolving https://github.com/aquasecurity/trivy-operator/issues/204. Since controller-gen is sorting the RBAC rules verbs, I think it is safest if we do the sorting as a pre-PR before migrating to generating the clusterrole.

Command used to do this: `yq -i '.rules[].verbs |= sort()' deploy/helm/generated/role.yaml`

## Related issues
- Relates to https://github.com/aquasecurity/trivy-operator/issues/204

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
