### PR TITLE
Revert "chore: disable caching of secrets and serviceaccounts (#276)"

### DIFF
--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -60,11 +60,15 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
+      - list
+      - watch
     verbs:
       - get
   - apiGroups:

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -73,11 +73,15 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
+      - list
+      - watch
     verbs:
       - get
   - apiGroups:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1228,11 +1228,15 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
+      - list
+      - watch
     verbs:
       - get
   - apiGroups:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -17,11 +17,9 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -48,12 +46,6 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		Scheme:                 trivyoperator.NewScheme(),
 		MetricsBindAddress:     operatorConfig.MetricsBindAddress,
 		HealthProbeBindAddress: operatorConfig.HealthProbeBindAddress,
-		// Disable cache for resources used to look up image pull secrets to avoid
-		// spinning up informers and to tighten operator RBAC permissions
-		ClientDisableCacheFor: []client.Object{
-			&corev1.Secret{},
-			&corev1.ServiceAccount{},
-		},
 	}
 
 	if operatorConfig.LeaderElectionEnabled {


### PR DESCRIPTION
This reverts commit 519d9fe3

## Description

When investigating https://github.com/aquasecurity/trivy-operator/issues/327, I notice that the operator complains about missing RBAC permissions to list/watch secrets. So I am pretty convinced that the fix proposed and merged in https://github.com/aquasecurity/trivy-operator/pull/276 does not work. This PR reverts it, and https://github.com/aquasecurity/trivy-operator/issues/230 should be reopened.

````
W0715 08:11:25.882410       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:trivy-system:trivy-operator" cannot list resource "secrets" in API group "" at the cluster scope
E0715 08:11:25.882442       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:trivy-system:trivy-operator" cannot list resource "secrets" in API group "" at the cluster scope
````

## Related issues
- Reopen https://github.com/aquasecurity/trivy-operator/issues/230
- Relates to https://github.com/aquasecurity/trivy-operator/issues/327

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
