### PR TITLE
fix: remove duplicate cronjob watcher

### DIFF
--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 	"reflect"
+
+	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
@@ -16,7 +17,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +76,6 @@ func (r *WorkloadController) SetupWithManager(mgr ctrl.Manager) error {
 		{kind: kube.KindReplicationController, forObject: &corev1.ReplicationController{}},
 		{kind: kube.KindStatefulSet, forObject: &appsv1.StatefulSet{}},
 		{kind: kube.KindDaemonSet, forObject: &appsv1.DaemonSet{}},
-		{kind: kube.KindCronJob, forObject: &batchv1beta1.CronJob{}},
 		{kind: kube.KindCronJob, forObject: r.ObjectResolver.GetSupportedObjectByKind(kube.KindCronJob)},
 		{kind: kube.KindJob, forObject: &batchv1.Job{}},
 	}


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

That should be only one watcher for cronjob, that will depend on the cluster, and is decided by `r.ObjectResolver.GetSupportedObjectByKind(kube.KindCronJob)}`

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/382

