### PR TITLE
feat: add securityContext for initContainers

### DIFF
--- a/docs/design/design_trivy_file_system_scanner.md
+++ b/docs/design/design_trivy_file_system_scanner.md
@@ -125,6 +125,13 @@ spec:
             - -v
             - /usr/local/bin/trivy
             - /var/trivy-operator/trivy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+               drop:
+                  - all
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: scan-volume
               mountPath: /var/trivy-operator
@@ -140,6 +147,13 @@ spec:
             - --download-db-only
             - --cache-dir
             - /var/trivy-operator/trivy-db
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+               drop:
+                  - all
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: scan-volume
               mountPath: /var/trivy-operator

--- a/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
+++ b/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
@@ -172,6 +172,13 @@ spec:
             - -v
             - /usr/local/bin/trivy
             - /var/trivy-operator/trivy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+             drop:
+              - all
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: scan-volume
               mountPath: /var/trivy-operator
@@ -182,6 +189,13 @@ spec:
             - --download-db-only
             - --cache-dir
             - /var/trivy-operator/trivy-db
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+             drop:
+              - all
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: scan-volume
               mountPath: /var/trivy-operator

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -44,14 +44,14 @@ To change the target namespace from all namespaces to the `default` namespace ed
 
 # Scanning configuration
 
-| CONFIGMAP KEY| DEFAULT| DESCRIPTION|
-|---|---|---|
-| `vulnerabilityReports.scanner`| `Trivy`| The name of the plugin that generates vulnerability reports. Either `Trivy` or `Aqua`.|
-| `vulnerabilityReports.scanJobsInSameNamespace` | `"false"`| Whether to run vulnerability scan jobs in same namespace of workload. Set `"true"` to enable.|
-| `scanJob.tolerations`| N/A| JSON representation of the [tolerations] to be applied to the scanner pods so that they can run on nodes with matching taints. Example: `'[{"key":"key1", "operator":"Equal", "value":"value1", "effect":"NoSchedule"}]'`|
-| `scanJob.annotations`| N/A| One-line comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
-| `scanJob.templateLabel`| N/A| One-line comma-separated representation of the template labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`|
-| `scanJob.podTemplateSecurityContext`| N/A| One-line JSON representation of the template securityContext which the user wants the scanner pods to be secured with. Example: `{"RunAsUser": 1000, "RunAsGroup": 1000, "RunAsNonRoot": true}`|
+| CONFIGMAP KEY| DEFAULT| DESCRIPTION                                                                                                                                                                                                                                                                              |
+|---|---|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `vulnerabilityReports.scanner`| `Trivy`| The name of the plugin that generates vulnerability reports. Either `Trivy` or `Aqua`.                                                                                                                                                                                                   |
+| `vulnerabilityReports.scanJobsInSameNamespace` | `"false"`| Whether to run vulnerability scan jobs in same namespace of workload. Set `"true"` to enable.                                                                                                                                                                                            |
+| `scanJob.tolerations`| N/A| JSON representation of the [tolerations] to be applied to the scanner pods so that they can run on nodes with matching taints. Example: `'[{"key":"key1", "operator":"Equal", "value":"value1", "effect":"NoSchedule"}]'`                                                                |
+| `scanJob.annotations`| N/A| One-line comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage`                                                      |
+| `scanJob.templateLabel`| N/A| One-line comma-separated representation of the template labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`                                                          |
+| `scanJob.podTemplateSecurityContext`| N/A| One-line JSON representation of the template securityContext which the user wants the scanner pods to be secured with. Does not affect the securityContext of the initContainers, which have their own default. Example: `{"RunAsUser": 1000, "RunAsGroup": 1000, "RunAsNonRoot": true}` |
 
 ## Example - patch ConfigMap
 

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -378,6 +378,15 @@ const (
 	SharedVolumeLocationOfTrivy = "/var/trivyoperator/trivy"
 )
 
+var InitContainerSecurityContext = corev1.SecurityContext{
+	Privileged:               pointer.BoolPtr(false),
+	AllowPrivilegeEscalation: pointer.BoolPtr(false),
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"all"},
+	},
+	ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+}
+
 // In the Standalone mode there is the init container responsible for
 // downloading the latest Trivy DB file from GitHub and storing it to the
 // emptyDir volume shared with main containers. In other words, the init
@@ -447,6 +456,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 				ReadOnly:  false,
 			},
 		},
+		SecurityContext: &InitContainerSecurityContext,
 	}
 
 	var containers []corev1.Container
@@ -1137,8 +1147,9 @@ func (p *plugin) getPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, 
 			"/usr/local/bin/trivy",
 			SharedVolumeLocationOfTrivy,
 		},
-		Resources:    requirements,
-		VolumeMounts: volumeMounts,
+		Resources:       requirements,
+		SecurityContext: &InitContainerSecurityContext,
+		VolumeMounts:    volumeMounts,
 	}
 
 	initContainerDB := corev1.Container{
@@ -1158,8 +1169,9 @@ func (p *plugin) getPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, 
 			"--db-repository",
 			dbRepository,
 		},
-		Resources:    requirements,
-		VolumeMounts: volumeMounts,
+		Resources:       requirements,
+		SecurityContext: &InitContainerSecurityContext,
+		VolumeMounts:    volumeMounts,
 	}
 
 	var containers []corev1.Container

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -763,6 +763,14 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							tmpVolumeMount,
 						},
@@ -1010,6 +1018,14 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							tmpVolumeMount,
@@ -1262,6 +1278,14 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							tmpVolumeMount,
@@ -1535,6 +1559,14 @@ CVE-2019-1543`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							tmpVolumeMount,
 						},
@@ -1794,6 +1826,14 @@ CVE-2019-1543`,
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							tmpVolumeMount,
@@ -3004,6 +3044,14 @@ CVE-2019-1543`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      trivy.FsSharedVolumeName,
@@ -3087,6 +3135,14 @@ CVE-2019-1543`,
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -3326,6 +3382,14 @@ CVE-2019-1543`,
 							corev1.ResourceMemory: resource.MustParse("500M"),
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"all"},
+						},
+						ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      trivy.FsSharedVolumeName,
@@ -3408,6 +3472,14 @@ CVE-2019-1543`,
 							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("500M"),
 						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"all"},
+						},
+						ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/vulnerabilityreport/testdata/fixture/cronjob-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/cronjob-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/daemonset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/daemonset-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/job-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/job-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/pod-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/pod-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/replicaset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicaset-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/replicationcontroller-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicationcontroller-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:

--- a/pkg/vulnerabilityreport/testdata/fixture/statefulset-expected-scan.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/statefulset-expected-scan.yaml
@@ -157,6 +157,13 @@ spec:
           image: "ghcr.io/aquasecurity/trivy:0.29.1"
           imagePullPolicy: IfNotPresent
           name: <INIT-CONTAINER-NAME>
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:


### PR DESCRIPTION
## Description
This change sets a default securityContext for initContainers. This is useful because some admission controllers reject containers with no securityContext. 
An alternative implementation could see `scanJob.podTemplateSecurityContext` being passed to pkg/plugins/trivy/plugin.go's `GetScanJobSpec`, but I thought this might be simpler.

## Related issues
- Improves #121 

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
