### PR TITLE
Revert "Revert "chore: disable caching of secrets and serviceaccounts…

### DIFF
--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -60,15 +60,11 @@ rules:
     verbs:
       - create
       - get
-      - list
-      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
-      - list
-      - watch
     verbs:
       - get
   - apiGroups:

--- a/deploy/static/02-trivy-operator.rbac.yaml
+++ b/deploy/static/02-trivy-operator.rbac.yaml
@@ -73,15 +73,11 @@ rules:
     verbs:
       - create
       - get
-      - list
-      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
-      - list
-      - watch
     verbs:
       - get
   - apiGroups:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1220,15 +1220,11 @@ rules:
     verbs:
       - create
       - get
-      - list
-      - watch
   # Permissions required to read image pull secrets references from serviceaccounts
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
-      - list
-      - watch
     verbs:
       - get
   - apiGroups:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -17,9 +17,11 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -46,6 +48,12 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		Scheme:                 trivyoperator.NewScheme(),
 		MetricsBindAddress:     operatorConfig.MetricsBindAddress,
 		HealthProbeBindAddress: operatorConfig.HealthProbeBindAddress,
+		// Disable cache for resources used to look up image pull secrets to avoid
+		// spinning up informers and to tighten operator RBAC permissions
+		ClientDisableCacheFor: []client.Object{
+			&corev1.Secret{},
+			&corev1.ServiceAccount{},
+		},
 	}
 
 	if operatorConfig.LeaderElectionEnabled {


### PR DESCRIPTION
… (#276)" (#329)"

This reverts commit 88bf64210371be903031f1a29269845d7f5d64de.

## Description

After some proper testing, assisted by @josedonizetti, it seems like this works after all. Thanks @josedonizetti! So proposing to revert the revert earlier today. I am really sorry about that, but there must have been something wrong with my test setup. For reference I am adding a link to the Slack thread where I discussed this with the controller-runtime maintainters: https://kubernetes.slack.com/archives/C02MRBMN00Z/p1657889202276989. After the responses from Alvaro (controller-runtime), I am even more sure this PR will fix https://github.com/aquasecurity/trivy-operator/issues/230.

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/230

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
