### PR TITLE
adds 'insecureRegistries' to the helm chart

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -65,6 +65,9 @@ data:
   {{- range $key, $registry := .nonSslRegistries }}
   trivy.nonSslRegistry.{{ $key }}: {{ $registry | quote }}
   {{- end }}
+  {{- range $key, $registry := .insecureRegistries }}
+  trivy.insecureRegistry.{{ $key }}: {{ $registry | quote }}
+  {{- end }}
   {{- range $key, $registry := .registry.mirror }}
   trivy.registry.mirror.{{ $key }}: {{ $registry | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -143,6 +143,12 @@ trivy:
   #  qaRegistry: qa.registry.aquasec.com
   #  internalRegistry: registry.registry.svc:5000
 
+  # The registry to which insecure connections are allowed. There can be multiple registries with different keys.
+  insecureRegistries: {}
+  #  pocRegistry: poc.myregistry.harbor.com.pl
+  #  qaRegistry: qa.registry.aquasec.com
+  #  internalRegistry: registry.registry.svc:5000
+
   # Mirrored registries. There can be multiple registries with different keys.
   # Make sure to quote registries containing dots
   registry:


### PR DESCRIPTION
## Description
Fixes https://github.com/aquasecurity/trivy-operator/issues/372 by adding ''trivy.insecureRegistry" to the helm chart

## Related issues
- Close #372

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
