### PR TITLE
fix: config and rbac report should not regenerate the same report if exist

### DIFF
--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -308,11 +308,11 @@ func (r *ResourceController) hasClusterReport(ctx context.Context, owner kube.Ob
 	}
 	if report != nil {
 		switch report.(type) {
-		case v1alpha1.ClusterConfigAuditReport:
+		case *v1alpha1.ClusterConfigAuditReport:
 			configReport := report.(*v1alpha1.ClusterConfigAuditReport)
 			return configReport.Labels[trivyoperator.LabelResourceSpecHash] == podSpecHash &&
 				configReport.Labels[trivyoperator.LabelPluginConfigHash] == pluginConfigHash, nil
-		case v1alpha1.ClusterRbacAssessmentReport:
+		case *v1alpha1.ClusterRbacAssessmentReport:
 			rbacReport := report.(*v1alpha1.ClusterRbacAssessmentReport)
 			return rbacReport.Labels[trivyoperator.LabelResourceSpecHash] == podSpecHash &&
 				rbacReport.Labels[trivyoperator.LabelPluginConfigHash] == pluginConfigHash, nil
@@ -327,11 +327,11 @@ func (r *ResourceController) findReportOwner(ctx context.Context, owner kube.Obj
 	}
 	if report != nil {
 		switch report.(type) {
-		case v1alpha1.ConfigAuditReport:
+		case *v1alpha1.ConfigAuditReport:
 			configReport := report.(*v1alpha1.ConfigAuditReport)
 			return configReport.Labels[trivyoperator.LabelResourceSpecHash] == podSpecHash &&
 				configReport.Labels[trivyoperator.LabelPluginConfigHash] == pluginConfigHash, nil
-		case v1alpha1.RbacAssessmentReport:
+		case *v1alpha1.RbacAssessmentReport:
 			rbacReport := report.(*v1alpha1.RbacAssessmentReport)
 			return rbacReport.Labels[trivyoperator.LabelResourceSpecHash] == podSpecHash &&
 				rbacReport.Labels[trivyoperator.LabelPluginConfigHash] == pluginConfigHash, nil


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
config and rbac report should not regenerate the same report if exist
## Related issues
- Close #357 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
