### PR TITLE
refactor: make IsActiveReplicaSet type safe

### DIFF
--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -193,8 +193,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 
 		if r.Config.ConfigAuditScannerScanOnlyCurrentRevisions && resourceKind == kube.KindReplicaSet {
-			controller := metav1.GetControllerOf(resource)
-			activeReplicaSet, err := r.IsActiveReplicaSet(ctx, resource, controller)
+			activeReplicaSet, controller, err := r.IsActiveReplicaSet(ctx, resource.(*appsv1.ReplicaSet))
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed checking current revision: %w", err)
 			}

--- a/pkg/kube/object_test.go
+++ b/pkg/kube/object_test.go
@@ -1213,8 +1213,7 @@ func TestObjectResolver_IsActiveReplicaSet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
-			controller := metav1.GetControllerOf(tc.resource)
-			isActive, err := or.IsActiveReplicaSet(context.TODO(), tc.resource, controller)
+			isActive, _, err := or.IsActiveReplicaSet(context.TODO(), tc.resource)
 			require.NoError(t, err)
 			assert.Equal(t, isActive, tc.result)
 		})

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -129,8 +129,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		}
 
 		if r.Config.VulnerabilityScannerScanOnlyCurrentRevisions && workloadKind == kube.KindReplicaSet {
-			controller := metav1.GetControllerOf(workloadObj)
-			activeReplicaSet, err := r.IsActiveReplicaSet(ctx, workloadObj, controller)
+			activeReplicaSet, controller, err := r.IsActiveReplicaSet(ctx, workloadObj.(*appsv1.ReplicaSet))
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed checking current revision: %w", err)
 			}


### PR DESCRIPTION
## Description

Just a small refactoring to make `IsActiveReplicaSet` type safe. Discovered during investigation of https://github.com/aquasecurity/trivy-operator/issues/373.

I also think we should look into avoiding this logic completely, ref. https://github.com/aquasecurity/trivy-operator/issues/237.

## Related issues
- Relates to https://github.com/aquasecurity/trivy-operator/issues/373

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
