### PR TITLE
Draft: refactor: use manager APIReader instead of disabling cache

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -16,11 +16,9 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,12 +45,6 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		Scheme:                 trivyoperator.NewScheme(),
 		MetricsBindAddress:     operatorConfig.MetricsBindAddress,
 		HealthProbeBindAddress: operatorConfig.HealthProbeBindAddress,
-		// Disable cache for resources used to look up image pull secrets to avoid
-		// spinning up informers and to tighten operator RBAC permissions
-		ClientDisableCacheFor: []client.Object{
-			&corev1.Secret{},
-			&corev1.ServiceAccount{},
-		},
 	}
 
 	if operatorConfig.LeaderElectionEnabled {
@@ -134,7 +126,8 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	}
 	limitChecker := jobs.NewLimitChecker(operatorConfig, mgr.GetClient(), trivyOperatorConfig)
 	logsReader := kube.NewLogsReader(kubeClientset)
-	secretsReader := kube.NewSecretsReader(mgr.GetClient())
+	// Use manager APIReader to avoid spinning up watches and informers
+	secretsReader := kube.NewSecretsReader(mgr.GetAPIReader())
 
 	if operatorConfig.VulnerabilityScannerEnabled {
 		plugin, pluginContext, err := plugins.NewResolver().


### PR DESCRIPTION
## Description

After reaching out to controller-runtime maintainers on Slack, I got a [nice suggestion](https://kubernetes.slack.com/archives/C02MRBMN00Z/p1657939191076559?thread_ts=1657889202.276989&cid=C02MRBMN00Z) to use `mgr.GetAPIReader()` instead of having to disable cache for secrets and serviceaccounts. And I think that is an improvement.

Current status: This is still a draft PR, since my local testing shows that with this change, the operator is again requesting access to list secrets cluster-wide - which we don't want.

## Related issues
- Relates to https://github.com/aquasecurity/trivy-operator/pull/276
- Relates to https://github.com/aquasecurity/trivy-operator/issues/230

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
