### PR TITLE
refactor: renovate golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,14 @@
-run:
-  timeout: 5m
 linters:
+  disable:
+    - structcheck # FIXME: Currently doesn't work on Go 1.18: https://github.com/golangci/golangci-lint/issues/2649
   enable:
     - errorlint
-    - govet
-    - gosec
     - gocritic
-  disable:
-    - gosimple
-    - ineffassign
-    - staticcheck
+    - gosec
+    # - unparam FIXME: Currently doesn't work on Go 1.18: https://github.com/golangci/golangci-lint/issues/2649
 linters-settings:
   gocritic:
     enabled-checks:
       - importShadow
+run:
+  timeout: 5m

--- a/pkg/compliance/clustercompliancereport_test.go
+++ b/pkg/compliance/clustercompliancereport_test.go
@@ -136,6 +136,7 @@ var _ = ginkgo.Describe("cluster compliance report", func() {
 	ginkgo.Context("reconcile compliance spec report without cis-bench and audit-config data and validate compliance reports data", func() {
 		var clusterComplianceSpec v1alpha1.ClusterComplianceReport
 		err := loadResource("./testdata/fixture/clusterComplianceSpec.json", &clusterComplianceSpec)
+		Expect(err).ToNot(HaveOccurred())
 		// create new client
 		clientWithComplianceSpecOnly := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&clusterComplianceSpec).Build()
 		// create compliance controller

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -262,13 +262,13 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 			}
 			return ctrl.Result{}, fmt.Errorf("evaluating resource: %w", err)
 		}
-		switch reportData.(type) {
+		switch rd := reportData.(type) {
 		case v1alpha1.ConfigAuditReportData:
 			reportBuilder := configauditreport.NewReportBuilder(r.Client.Scheme()).
 				Controller(resource).
 				ResourceSpecHash(resourceHash).
 				PluginConfigHash(policiesHash).
-				Data(reportData.(v1alpha1.ConfigAuditReportData))
+				Data(rd)
 			if err := reportBuilder.Write(ctx, r.ReadWriter); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -277,7 +277,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 				Controller(resource).
 				ResourceSpecHash(resourceHash).
 				PluginConfigHash(policiesHash).
-				Data(reportData.(v1alpha1.RbacAssessmentReportData))
+				Data(rd)
 			if err := rbacReportBuilder.Write(ctx, r.RbacReadWriter); err != nil {
 				return ctrl.Result{}, err
 			}

--- a/pkg/configauditreport/controller_test.go
+++ b/pkg/configauditreport/controller_test.go
@@ -1,1 +1,0 @@
-package configauditreport_test

--- a/pkg/plugins/trivy/model_test.go
+++ b/pkg/plugins/trivy/model_test.go
@@ -1,1 +1,0 @@
-package trivy_test

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -330,6 +330,9 @@ func (p *plugin) GetScanJobSpec(ctx trivyoperator.PluginContext, workload client
 	}
 
 	command, err := config.GetCommand()
+	if err != nil {
+		return corev1.PodSpec{}, nil, err
+	}
 
 	if command == Image {
 		switch mode {

--- a/pkg/trivyoperator/constants_test.go
+++ b/pkg/trivyoperator/constants_test.go
@@ -1,1 +1,0 @@
-package trivyoperator_test

--- a/pkg/vulnerabilityreport/controller_test.go
+++ b/pkg/vulnerabilityreport/controller_test.go
@@ -1,1 +1,0 @@
-package vulnerabilityreport_test

--- a/pkg/vulnerabilityreport/plugin_test.go
+++ b/pkg/vulnerabilityreport/plugin_test.go
@@ -1,1 +1,0 @@
-package vulnerabilityreport_test

--- a/pkg/vulnerabilityreport/scanner_test.go
+++ b/pkg/vulnerabilityreport/scanner_test.go
@@ -1,1 +1,0 @@
-package vulnerabilityreport_test


### PR DESCRIPTION
## Description

This renovates the golangci-lint configuration by:

- Sorting keys/list alphabetically
- Remove enabling [linters that are enabled by default](https://golangci-lint.run/usage/linters/#enabled-by-default)
- Enabling all linters enabled by default in golangci-lint, except the ones that do not yet work on Go 1.18

Fixing some minor issues reported by linters enabled in this PR. Also delete some empty files.

## Related issues
- Relates to https://github.com/aquasecurity/trivy-operator/issues/311

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
