### PR TITLE
fix: update policies not trigger rescan after operator startup

### DIFF
--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -222,11 +222,11 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 
 		// Skip processing if there are no policies applicable to the resource
-		suppoerted, err := policies.SupportedKind(resource, r.RbacAssessmentScannerEnabled)
+		supported, err := policies.SupportedKind(resource, r.RbacAssessmentScannerEnabled)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
 		}
-		if !suppoerted {
+		if !supported {
 			log.V(1).Info("resource not supported",
 				"kind", resource.GetObjectKind())
 			return ctrl.Result{}, nil

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -222,7 +222,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 
 		// Skip processing if there are no policies applicable to the resource
-		suppoerted, err := policies.Supported(resource, r.RbacAssessmentScannerEnabled)
+		suppoerted, err := policies.SupportedKind(resource, r.RbacAssessmentScannerEnabled)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
 		}

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -222,8 +222,16 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 
 		// Skip processing if there are no policies applicable to the resource
-
-		applicable, reason, err := policies.Applicable(resource, r.RbacAssessmentScannerEnabled)
+		suppoerted, err := policies.Supported(resource, r.RbacAssessmentScannerEnabled)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
+		}
+		if !suppoerted {
+			log.V(1).Info("resource not supported",
+				"kind", resource.GetObjectKind())
+			return ctrl.Result{}, nil
+		}
+		applicable, reason, err := policies.Applicable(resource)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
 		}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -150,8 +150,8 @@ func (p *Policies) Applicable(resource client.Object) (bool, string, error) {
 	return true, "", nil
 }
 
-//Supported scan policies supported for this kind
-func (p *Policies) Supported(resource client.Object, rbacDEnable bool) (bool, error) {
+//SupportedKind scan policies supported for this kind
+func (p *Policies) SupportedKind(resource client.Object, rbacDEnable bool) (bool, error) {
 	resourceKind := resource.GetObjectKind().GroupVersionKind().Kind
 	if resourceKind == "" {
 		return false, errors.New("resource kind must not be blank")

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -134,17 +134,34 @@ func (p *Policies) ModulePolicyByKind(kind string) ([]string, error) {
 	return policy, nil
 }
 
-func (p *Policies) Applicable(resource client.Object, rbacDEnable bool) (bool, string, error) {
+//Applicable check if policies exist either built in or via policies configmap
+func (p *Policies) Applicable(resource client.Object) (bool, string, error) {
 	resourceKind := resource.GetObjectKind().GroupVersionKind().Kind
 	if resourceKind == "" {
 		return false, "", errors.New("resource kind must not be blank")
 	}
+	policies, err := p.PoliciesByKind(resourceKind)
+	if err != nil {
+		return false, "", err
+	}
+	if len(policies) == 0 && !p.cac.GetUseBuiltinRegoPolicies() {
+		return false, fmt.Sprintf("no policies found for kind %s", resource.GetObjectKind().GroupVersionKind().Kind), nil
+	}
+	return true, "", nil
+}
+
+//Supported scan policies supported for this kind
+func (p *Policies) Supported(resource client.Object, rbacDEnable bool) (bool, error) {
+	resourceKind := resource.GetObjectKind().GroupVersionKind().Kind
+	if resourceKind == "" {
+		return false, errors.New("resource kind must not be blank")
+	}
 	for _, kind := range p.cac.GetSupportedConfigAuditKinds() {
 		if kind == resourceKind && !p.rbacDisabled(rbacDEnable, kind) {
-			return true, "", nil
+			return true, nil
 		}
 	}
-	return false, "", nil
+	return false, nil
 }
 
 func (p *Policies) rbacDisabled(rbacEnable bool, kind string) bool {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -143,7 +143,7 @@ func TestPolicies_Supported(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			log := ctrl.Log.WithName("resourcecontroller")
-			ready, err := policy.NewPolicies(tc.data, testConfig{}, log).Supported(tc.resource, tc.rbacEnable)
+			ready, err := policy.NewPolicies(tc.data, testConfig{}, log).SupportedKind(tc.resource, tc.rbacEnable)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ready).To(Equal(tc.expected))
 		})


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
update policies not trigger rescan after operator startup

## Related issues
- Close #351 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ x I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
