### PR TITLE
refactor: extract config.Config

### DIFF
--- a/pkg/compliance/io.go
+++ b/pkg/compliance/io.go
@@ -3,10 +3,10 @@ package compliance
 import (
 	"context"
 	"fmt"
-	"github.com/aquasecurity/trivy-operator/pkg/utils"
 	"strings"
 
-	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
+	"github.com/aquasecurity/trivy-operator/pkg/utils"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
@@ -26,18 +26,18 @@ type Mgr interface {
 	GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportSpec) error
 }
 
-func NewMgr(c client.Client, log logr.Logger, config trivyoperator.ConfigData) Mgr {
+func NewMgr(c client.Client, log logr.Logger, cfg config.Config) Mgr {
 	return &cm{
 		client: c,
 		log:    log,
-		config: config,
+		cfg:    cfg,
 	}
 }
 
 type cm struct {
 	client client.Client
 	log    logr.Logger
-	config trivyoperator.ConfigData
+	cfg    config.Config
 }
 
 type summaryTotal struct {
@@ -249,7 +249,7 @@ func (w *cm) createScanCheckResult(results []*ScannerCheckResult) []v1alpha1.Sca
 		var ctt v1alpha1.ScannerCheckResult
 		failedResultEntries := make([]v1alpha1.ResultDetails, 0)
 		for _, crd := range checkResult.Details {
-			if len(failedResultEntries) >= w.config.ComplianceFailEntriesLimit() {
+			if len(failedResultEntries) >= w.cfg.ComplianceFailEntriesLimit() {
 				continue
 			}
 			//control check detail relevant to fail checks only

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"time"
+
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Config struct {
+	config     etc.Config
+	configData trivyoperator.ConfigData
+}
+
+func GetConfig(config etc.Config, configData trivyoperator.ConfigData) Config {
+	return Config{
+		config:     config,
+		configData: configData,
+	}
+}
+
+func (cfg Config) ResolveInstallMode() (etc.InstallMode, string, []string, error) {
+	return cfg.config.ResolveInstallMode()
+}
+
+func (cfg Config) ExcludeNamespaces() string {
+	return cfg.config.ExcludeNamespaces
+}
+
+func (cfg Config) MetricsBindAddress() string {
+	return cfg.config.MetricsBindAddress
+}
+
+func (cfg Config) HealthProbeBindAddress() string {
+	return cfg.config.HealthProbeBindAddress
+}
+
+func (cfg Config) LeaderElectionEnabled() bool {
+	return cfg.config.LeaderElectionEnabled
+}
+
+func (cfg Config) LeaderElectionID() string {
+	return cfg.config.LeaderElectionID
+}
+
+func (cfg Config) VulnerabilityScannerEnabled() bool {
+	return cfg.configData.VulnerabilityScannerEnabled()
+}
+
+func (cfg Config) ExposedSecretsScannerEnabled() bool {
+	return cfg.configData.ExposedSecretsScannerEnabled()
+}
+
+func (cfg Config) VulnerabilityScannerReportTTL() *time.Duration {
+	return cfg.config.VulnerabilityScannerReportTTL
+}
+
+func (cfg Config) ConfigAuditScannerEnabled() bool {
+	return cfg.config.ConfigAuditScannerEnabled
+}
+
+func (cfg Config) ServiceAccount() string {
+	return cfg.config.ServiceAccount
+}
+
+func (cfg Config) ClusterComplianceEnabled() bool {
+	return cfg.config.ClusterComplianceEnabled
+}
+
+func (cfg Config) MetricsFindingsEnabled() bool {
+	return cfg.config.MetricsFindingsEnabled
+}
+
+func (cfg Config) GetVulnerabilityReportsScanner() (trivyoperator.Scanner, error) {
+	return cfg.configData.GetVulnerabilityReportsScanner()
+}
+
+func (cfg Config) VulnerabilityScanJobsInSameNamespace() bool {
+	return cfg.configData.VulnerabilityScanJobsInSameNamespace()
+}
+
+func (cfg Config) GetConfigAuditReportsScanner() (trivyoperator.Scanner, error) {
+	return cfg.configData.GetConfigAuditReportsScanner()
+}
+
+func (cfg Config) VulnerabilityScannerScanOnlyCurrentRevisions() bool {
+	return cfg.config.VulnerabilityScannerScanOnlyCurrentRevisions
+}
+
+func (cfg Config) Namespace() string {
+	return cfg.config.Namespace
+}
+
+func (cfg Config) ConcurrentScanJobsLimit() int {
+	return cfg.config.ConcurrentScanJobsLimit
+}
+
+func (cfg Config) ScanJobRetryAfter() time.Duration {
+	return cfg.config.ScanJobRetryAfter
+}
+
+func (cfg Config) GetScanJobTolerations() ([]corev1.Toleration, error) {
+	return cfg.configData.GetScanJobTolerations()
+}
+
+func (cfg Config) GetScanJobAnnotations() (map[string]string, error) {
+	return cfg.configData.GetScanJobAnnotations()
+}
+
+func (cfg Config) GetScanJobNodeSelector() (map[string]string, error) {
+	return cfg.configData.GetScanJobNodeSelector()
+}
+
+func (cfg Config) GetScanJobPodSecurityContext() (*corev1.PodSecurityContext, error) {
+	return cfg.configData.GetScanJobPodSecurityContext()
+}
+
+func (cfg Config) GetScanJobPodTemplateLabels() (labels.Set, error) {
+	return cfg.configData.GetScanJobPodTemplateLabels()
+}
+
+func (cfg Config) ScanJobTimeout() time.Duration {
+	return cfg.config.ScanJobTimeout
+}
+
+func (cfg Config) ConfigAuditScannerScanOnlyCurrentRevisions() bool {
+	return cfg.config.ConfigAuditScannerScanOnlyCurrentRevisions
+}
+
+func (cfg Config) RbacAssessmentScannerEnabled() bool {
+	return cfg.config.RbacAssessmentScannerEnabled
+}
+
+func (cfg Config) BatchDeleteDelay() time.Duration {
+	return cfg.config.BatchDeleteDelay
+}
+
+func (cfg Config) BatchDeleteLimit() int {
+	return cfg.config.BatchDeleteLimit
+}
+
+func (cfg Config) ComplianceFailEntriesLimit() int {
+	return cfg.configData.ComplianceFailEntriesLimit()
+}
+
+func (cfg Config) GetTargetNamespaces() []string {
+	return cfg.config.GetTargetNamespaces()
+}
+
+func (cfg Config) GetScanJobContainerSecurityContext() (*corev1.SecurityContext, error) {
+	return cfg.configData.GetScanJobContainerSecurityContext()
+}

--- a/pkg/configauditreport/plugin.go
+++ b/pkg/configauditreport/plugin.go
@@ -1,7 +1,7 @@
 package configauditreport
 
 import (
-	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 )
 
 // PluginInMemory defines the interface between trivy-operator and trivy configuration
@@ -9,9 +9,9 @@ type PluginInMemory interface {
 
 	// Init is a callback to initialize this plugin, e.g. ensure the default
 	// configuration.
-	Init(ctx trivyoperator.PluginContext) error
+	Init(ctx pluginconfig.PluginContext) error
 
-	NewConfigForConfigAudit(ctx trivyoperator.PluginContext) (ConfigAuditConfig, error)
+	NewConfigForConfigAudit(ctx pluginconfig.PluginContext) (ConfigAuditConfig, error)
 }
 
 // ConfigAuditConfig defines the interface between trivy-operator and trivy configuration which related to configauditreport

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -12,7 +12,7 @@ import (
 	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 )
 
 const (
@@ -166,7 +166,7 @@ var (
 // metrics from a dedicated workload supporting sharding etc.
 type ResourcesMetricsCollector struct {
 	logr.Logger
-	etc.Config
+	config.Config
 	client.Client
 }
 

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +19,12 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 	var collector ResourcesMetricsCollector
 	var client *fake.ClientBuilder
 
+	etcConfig := etc.Config{}
+
+	defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+
+	cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
+
 	BeforeEach(func() {
 		scheme := runtime.NewScheme()
 		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
@@ -25,6 +34,7 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 	JustBeforeEach(func() {
 		collector = ResourcesMetricsCollector{
 			Client: client.Build(),
+			Config: cfg,
 		}
 	})
 
@@ -92,7 +102,15 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 		})
 
 		It("should produce correct metrics from target namespaces", func() {
-			collector.TargetNamespaces = "default,some-ns"
+			etcConfig := etc.Config{TargetNamespaces: "default,some-ns"}
+			defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+			cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
+
+			collector = ResourcesMetricsCollector{
+				Client: client.Build(),
+				Config: cfg,
+			}
+
 			const expected = `
         # HELP trivy_image_vulnerabilities Number of container image vulnerabilities
         # TYPE trivy_image_vulnerabilities gauge
@@ -165,7 +183,15 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 		})
 
 		It("should produce correct metrics from target namespaces", func() {
-			collector.TargetNamespaces = "default,some-ns"
+			etcConfig := etc.Config{TargetNamespaces: "default,some-ns"}
+			defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+			cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
+
+			collector = ResourcesMetricsCollector{
+				Client: client.Build(),
+				Config: cfg,
+			}
+
 			const expected = `
         # HELP trivy_image_exposedsecrets Number of image exposed secrets
         # TYPE trivy_image_exposedsecrets gauge
@@ -229,7 +255,15 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 		})
 
 		It("should produce correct metrics from target namespaces", func() {
-			collector.TargetNamespaces = "default,some-ns"
+			etcConfig := etc.Config{TargetNamespaces: "default,some-ns"}
+			defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+			cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
+
+			collector = ResourcesMetricsCollector{
+				Client: client.Build(),
+				Config: cfg,
+			}
+
 			const expected = `
         # HELP trivy_resource_configaudits Number of failing resource configuration auditing checks
         # TYPE trivy_resource_configaudits gauge
@@ -292,7 +326,15 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 		})
 
 		It("should produce correct rbac assessment metrics from target namespaces", func() {
-			collector.TargetNamespaces = "default,some-ns"
+			etcConfig := etc.Config{TargetNamespaces: "default,some-ns"}
+			defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+			cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
+
+			collector = ResourcesMetricsCollector{
+				Client: client.Build(),
+				Config: cfg,
+			}
+
 			const expected = `
       # HELP trivy_role_rbacassessments Number of rbac risky role assessment checks
       # TYPE trivy_role_rbacassessments gauge
@@ -309,6 +351,7 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 				To(Succeed())
 		})
 	})
+
 	Context("RbacAssessment", func() {
 		BeforeEach(func() {
 			car1 := &v1alpha1.ClusterRbacAssessmentReport{}

--- a/pkg/operator/jobs/limit_checker_test.go
+++ b/pkg/operator/jobs/limit_checker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"context"
 
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/jobs"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
@@ -16,11 +17,14 @@ import (
 
 var _ = Describe("LimitChecker", func() {
 
-	config := etc.Config{
+	etcConfig := etc.Config{
 		Namespace:               "trivy-operator",
 		ConcurrentScanJobsLimit: 2,
 	}
+
 	defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+
+	cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
 
 	Context("When there are more jobs than limit", func() {
 
@@ -54,7 +58,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := jobs.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
+			instance := jobs.NewLimitChecker(cfg, client)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeTrue())
@@ -80,7 +84,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := jobs.NewLimitChecker(config, client, defaultTrivyOperatorConfig)
+			instance := jobs.NewLimitChecker(cfg, client)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeFalse())
@@ -119,9 +123,13 @@ var _ = Describe("LimitChecker", func() {
 					},
 				}},
 			).Build()
+
 			trivyOperatorConfig := defaultTrivyOperatorConfig
 			trivyOperatorConfig[trivyoperator.KeyVulnerabilityScansInSameNamespace] = "true"
-			instance := jobs.NewLimitChecker(config, client, trivyOperatorConfig)
+
+			cfg = config.GetConfig(etcConfig, trivyOperatorConfig)
+
+			instance := jobs.NewLimitChecker(cfg, client)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeTrue())

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
@@ -27,8 +28,8 @@ import (
 // runs scan jobs. However, we do not want to scan the workloads that might run
 // in the operator namespace unless the operator namespace is added to the list
 // of target namespaces.
-var InstallModePredicate = func(config etc.Config) (predicate.Predicate, error) {
-	mode, operatorNamespace, targetNamespaces, err := config.ResolveInstallMode()
+var InstallModePredicate = func(cfg config.Config) (predicate.Predicate, error) {
+	mode, operatorNamespace, targetNamespaces, err := cfg.ResolveInstallMode()
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +43,8 @@ var InstallModePredicate = func(config etc.Config) (predicate.Predicate, error) 
 			return ext.SliceContainsString(targetNamespaces, obj.GetNamespace())
 		}
 
-		if mode == etc.AllNamespaces && strings.TrimSpace(config.ExcludeNamespaces) != "" {
-			namespaces := strings.Split(config.ExcludeNamespaces, ",")
+		if mode == etc.AllNamespaces && strings.TrimSpace(cfg.ExcludeNamespaces()) != "" {
+			namespaces := strings.Split(cfg.ExcludeNamespaces(), ",")
 			for _, namespace := range namespaces {
 				matches, err := filepath.Match(strings.TrimSpace(namespace), obj.GetNamespace())
 				if err != nil {

--- a/pkg/pluginconfig/plugin_test.go
+++ b/pkg/pluginconfig/plugin_test.go
@@ -1,9 +1,11 @@
-package trivyoperator_test
+package pluginconfig_test
 
 import (
 	"testing"
 
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +14,7 @@ import (
 
 func TestGetPluginConfigMapName(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	name := trivyoperator.GetPluginConfigMapName("Trivy")
+	name := pluginconfig.GetPluginConfigMapName("Trivy")
 	g.Expect(name).To(gomega.Equal("trivy-operator-trivy-config"))
 }
 
@@ -34,7 +36,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 			}).
 			Build()
 
-		pluginContext := trivyoperator.NewPluginContext().
+		pluginContext := pluginconfig.NewPluginContext().
 			WithName("trivy").
 			WithNamespace("trivyoperator-ns").
 			WithClient(client).
@@ -44,7 +46,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(cm).To(gomega.Equal(
-			trivyoperator.PluginConfig{
+			pluginconfig.PluginConfig{
 				Data: map[string]string{
 					"foo": "bar",
 				},
@@ -75,7 +77,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 			}).
 			Build()
 
-		pluginContext := trivyoperator.NewPluginContext().
+		pluginContext := pluginconfig.NewPluginContext().
 			WithName("trivy").
 			WithNamespace("trivyoperator-ns").
 			WithClient(client).
@@ -85,7 +87,7 @@ func TestPluginContext_GetConfig(t *testing.T) {
 
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(cm).To(gomega.Equal(
-			trivyoperator.PluginConfig{
+			pluginconfig.PluginConfig{
 				Data: map[string]string{
 					"foo": "bar",
 				},

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+
 	containerimage "github.com/google/go-containerregistry/pkg/name"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -73,7 +74,6 @@ type ConfigData map[string]string
 type ConfigManager interface {
 	EnsureDefault(ctx context.Context) error
 	Read(ctx context.Context) (ConfigData, error)
-	Delete(ctx context.Context) error
 }
 
 // GetDefaultConfig returns the default configuration settings.
@@ -344,22 +344,6 @@ func (c *configManager) Read(ctx context.Context) (ConfigData, error) {
 	}
 
 	return data, nil
-}
-
-func (c *configManager) Delete(ctx context.Context) error {
-	err := c.client.CoreV1().ConfigMaps(c.namespace).Delete(ctx, ConfigMapName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	err = c.client.CoreV1().ConfigMaps(c.namespace).Delete(ctx, GetPluginConfigMapName("Trivy"), metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	err = c.client.CoreV1().Secrets(c.namespace).Delete(ctx, SecretName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 // LinuxNodeAffinity constructs a new Affinity resource with linux supported nodes.

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -8,8 +8,10 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/docker"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/utils"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +24,7 @@ import (
 
 type ScanJobBuilder struct {
 	plugin                   Plugin
-	pluginContext            trivyoperator.PluginContext
+	pluginContext            pluginconfig.PluginContext
 	timeout                  time.Duration
 	object                   client.Object
 	credentials              map[string]docker.Auth
@@ -43,7 +45,7 @@ func (s *ScanJobBuilder) WithPlugin(plugin Plugin) *ScanJobBuilder {
 	return s
 }
 
-func (s *ScanJobBuilder) WithPluginContext(pluginContext trivyoperator.PluginContext) *ScanJobBuilder {
+func (s *ScanJobBuilder) WithPluginContext(pluginContext pluginconfig.PluginContext) *ScanJobBuilder {
 	s.pluginContext = pluginContext
 	return s
 }

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/docker"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
 	"github.com/onsi/gomega"
@@ -68,7 +71,7 @@ func TestScanJobBuilder(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 		job, _, err := vulnerabilityreport.NewScanJobBuilder().
 			WithPlugin(&testPlugin{}).
-			WithPluginContext(trivyoperator.NewPluginContext().
+			WithPluginContext(pluginconfig.NewPluginContext().
 				WithName("test-plugin").
 				WithNamespace("trivy-operator-ns").
 				WithServiceAccountName("trivy-operator-sa").
@@ -141,13 +144,13 @@ func TestScanJobBuilder(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 		job, _, err := vulnerabilityreport.NewScanJobBuilder().
 			WithPlugin(&testPlugin{}).
-			WithPluginContext(trivyoperator.NewPluginContext().
+			WithPluginContext(pluginconfig.NewPluginContext().
 				WithName("test-plugin").
 				WithNamespace("trivy-operator-ns").
 				WithServiceAccountName("trivy-operator-sa").
-				WithTrivyOperatorConfig(trivyoperator.ConfigData{
+				WithTrivyOperatorConfig(getConfig(trivyoperator.ConfigData{
 					trivyoperator.KeyVulnerabilityScansInSameNamespace: "true"},
-				).
+				)).
 				Get()).
 			WithTimeout(3 * time.Second).
 			WithObject(&appsv1.ReplicaSet{
@@ -217,14 +220,20 @@ func TestScanJobBuilder(t *testing.T) {
 type testPlugin struct {
 }
 
-func (p *testPlugin) Init(_ trivyoperator.PluginContext) error {
+func (p *testPlugin) Init(_ pluginconfig.PluginContext) error {
 	return nil
 }
 
-func (p *testPlugin) GetScanJobSpec(_ trivyoperator.PluginContext, _ client.Object, _ map[string]docker.Auth, _ *corev1.SecurityContext) (corev1.PodSpec, []*corev1.Secret, error) {
+func (p *testPlugin) GetScanJobSpec(_ pluginconfig.PluginContext, _ client.Object, _ map[string]docker.Auth, _ *corev1.SecurityContext) (corev1.PodSpec, []*corev1.Secret, error) {
 	return corev1.PodSpec{}, nil, nil
 }
 
-func (p *testPlugin) ParseReportData(_ trivyoperator.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, error) {
+func (p *testPlugin) ParseReportData(_ pluginconfig.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, error) {
 	return v1alpha1.VulnerabilityReportData{}, v1alpha1.ExposedSecretReportData{}, nil
+}
+
+func getConfig(configData map[string]string) config.Config {
+	var etcConfig etc.Config
+
+	return config.GetConfig(etcConfig, configData)
 }

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/workload"
 	"reflect"
+
+	"github.com/aquasecurity/trivy-operator/pkg/config"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/workload"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 
 	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 	"go.uber.org/multierr"
@@ -13,7 +16,6 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/jobs"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/go-logr/logr"
@@ -35,15 +37,14 @@ import (
 // implements the Plugin interface.
 type WorkloadController struct {
 	logr.Logger
-	etc.Config
+	config.Config
 	client.Client
 	kube.ObjectResolver
 	jobs.LimitChecker
 	kube.LogsReader
 	kube.SecretsReader
 	Plugin
-	trivyoperator.PluginContext
-	trivyoperator.ConfigData
+	pluginconfig.PluginContext
 	VulnerabilityReadWriter ReadWriter
 	ExposedSecretReadWriter exposedsecretreport.ReadWriter
 }
@@ -97,8 +98,8 @@ func (r *WorkloadController) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 	var predicates []predicate.Predicate
-	if !r.ConfigData.VulnerabilityScanJobsInSameNamespace() {
-		predicates = append(predicates, InNamespace(r.Config.Namespace))
+	if !r.Config.VulnerabilityScanJobsInSameNamespace() {
+		predicates = append(predicates, InNamespace(r.Config.Namespace()))
 	}
 	predicates = append(predicates, ManagedByTrivyOperator, IsVulnerabilityReportScan, JobHasAnyCondition)
 	return ctrl.NewControllerManagedBy(mgr).
@@ -122,7 +123,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 
 		// Skip processing if it's a Pod controlled by a built-in K8s workload.
 		if skip, err := workload.SkipProcessing(ctx, workloadObj, r.ObjectResolver,
-			r.Config.VulnerabilityScannerScanOnlyCurrentRevisions, log); skip {
+			r.Config.VulnerabilityScannerScanOnlyCurrentRevisions(), log); skip {
 			return ctrl.Result{}, err
 		}
 
@@ -162,11 +163,11 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		log.V(1).Info("Checking scan jobs limit", "count", scanJobsCount, "limit", r.ConcurrentScanJobsLimit)
+		log.V(1).Info("Checking scan jobs limit", "count", scanJobsCount, "limit", r.Config.ConcurrentScanJobsLimit())
 
 		if limitExceeded {
-			log.V(1).Info("Pushing back scan job", "count", scanJobsCount, "retryAfter", r.ScanJobRetryAfter)
-			return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
+			log.V(1).Info("Pushing back scan job", "count", scanJobsCount, "retryAfter", r.Config.ScanJobRetryAfter())
+			return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter()}, nil
 		}
 
 		return ctrl.Result{}, r.submitScanJob(ctx, workloadObj)
@@ -237,7 +238,7 @@ func compareReports(actual map[string]bool, images kube.ContainerImages) bool {
 func (r *WorkloadController) hasActiveScanJob(ctx context.Context, owner kube.ObjectRef, hash string) (bool, *batchv1.Job, error) {
 	jobName := fmt.Sprintf("scan-vulnerabilityreport-%s", kube.ComputeHash(owner))
 	job := &batchv1.Job{}
-	err := r.Get(ctx, client.ObjectKey{Namespace: r.Config.Namespace, Name: jobName}, job)
+	err := r.Get(ctx, client.ObjectKey{Namespace: r.Config.Namespace(), Name: jobName}, job)
 	if err != nil {
 		if k8sapierror.IsNotFound(err) {
 			return false, nil, nil
@@ -258,32 +259,32 @@ func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Obj
 		return err
 	}
 
-	scanJobTolerations, err := r.GetScanJobTolerations()
+	scanJobTolerations, err := r.Config.GetScanJobTolerations()
 	if err != nil {
 		return fmt.Errorf("getting scan job tolerations: %w", err)
 	}
 
-	scanJobAnnotations, err := r.GetScanJobAnnotations()
+	scanJobAnnotations, err := r.Config.GetScanJobAnnotations()
 	if err != nil {
 		return fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
-	scanJobNodeSelector, err := r.GetScanJobNodeSelector()
+	scanJobNodeSelector, err := r.Config.GetScanJobNodeSelector()
 	if err != nil {
 		return fmt.Errorf("getting scan job nodeSelector: %w", err)
 	}
 
-	scanJobSecurityContext, err := r.GetScanJobPodSecurityContext()
+	scanJobSecurityContext, err := r.Config.GetScanJobPodSecurityContext()
 	if err != nil {
 		return fmt.Errorf("getting scan job podSecurityContext: %w", err)
 	}
 
-	scanJobContainerSecurityContext, err := r.GetScanJobContainerSecurityContext()
+	scanJobContainerSecurityContext, err := r.Config.GetScanJobContainerSecurityContext()
 	if err != nil {
 		return fmt.Errorf("getting scan job [container] securityContext: %w", err)
 	}
 
-	scanJobPodTemplateLabels, err := r.GetScanJobPodTemplateLabels()
+	scanJobPodTemplateLabels, err := r.Config.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return fmt.Errorf("getting scan job template labels: %w", err)
 	}
@@ -291,7 +292,7 @@ func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Obj
 	scanJob, secrets, err := NewScanJobBuilder().
 		WithPlugin(r.Plugin).
 		WithPluginContext(r.PluginContext).
-		WithTimeout(r.Config.ScanJobTimeout).
+		WithTimeout(r.Config.ScanJobTimeout()).
 		WithObject(owner).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
@@ -431,14 +432,14 @@ func (r *WorkloadController) processCompleteScanJob(ctx context.Context, job *ba
 		return merr
 	}
 
-	if r.Config.VulnerabilityScannerEnabled {
+	if r.Config.VulnerabilityScannerEnabled() {
 		err = r.VulnerabilityReadWriter.Write(ctx, vulnerabilityReports)
 		if err != nil {
 			return err
 		}
 	}
 
-	if r.Config.ExposedSecretScannerEnabled {
+	if r.Config.ExposedSecretsScannerEnabled() {
 		err = r.ExposedSecretReadWriter.Write(ctx, secretReports)
 		if err != nil {
 			return err
@@ -491,8 +492,8 @@ func (r *WorkloadController) processScanJobResults(ctx context.Context, job *bat
 		Data(vulnReportData).
 		PodSpecHash(podSpecHash)
 
-	if r.Config.VulnerabilityScannerReportTTL != nil {
-		reportBuilder.ReportTTL(r.Config.VulnerabilityScannerReportTTL)
+	if r.Config.VulnerabilityScannerReportTTL() != nil {
+		reportBuilder.ReportTTL(r.Config.VulnerabilityScannerReportTTL())
 	}
 
 	report, err := reportBuilder.Get()

--- a/pkg/vulnerabilityreport/plugin.go
+++ b/pkg/vulnerabilityreport/plugin.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/docker"
-	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -16,7 +17,7 @@ type Plugin interface {
 
 	// Init is a callback to initialize this plugin, e.g. ensure the default
 	// configuration.
-	Init(ctx trivyoperator.PluginContext) error
+	Init(ctx pluginconfig.PluginContext) error
 
 	// GetScanJobSpec describes the pod that will be created by Trivy-operator when
 	// it schedules a Kubernetes job to scan the workload with the specified
@@ -24,11 +25,11 @@ type Plugin interface {
 	// The second argument maps container names to Docker registry credentials,
 	// which can be passed to the scanner as environment variables with values
 	// set from returned secrets.
-	GetScanJobSpec(ctx trivyoperator.PluginContext, workload client.Object, credentials map[string]docker.Auth,
+	GetScanJobSpec(ctx pluginconfig.PluginContext, workload client.Object, credentials map[string]docker.Auth,
 		securityContext *corev1.SecurityContext) (corev1.PodSpec, []*corev1.Secret, error)
 
 	// ParseReportData is a callback to parse and convert logs of
 	// the pod controlled by the scan job to v1alpha1.VulnerabilityScanResult.
-	ParseReportData(ctx trivyoperator.PluginContext, imageRef string, logsReader io.ReadCloser) (
+	ParseReportData(ctx pluginconfig.PluginContext, imageRef string, logsReader io.ReadCloser) (
 		v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, error)
 }

--- a/pkg/vulnerabilityreport/suite_test.go
+++ b/pkg/vulnerabilityreport/suite_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/jobs"
+	"github.com/aquasecurity/trivy-operator/pkg/pluginconfig"
 	"github.com/aquasecurity/trivy-operator/pkg/plugins"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
@@ -76,7 +78,7 @@ var _ = BeforeSuite(func() {
 	objectResolver := kube.NewObjectResolver(managerClient, compatibleObjectMapper)
 	Expect(err).ToNot(HaveOccurred())
 
-	config := etc.Config{
+	etcConfig := etc.Config{
 		Namespace:               "default",
 		TargetNamespaces:        "default",
 		ConcurrentScanJobsLimit: 10,
@@ -87,15 +89,17 @@ var _ = BeforeSuite(func() {
 	trivyOperatorConfig.Set(trivyoperator.KeyVulnerabilityScannerEnabled, "true")
 	trivyOperatorConfig.Set(trivyoperator.KeyExposedSecretsScannerEnabled, "true")
 
+	cfg := config.GetConfig(etcConfig, trivyOperatorConfig)
+
 	plugin, pluginContext, err := plugins.NewResolver().
-		WithNamespace(config.Namespace).
-		WithServiceAccountName(config.ServiceAccount).
-		WithConfig(trivyOperatorConfig).
+		WithNamespace(cfg.Namespace()).
+		WithServiceAccountName(cfg.ServiceAccount()).
+		WithConfig(cfg).
 		WithClient(managerClient).
 		WithObjectResolver(&objectResolver).
 		GetVulnerabilityPlugin()
 	Expect(err).ToNot(HaveOccurred())
-	err = pluginContext.EnsureConfig(trivyoperator.PluginConfig{
+	err = pluginContext.EnsureConfig(pluginconfig.PluginConfig{
 		Data: map[string]string{
 			"trivy.imageRef":     "ghcr.io/aquasecurity/trivy:0.29.1",
 			"trivy.mode":         "Standalone",
@@ -106,10 +110,10 @@ var _ = BeforeSuite(func() {
 
 	err = (&vulnerabilityreport.WorkloadController{
 		Logger:                  ctrl.Log.WithName("reconciler").WithName("vulnerabilityreport"),
-		Config:                  config,
+		Config:                  cfg,
 		Client:                  managerClient,
 		ObjectResolver:          objectResolver,
-		LimitChecker:            jobs.NewLimitChecker(config, managerClient, trivyOperatorConfig),
+		LimitChecker:            jobs.NewLimitChecker(cfg, managerClient),
 		SecretsReader:           kube.NewSecretsReader(managerClient),
 		Plugin:                  plugin,
 		PluginContext:           pluginContext,

--- a/pkg/vulnerabilityreport/ttl_report.go
+++ b/pkg/vulnerabilityreport/ttl_report.go
@@ -5,24 +5,24 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 	"github.com/aquasecurity/trivy-operator/pkg/utils"
 
-	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
-	"github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type TTLReportReconciler struct {
 	logr.Logger
-	etc.Config
+	config.Config
 	client.Client
 	ext.Clock
 }
@@ -53,38 +53,38 @@ func (r *TTLReportReconciler) reconcileReport() reconcile.Func {
 }
 
 func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName) (ctrl.Result, error) {
-		log := r.Logger.WithValues("report", namespacedName)
+	log := r.Logger.WithValues("report", namespacedName)
 
-		report := &v1alpha1.VulnerabilityReport{}
-		err := r.Client.Get(ctx, namespacedName, report)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				log.V(1).Info("Ignoring cached report that must have been deleted")
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, fmt.Errorf("getting report from cache: %w", err)
-		}
-
-		ttlReportAnnotationStr, ok := report.Annotations[v1alpha1.TTLReportAnnotation]
-		if !ok {
-			log.V(1).Info("Ignoring report without TTL set")
+	report := &v1alpha1.VulnerabilityReport{}
+	err := r.Client.Get(ctx, namespacedName, report)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Ignoring cached report that must have been deleted")
 			return ctrl.Result{}, nil
 		}
+		return ctrl.Result{}, fmt.Errorf("getting report from cache: %w", err)
+	}
 
-		reportTTLTime, err := time.ParseDuration(ttlReportAnnotationStr)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed parsing %v with value %v %w", v1alpha1.TTLReportAnnotation, ttlReportAnnotationStr, err)
+	ttlReportAnnotationStr, ok := report.Annotations[v1alpha1.TTLReportAnnotation]
+	if !ok {
+		log.V(1).Info("Ignoring report without TTL set")
+		return ctrl.Result{}, nil
+	}
+
+	reportTTLTime, err := time.ParseDuration(ttlReportAnnotationStr)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed parsing %v with value %v %w", v1alpha1.TTLReportAnnotation, ttlReportAnnotationStr, err)
+	}
+	ttlExpired, durationToTTLExpiration := utils.IsTTLExpired(reportTTLTime, report.Report.UpdateTimestamp.Time, r.Clock)
+	if ttlExpired {
+		log.V(1).Info("Removing vulnerabilityReport with expired TTL")
+		err := r.Client.Delete(ctx, report, &client.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return ctrl.Result{}, err
 		}
-		ttlExpired, durationToTTLExpiration := utils.IsTTLExpired(reportTTLTime, report.Report.UpdateTimestamp.Time, r.Clock)
-		if ttlExpired {
-			log.V(1).Info("Removing vulnerabilityReport with expired TTL")
-			err := r.Client.Delete(ctx, report, &client.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-			// Since the report is deleted there is no reason to requeue
-			return ctrl.Result{}, nil
-		}
-		log.V(1).Info("RequeueAfter", "durationToTTLExpiration", durationToTTLExpiration)
-		return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
+		// Since the report is deleted there is no reason to requeue
+		return ctrl.Result{}, nil
+	}
+	log.V(1).Info("RequeueAfter", "durationToTTLExpiration", durationToTTLExpiration)
+	return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
 }

--- a/pkg/vulnerabilityreport/ttl_report_test.go
+++ b/pkg/vulnerabilityreport/ttl_report_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/config"
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
@@ -31,17 +32,23 @@ func TestRegenerateReportIfExpired(t *testing.T) {
 	scheme := trivyoperator.NewScheme()
 
 	// set the VulnerabilityScannerReportTTL
-	config, err := etc.GetOperatorConfig()
+	etcConfig, err := etc.GetOperatorConfig()
 	require.NoError(t, err)
+
 	hours, err := time.ParseDuration("24h")
 	require.NoError(t, err)
-	config.VulnerabilityScannerReportTTL = &hours
+
+	etcConfig.VulnerabilityScannerReportTTL = &hours
+
+	defaultTrivyOperatorConfig := trivyoperator.GetDefaultConfig()
+
+	cfg := config.GetConfig(etcConfig, defaultTrivyOperatorConfig)
 
 	// logger object
 	logger := log.Log.WithName("testing")
 
 	// create TTLReport controller
-	instance := vulnerabilityreport.TTLReportReconciler{Logger: logger, Config: config, Clock: clock}
+	instance := vulnerabilityreport.TTLReportReconciler{Logger: logger, Config: cfg, Clock: clock}
 
 	// vuln report data
 	vulnReport := v1alpha1.VulnerabilityReport{}
@@ -64,7 +71,7 @@ func TestRegenerateReportIfExpired(t *testing.T) {
 		{
 			name:                  "Report timestamp exceeds TTL",
 			reportUpdateTimestamp: -25 * time.Hour, // > 24 TTL
-			wantReportDeleted:     true, // = time.Duration(0)
+			wantReportDeleted:     true,            // = time.Duration(0)
 			ttlStr:                "24h",
 		},
 		{


### PR DESCRIPTION
have only one source of configuration

Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/415

Remove this section if you don't have related PRs.

## Checklist
- [] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [] I've added tests that prove my fix is effective or that my feature works.
- [] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
