### PR TITLE
chore: make GHCR the default registry for trivy-operator image

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Scan Trivy Operator image for vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'docker.io/aquasec/trivy-operator:${{ github.sha }}-amd64'
+          image-ref: 'ghcr.io/aquasecurity/trivy-operator:${{ github.sha }}-amd64'
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ have to
 
 | Binary               | Image                                          | Description                                                   |
 |----------------------|------------------------------------------------|---------------------------------------------------------------|
-| `trivy-operator`     | `docker.io/aquasec/trivy-operator:dev`         | Trivy Operator                                                |
+| `trivy-operator`     | `ghcr.io/aquasecurity/trivy-operator:dev`         | Trivy Operator                                                |
 
 To build all Trivy-operator binary, run:
 
@@ -100,7 +100,7 @@ make docker-build
 To load Docker images into your KIND cluster, run:
 
 ```
-kind load docker-image aquasec/trivy-operator:dev
+kind load docker-image aquasecurity/trivy-operator:dev
 ```
 
 ## Testing
@@ -198,7 +198,7 @@ basic development workflow. For other install modes see [Operator Multitenancy w
 
 1. Build the operator binary into the Docker image and load it from your host into KIND cluster nodes:
    ```
-   make docker-build-trivy-operator && kind load docker-image aquasec/trivy-operator:dev
+   make docker-build-trivy-operator && kind load docker-image aquasecurity/trivy-operator:dev
    ```
 2. Create the `trivy-operator` Deployment in the `trivy-system` namespace to run the operator's container:
    ```

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ GINKGO=$(GOBIN)/ginkgo
 SOURCES := $(shell find . -name '*.go')
 
 IMAGE_TAG := dev
-TRIVY_OPERATOR_IMAGE := aquasec/trivy-operator:$(IMAGE_TAG)
-TRIVY_OPERATOR_IMAGE_UBI8 := aquasec/trivy-operator:$(IMAGE_TAG)-ubi8
+TRIVY_OPERATOR_IMAGE := aquasecurity/trivy-operator:$(IMAGE_TAG)
+TRIVY_OPERATOR_IMAGE_UBI8 := aquasecurity/trivy-operator:$(IMAGE_TAG)-ubi8
 
 MKDOCS_IMAGE := aquasec/mkdocs-material:trivy-operator
 MKDOCS_PORT := 8000

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -61,7 +61,7 @@ operator:
   # metricsFindingsEnabled the flag to enable metrics for findings
   metricsFindingsEnabled: true
 image:
-  repository: "docker.io/aquasec/trivy-operator"
+  repository: "ghcr.io/aquasecurity/trivy-operator"
   # tag is an override of the image tag, which is by default set by the
   # appVersion field in Chart.yaml.
   tag: ""

--- a/deploy/static/kustomization.yaml
+++ b/deploy/static/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - trivy-operator.yaml
 images:
-  - name: docker.io/aquasec/trivy-operator
-    newName: docker.io/aquasec/trivy-operator
+  - name: ghcr.io/aquasecurity/trivy-operator
+    newName: aquasecurity/trivy-operator
     newTag: dev

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1240,7 +1240,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "trivy-operator"
-          image: "docker.io/aquasec/trivy-operator:0.1.5"
+          image: "ghcr.io/aquasecurity/trivy-operator:0.1.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: OPERATOR_NAMESPACE


### PR DESCRIPTION
## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/262

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
