### PR TITLE
fix: use upstream alpine 3.16.1 image (fix CVE-2022-2097)

### DIFF
--- a/build/trivy-operator/Dockerfile
+++ b/build/trivy-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16.1
 
 RUN adduser -u 10000 -D -g '' trivyoperator trivyoperator
 


### PR DESCRIPTION
## Description

This upgrades the uptream alpine image to `3.16.1`. ~~I attempted the workaround suggested in https://github.com/alpinelinux/docker-alpine/issues/261#issuecomment-1186281774, but that didn't work (package conflicts).~~ Update: New patched image tag just released.

````
D:~/projects/github/trivy-operator (fix/workaround-image-vuln) $ make docker-build
CGO_ENABLED=0 GOOS=linux go build -o ./bin/trivy-operator ./cmd/trivy-operator/main.go
docker build --no-cache -t aquasec/trivy-operator:dev -f build/trivy-operator/Dockerfile bin
[+] Building 3.1s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                               0.1s
 => => transferring dockerfile: 225B                                                                               0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.16.1                                                   1.0s
 => [internal] load build context                                                                                  1.4s
 => => transferring context: 72.15MB                                                                               1.3s
 => CACHED [1/3] FROM docker.io/library/alpine:3.16.1@sha256:3f8cc766beda6881786ed96010a0e3e134735ed516cc92b7729b  0.0s
 => => resolve docker.io/library/alpine:3.16.1@sha256:3f8cc766beda6881786ed96010a0e3e134735ed516cc92b7729bb6b0065  0.1s
 => [2/3] RUN adduser -u 10000 -D -g '' trivyoperator trivyoperator                                                0.8s
 => [3/3] COPY trivy-operator /usr/local/bin/trivy-operator                                                        0.3s
 => exporting to image                                                                                             0.4s
 => => exporting layers                                                                                            0.4s
 => => writing image sha256:8976c73b9506f56b12fc2a2f6052ac9b95af051304655b5ca59a1d97df9c587e                       0.0s
 => => naming to docker.io/aquasec/trivy-operator:dev                                                              0.0s
docker build --no-cache -f build/trivy-operator/Dockerfile.ubi8 -t aquasec/trivy-operator:dev-ubi8 bin
[+] Building 6.1s (10/10) FINISHED
 => [internal] load build definition from Dockerfile.ubi8                                                          0.0s
 => => transferring dockerfile: 292B                                                                               0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:8.5                                   1.2s
 => CACHED [1/5] FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5@sha256:3f32ebba0cbf3849a48372d4fc3a4ce70816  0.0s
 => [internal] load build context                                                                                  0.0s
 => => transferring context: 38B                                                                                   0.0s
 => [2/5] RUN microdnf install shadow-utils                                                                        3.5s
 => [3/5] RUN useradd -u 10000 trivyoperator                                                                       0.6s
 => [4/5] WORKDIR /opt/bin/                                                                                        0.0s
 => [5/5] COPY trivy-operator /usr/local/bin/trivy-operator                                                        0.2s
 => exporting to image                                                                                             0.3s
 => => exporting layers                                                                                            0.3s
 => => writing image sha256:8c241bec1454f96cd5bf19b9e5ecf6d72f63c77f59d60856689f452d56f969a3                       0.0s
 => => naming to docker.io/aquasec/trivy-operator:dev-ubi8                                                         0.0s
D:~/projects/github/trivy-operator (fix/workaround-image-vuln) $ trivy image docker.io/aquasec/trivy-operator:dev
2022-07-18T23:19:49.113+0200    INFO    Vulnerability scanning is enabled
2022-07-18T23:19:49.113+0200    INFO    Secret scanning is enabled
2022-07-18T23:19:49.113+0200    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret
scanning
2022-07-18T23:19:49.113+0200    INFO    Please see also https://aquasecurity.github.io/trivy/0.30.0/docs/secret/scanning
/#recommendation for faster secret detection
2022-07-18T23:19:50.740+0200    INFO    Detected OS: alpine
2022-07-18T23:19:50.740+0200    INFO    Detecting Alpine vulnerabilities...
2022-07-18T23:19:50.741+0200    INFO    Number of language-specific files: 1
2022-07-18T23:19:50.741+0200    INFO    Detecting gobinary vulnerabilities...
D:~/projects/github/trivy-operator (fix/workaround-image-vuln) $
````

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/334

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
