### PR TITLE
refactor: offload some code from workload_controller.go

### DIFF
--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -175,6 +177,15 @@ func (ci ContainerImages) AsJSON() (string, error) {
 
 func (ci ContainerImages) FromJSON(value string) error {
 	return json.Unmarshal([]byte(value), &ci)
+}
+
+func (ci ContainerImages) DeepEqualTo(m map[string]bool) bool {
+	expected := map[string]bool{}
+	for containerName := range ci {
+		expected[containerName] = true
+	}
+
+	return reflect.DeepEqual(m, expected)
 }
 
 func ObjectRefFromKindAndObjectKey(kind Kind, name client.ObjectKey) ObjectRef {

--- a/pkg/vulnerabilityreport/io.go
+++ b/pkg/vulnerabilityreport/io.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +25,7 @@ type Writer interface {
 // owned by the given kube.ObjectRef or an empty slice if the reports are not found.
 type Reader interface {
 	FindByOwner(context.Context, kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error)
+	HasVulnerabilityReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error)
 }
 
 type ReadWriter interface {
@@ -87,4 +89,23 @@ func (r *readWriter) FindByOwner(ctx context.Context, owner kube.ObjectRef) ([]v
 	}
 
 	return list.DeepCopy().Items, nil
+}
+
+func (r *readWriter) HasVulnerabilityReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error) {
+	// TODO FindVulnerabilityReportsByOwner should accept optional label selector to further narrow down search results
+	list, err := r.FindByOwner(ctx, owner)
+	if err != nil {
+		return false, err
+	}
+
+	actual := map[string]bool{}
+	for _, report := range list {
+		if containerName, ok := report.Labels[trivyoperator.LabelContainerName]; ok {
+			if hash == report.Labels[trivyoperator.LabelResourceSpecHash] {
+				actual[containerName] = true
+			}
+		}
+	}
+
+	return images.DeepEqualTo(actual), nil
 }

--- a/pkg/vulnerabilityreport/workload_controller.go
+++ b/pkg/vulnerabilityreport/workload_controller.go
@@ -1,13 +1,12 @@
 package vulnerabilityreport
 
 import (
+	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
+
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-
-	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
-
+	
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
@@ -196,64 +195,17 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 }
 
 func (r *WorkloadController) hasReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error) {
-	hasVulnerabilityReports, err := r.hasVulnerabilityReports(ctx, owner, hash, images)
+	hasVulnerabilityReports, err := r.VulnerabilityReadWriter.HasVulnerabilityReports(ctx, owner, hash, images)
 	if err != nil {
 		return false, err
 	}
 
-	hasSecretReports, err := r.hasSecretReports(ctx, owner, hash, images)
+	hasSecretReports, err := r.ExposedSecretReadWriter.HasSecretReports(ctx, owner, hash, images)
 	if err != nil {
 		return false, err
 	}
 
 	return hasVulnerabilityReports && hasSecretReports, nil
-}
-
-func (r *WorkloadController) hasVulnerabilityReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error) {
-	// TODO FindByOwner should accept optional label selector to further narrow down search results
-	list, err := r.VulnerabilityReadWriter.FindByOwner(ctx, owner)
-	if err != nil {
-		return false, err
-	}
-
-	actual := map[string]bool{}
-	for _, report := range list {
-		if containerName, ok := report.Labels[trivyoperator.LabelContainerName]; ok {
-			if hash == report.Labels[trivyoperator.LabelResourceSpecHash] {
-				actual[containerName] = true
-			}
-		}
-	}
-
-	return compareReports(actual, images), nil
-}
-
-func (r *WorkloadController) hasSecretReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error) {
-	// TODO FindByOwner should accept optional label selector to further narrow down search results
-	list, err := r.ExposedSecretReadWriter.FindByOwner(ctx, owner)
-	if err != nil {
-		return false, err
-	}
-
-	actual := map[string]bool{}
-	for _, report := range list {
-		if containerName, ok := report.Labels[trivyoperator.LabelContainerName]; ok {
-			if hash == report.Labels[trivyoperator.LabelResourceSpecHash] {
-				actual[containerName] = true
-			}
-		}
-	}
-
-	return compareReports(actual, images), nil
-}
-
-func compareReports(actual map[string]bool, images kube.ContainerImages) bool {
-	expected := map[string]bool{}
-	for containerName := range images {
-		expected[containerName] = true
-	}
-
-	return reflect.DeepEqual(actual, expected)
 }
 
 func (r *WorkloadController) hasActiveScanJob(ctx context.Context, owner kube.ObjectRef, hash string) (bool, *batchv1.Job, error) {


### PR DESCRIPTION
## Description

This is a minor refactoring moving some code out of `controller.go`/`workload_controller.go`. As discussed with @chen-keinan this must be done stepwise, and I hope this is an ok first step. I attempted the full refactoring suggested in https://github.com/aquasecurity/trivy-operator/issues/370, and the change in this PR seems like a good way forward.

## Related issues
- Relates to https://github.com/aquasecurity/trivy-operator/issues/370

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
