### PR TITLE
fix: ensure that report name is a valid resource name

### DIFF
--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -3,15 +3,14 @@ package configauditreport
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/reports"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -52,13 +51,7 @@ func (b *ReportBuilder) Data(data v1alpha1.ConfigAuditReportData) *ReportBuilder
 }
 
 func (b *ReportBuilder) reportName() string {
-	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
-	name := b.controller.GetName()
-	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
-		return reportName
-	}
-	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))
+	return reports.NameFromController(b.controller)
 }
 
 func (b *ReportBuilder) GetClusterReport() (v1alpha1.ClusterConfigAuditReport, error) {

--- a/pkg/exposedsecretreport/builder.go
+++ b/pkg/exposedsecretreport/builder.go
@@ -2,14 +2,13 @@ package exposedsecretreport
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/reports"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -50,14 +49,7 @@ func (b *ReportBuilder) Data(data v1alpha1.ExposedSecretReportData) *ReportBuild
 }
 
 func (b *ReportBuilder) reportName() string {
-	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
-	name := b.controller.GetName()
-	reportName := fmt.Sprintf("%s-%s-%s", strings.ToLower(kind), name, b.container)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
-		return reportName
-	}
-
-	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name+"-"+b.container))
+	return reports.NameFromControllerContainer(b.controller, b.container)
 }
 
 func (b *ReportBuilder) Get() (v1alpha1.ExposedSecretReport, error) {

--- a/pkg/operator/reports/name.go
+++ b/pkg/operator/reports/name.go
@@ -1,0 +1,36 @@
+package reports
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NameFromController(controller client.Object) string {
+	kind := controller.GetObjectKind().GroupVersionKind().Kind
+	name := controller.GetName()
+	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
+	if isValidName(reportName) {
+		return reportName
+	}
+	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))
+}
+
+func NameFromControllerContainer(controller client.Object, container string) string {
+	kind := controller.GetObjectKind().GroupVersionKind().Kind
+	name := controller.GetName()
+	reportName := fmt.Sprintf("%s-%s-%s", strings.ToLower(kind), name, container)
+	if isValidName(reportName) {
+		return reportName
+	}
+
+	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name+"-"+container))
+}
+
+func isValidName(name string) bool {
+	// We also use report names as label values, so must validate both valid resource name and label value
+	return len(validation.IsDNS1123Subdomain(name)) == 0 && len(validation.IsValidLabelValue(name)) == 0
+}

--- a/pkg/operator/reports/name_test.go
+++ b/pkg/operator/reports/name_test.go
@@ -1,0 +1,83 @@
+package reports_test
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/reports"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// This name is longer than the allowed max label value length (63 chars)
+	longName = "wFnr9RzD3ELAtP18V0yxlOEQU4zFPzLi0BPPSBhYq8dHjm1rDKipV3yaZDP9H8EaSJmhlBRXoIc7niDp"
+	// Some initial K8s types allow any character except unsafe ones
+	uppercaseName = "cluster-crd-clusterRole"
+	// Underscores are allowed in label values, but not in names
+	underscoreName = "some_strange_resource"
+)
+
+func TestNameFromController(t *testing.T) {
+	type args struct {
+		controller client.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{name: "standard name", args: args{controller: newClusterRole("admin")}, want: "clusterrole-admin"},
+		{name: "uppercase name", args: args{controller: newClusterRole(uppercaseName)}, want: "clusterrole-5bdb67fb96"},
+		{name: "underscore name", args: args{controller: newClusterRole(underscoreName)}, want: "clusterrole-77f8d84c9f"},
+		{name: "long name", args: args{controller: newClusterRole(longName)}, want: "clusterrole-7b4cdd687c"},
+		{name: "other kind", args: args{controller: newPod("my-pod")}, want: "pod-my-pod"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reports.NameFromController(tt.args.controller); got != tt.want {
+				t.Errorf("NameFromController() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNameFromControllerContainer(t *testing.T) {
+	type args struct {
+		controller client.Object
+		container  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{name: "standard name", args: args{controller: newPod("pod-123"), container: "app"}, want: "pod-pod-123-app"},
+		{name: "uppercase name", args: args{controller: newPod(uppercaseName), container: "nginx"}, want: "pod-57fbbcc98f"},
+		{name: "underscore name", args: args{controller: newPod(underscoreName), container: "bin"}, want: "pod-94c47cb9f"},
+		{name: "long name", args: args{controller: newPod(longName), container: "hello"}, want: "pod-f78f5c56"},
+		{name: "other kind", args: args{controller: newClusterRole("my-other-resource"), container: "foo"}, want: "clusterrole-my-other-resource-foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reports.NameFromControllerContainer(tt.args.controller, tt.args.container); got != tt.want {
+				t.Errorf("NameFromControllerContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newClusterRole(name string) *rbacv1.ClusterRole {
+	cr := &rbacv1.ClusterRole{}
+	cr.Name = name
+	cr.Kind = string(kube.KindClusterRole)
+	return cr
+}
+
+func newPod(name string) *corev1.Pod {
+	pod := &corev1.Pod{}
+	pod.Name = name
+	pod.Kind = string(kube.KindPod)
+	return pod
+}

--- a/pkg/rbacassessment/builder.go
+++ b/pkg/rbacassessment/builder.go
@@ -3,17 +3,17 @@ package rbacassessment
 import (
 	"context"
 	"fmt"
+
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/reports"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 type ReportBuilder struct {
@@ -51,13 +51,7 @@ func (b *ReportBuilder) Data(data v1alpha1.RbacAssessmentReportData) *ReportBuil
 }
 
 func (b *ReportBuilder) reportName() string {
-	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
-	name := b.controller.GetName()
-	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
-		return reportName
-	}
-	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))
+	return reports.NameFromController(b.controller)
 }
 
 func (b *ReportBuilder) GetClusterReport() (v1alpha1.ClusterRbacAssessmentReport, error) {

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -2,19 +2,18 @@ package vulnerabilityreport
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/docker"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/reports"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/utils"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -227,14 +226,7 @@ func (b *ReportBuilder) ReportTTL(ttl *time.Duration) *ReportBuilder {
 }
 
 func (b *ReportBuilder) reportName() string {
-	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
-	name := b.controller.GetName()
-	reportName := fmt.Sprintf("%s-%s-%s", strings.ToLower(kind), name, b.container)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
-		return reportName
-	}
-
-	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name+"-"+b.container))
+	return reports.NameFromControllerContainer(b.controller, b.container)
 }
 
 func (b *ReportBuilder) Get() (v1alpha1.VulnerabilityReport, error) {


### PR DESCRIPTION
## Description

This adds the required extra validation to report names to fix #343. Also refactor the code to avoid duplication in this area.

I know plural package names are discouraged in Golang, but naming things is hard. Please let me know if you have any constructive input to naming.

## Related issues
- Close #343

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
