### PR TITLE
feat: allow configuration of operator pod labels

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   selector:
     matchLabels:
       {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+      {{- if .Values.operator.podLabels }}
+      {{- toYaml .Values.operator.podLabels | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -21,6 +21,9 @@ operator:
   # replicas the number of replicas of the operator's pod
   replicas: 1
 
+  # additional labels for the operator pod
+  podLabels: {}
+
   # leaderElectionId determines the name of the resource that leader election
   # will use for holding the leader lock.
   leaderElectionId: "trivyoperator-lock"


### PR DESCRIPTION
## Description

Adds `operator.podLabels` configuration property to allow custom labels for the operator pod.

## Related issues
- Close #464 

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] ~~I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).~~
- [ ] ~~I've added usage information (if the PR introduces new options)~~
- [ ] ~~I've included a "before" and "after" example to the description (if the PR is a user interface change).~~
