### PR TITLE
fix: set configauditreport updatetimestamp

### DIFF
--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport"
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 
@@ -386,9 +387,10 @@ func (r *ResourceController) evaluate(ctx context.Context, policies *policy.Poli
 		}, nil
 	}
 	return v1alpha1.ConfigAuditReportData{
-		Scanner: r.scanner(),
-		Summary: v1alpha1.ConfigAuditSummaryFromChecks(checks),
-		Checks:  checks,
+		UpdateTimestamp: metav1.NewTime(ext.NewSystemClock().Now()),
+		Scanner:         r.scanner(),
+		Summary:         v1alpha1.ConfigAuditSummaryFromChecks(checks),
+		Checks:          checks,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

On k8s 1.19 it is not accepted a zero value metav1.Time, so we need to set it when creating the config audit report like we do for the vulnerability report -> https://github.com/aquasecurity/trivy-operator/blob/main/pkg/plugins/trivy/plugin.go#L1363

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/400
