### PR TITLE
fix: skip replicaSet scanning when there is no active pod

### DIFF
--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -571,31 +571,31 @@ func (o *ObjectResolver) GetNodeName(ctx context.Context, obj client.Object) (st
 		if err != nil {
 			return "", err
 		}
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), replicaSet.Spec.Selector.MatchLabels)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), replicaSet.Spec.Selector.MatchLabels)
 		if err != nil {
 			return "", err
 		}
 		return pods[0].Spec.NodeName, nil
 	case *appsv1.ReplicaSet:
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
 		if err != nil {
 			return "", err
 		}
 		return pods[0].Spec.NodeName, nil
 	case *corev1.ReplicationController:
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector)
 		if err != nil {
 			return "", err
 		}
 		return pods[0].Spec.NodeName, nil
 	case *appsv1.StatefulSet:
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
 		if err != nil {
 			return "", err
 		}
 		return pods[0].Spec.NodeName, nil
 	case *appsv1.DaemonSet:
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
 		if err != nil {
 			return "", err
 		}
@@ -605,7 +605,7 @@ func (o *ObjectResolver) GetNodeName(ctx context.Context, obj client.Object) (st
 	case *batchv1.CronJob:
 		return "", ErrUnSupportedKind
 	case *batchv1.Job:
-		pods, err := o.getActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
+		pods, err := o.GetActivePodsMatchingLabels(ctx, obj.GetNamespace(), r.Spec.Selector.MatchLabels)
 		if err != nil {
 			return "", err
 		}
@@ -650,7 +650,7 @@ func (o *ObjectResolver) getPodsMatchingLabels(ctx context.Context, namespace st
 	return podList.Items, err
 }
 
-func (o *ObjectResolver) getActivePodsMatchingLabels(ctx context.Context, namespace string,
+func (o *ObjectResolver) GetActivePodsMatchingLabels(ctx context.Context, namespace string,
 	labels map[string]string) ([]corev1.Pod, error) {
 	pods, err := o.getPodsMatchingLabels(ctx, namespace, labels)
 	if err != nil {

--- a/pkg/vulnerabilityreport/testdata/fixture/pod.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/pod.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: my-pod
+  labels:
+    app.kubernetes.io/name: wordpress
+    pod-template-hash: 84bbf6f4dd
+    app: nginx
 spec:
   containers:
     - image: app-image:app-image-tag

--- a/pkg/vulnerabilityreport/testdata/fixture/replicaset.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicaset.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  labels:
-    app.kubernetes.io/name: wordpress
-    pod-template-hash: 84bbf6f4dd
   name: wordpress-84bbf6f4dd
 spec:
   selector:

--- a/pkg/vulnerabilityreport/testdata/fixture/replicaset.yaml
+++ b/pkg/vulnerabilityreport/testdata/fixture/replicaset.yaml
@@ -2,6 +2,9 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
+  labels:
+    app.kubernetes.io/name: wordpress
+    pod-template-hash: 84bbf6f4dd
   name: wordpress-84bbf6f4dd
 spec:
   selector:


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
skip replicaSet scanning when there is no active pod

## Related issues
- Related #387 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
