### PR TITLE
fix: update policies not trigger rescan

### DIFF
--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -222,8 +222,16 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 
 		// Skip processing if there are no policies applicable to the resource
-
-		applicable, reason, err := policies.Applicable(resource, r.RbacAssessmentScannerEnabled)
+		suppoerted, err := policies.Supported(resource, r.RbacAssessmentScannerEnabled)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
+		}
+		if !suppoerted {
+			log.V(1).Info("resource not supported",
+				"kind", resource.GetObjectKind())
+			return ctrl.Result{}, nil
+		}
+		applicable, reason, err := policies.Applicable(resource)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
 		}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -134,17 +134,34 @@ func (p *Policies) ModulePolicyByKind(kind string) ([]string, error) {
 	return policy, nil
 }
 
-func (p *Policies) Applicable(resource client.Object, rbacDEnable bool) (bool, string, error) {
+//Applicable check if policies exist either built in or via policies configmap
+func (p *Policies) Applicable(resource client.Object) (bool, string, error) {
 	resourceKind := resource.GetObjectKind().GroupVersionKind().Kind
 	if resourceKind == "" {
 		return false, "", errors.New("resource kind must not be blank")
 	}
+	policies, err := p.PoliciesByKind(resourceKind)
+	if err != nil {
+		return false, "", err
+	}
+	if len(policies) == 0 && !p.cac.GetUseBuiltinRegoPolicies() {
+		return false, fmt.Sprintf("no policies found for kind %s", resource.GetObjectKind().GroupVersionKind().Kind), nil
+	}
+	return true, "", nil
+}
+
+//Supported scan policies supported for this kind
+func (p *Policies) Supported(resource client.Object, rbacDEnable bool) (bool, error) {
+	resourceKind := resource.GetObjectKind().GroupVersionKind().Kind
+	if resourceKind == "" {
+		return false, errors.New("resource kind must not be blank")
+	}
 	for _, kind := range p.cac.GetSupportedConfigAuditKinds() {
 		if kind == resourceKind && !p.rbacDisabled(rbacDEnable, kind) {
-			return true, "", nil
+			return true, nil
 		}
 	}
-	return false, "", nil
+	return false, nil
 }
 
 func (p *Policies) rbacDisabled(rbacEnable bool, kind string) bool {

--- a/pkg/vulnerabilityreport/ttl_report.go
+++ b/pkg/vulnerabilityreport/ttl_report.go
@@ -13,11 +13,11 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type TTLReportReconciler struct {
@@ -53,38 +53,38 @@ func (r *TTLReportReconciler) reconcileReport() reconcile.Func {
 }
 
 func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName) (ctrl.Result, error) {
-		log := r.Logger.WithValues("report", namespacedName)
+	log := r.Logger.WithValues("report", namespacedName)
 
-		report := &v1alpha1.VulnerabilityReport{}
-		err := r.Client.Get(ctx, namespacedName, report)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				log.V(1).Info("Ignoring cached report that must have been deleted")
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, fmt.Errorf("getting report from cache: %w", err)
-		}
-
-		ttlReportAnnotationStr, ok := report.Annotations[v1alpha1.TTLReportAnnotation]
-		if !ok {
-			log.V(1).Info("Ignoring report without TTL set")
+	report := &v1alpha1.VulnerabilityReport{}
+	err := r.Client.Get(ctx, namespacedName, report)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Ignoring cached report that must have been deleted")
 			return ctrl.Result{}, nil
 		}
+		return ctrl.Result{}, fmt.Errorf("getting report from cache: %w", err)
+	}
 
-		reportTTLTime, err := time.ParseDuration(ttlReportAnnotationStr)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed parsing %v with value %v %w", v1alpha1.TTLReportAnnotation, ttlReportAnnotationStr, err)
+	ttlReportAnnotationStr, ok := report.Annotations[v1alpha1.TTLReportAnnotation]
+	if !ok {
+		log.V(1).Info("Ignoring report without TTL set")
+		return ctrl.Result{}, nil
+	}
+
+	reportTTLTime, err := time.ParseDuration(ttlReportAnnotationStr)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed parsing %v with value %v %w", v1alpha1.TTLReportAnnotation, ttlReportAnnotationStr, err)
+	}
+	ttlExpired, durationToTTLExpiration := utils.IsTTLExpired(reportTTLTime, report.Report.UpdateTimestamp.Time, r.Clock)
+	if ttlExpired {
+		log.V(1).Info("Removing vulnerabilityReport with expired TTL")
+		err := r.Client.Delete(ctx, report, &client.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return ctrl.Result{}, err
 		}
-		ttlExpired, durationToTTLExpiration := utils.IsTTLExpired(reportTTLTime, report.Report.UpdateTimestamp.Time, r.Clock)
-		if ttlExpired {
-			log.V(1).Info("Removing vulnerabilityReport with expired TTL")
-			err := r.Client.Delete(ctx, report, &client.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-			// Since the report is deleted there is no reason to requeue
-			return ctrl.Result{}, nil
-		}
-		log.V(1).Info("RequeueAfter", "durationToTTLExpiration", durationToTTLExpiration)
-		return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
+		// Since the report is deleted there is no reason to requeue
+		return ctrl.Result{}, nil
+	}
+	log.V(1).Info("RequeueAfter", "durationToTTLExpiration", durationToTTLExpiration)
+	return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
 }

--- a/pkg/vulnerabilityreport/ttl_report_test.go
+++ b/pkg/vulnerabilityreport/ttl_report_test.go
@@ -64,7 +64,7 @@ func TestRegenerateReportIfExpired(t *testing.T) {
 		{
 			name:                  "Report timestamp exceeds TTL",
 			reportUpdateTimestamp: -25 * time.Hour, // > 24 TTL
-			wantReportDeleted:     true, // = time.Duration(0)
+			wantReportDeleted:     true,            // = time.Duration(0)
 			ttlStr:                "24h",
 		},
 		{


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
update policies after operator startup do not trigger rescan 

## Related issues
- Related to #351 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
