### PR TITLE
fix: should not error when serviceaccount not found

### DIFF
--- a/pkg/kube/secrets_test.go
+++ b/pkg/kube/secrets_test.go
@@ -183,6 +183,15 @@ func TestMapContainerNamesToDockerAuths(t *testing.T) {
 }
 
 func TestListImagePullSecretsByPodSpec(t *testing.T) {
+	t.Run("Test no error when service account not found", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).Build()
+		spec := corev1.PodSpec{}
+		sr := kube.NewSecretsReader(client)
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		require.NoError(t, err)
+		assert.True(t, len(foundsecret) == 0)
+	})
+
 	t.Run("Test with no service account but with one secrets should return one pull image secret from corev1.Secret", func(t *testing.T) {
 		var secret corev1.Secret
 		err := loadResource("./testdata/fixture/secret.json", &secret)


### PR DESCRIPTION
## Description

Working with new integration tests, I was bugged by #305, so here is a PR to fix it.

## Related issues
- Close #305 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
