### PR TITLE
fix: metrics service port

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -71,7 +71,7 @@ image:
 # service only expose a metrics endpoint for prometheus to scrape,
 # trivy-operator does not have a user interface.
 service:
-  metricsPort: 80
+  metricsPort: 8080
 
 # Prometheus ServiceMonitor configuration
 serviceMonitor:


### PR DESCRIPTION
Just changing port by default metrics service port

## Description

## Related issues
- Close #344 

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.

