### PR TITLE
docs: add webhook integration to main menu

### DIFF
--- a/docs/integrations/webhook.md
+++ b/docs/integrations/webhook.md
@@ -2,7 +2,7 @@
 
 Trivy Operator allows you to send reports externally to a webhook as they get produced. This is useful in cases where you would like to _"set-and-forget"_ the operator and monitor the reports elsewhere. It's also useful when you have to make decisions based on a report, e.g. prune a vulnerable image, remove a deployment with exposed secrets etc.
 
-The latter use case can be fulfilled by using a SOAR tool [Postee]. Out of the box, Postee offers a variety of integrations with other third party services such as ServiceNow, Slack, AWS Security Hub and many more.  
+The latter use case can be fulfilled by using a SOAR tool [Postee](https://github.com/aquasecurity/postee). Out of the box, Postee offers a variety of integrations with other third party services such as ServiceNow, Slack, AWS Security Hub and many more.  
 
 ![img.png](../images/webhook-integration.png)
 
@@ -12,5 +12,3 @@ You can enable the Webhook integration as follows:
 2. Optional: Set `OPERATOR_WEBHOOK_BROADCAST_TIMEOUT` to a time limit that suites your use case. Default is `30s`.
 
 The Webhook integration is only able to send `vulnerabilityreport` and `exposedsecretreport` type of reports.
-
-[Postee]:(https://github.com/aquasecurity/postee)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - Integrations:
           - Metrics: integrations/metrics.md
           - Lens Extension: integrations/lens.md
+          - Webhook Integration: integrations/webhook.md
       - Tutorials:
           - Writing Custom Configuration Audit Policies: tutorials/writing-custom-configuration-audit-policies.md
           - Manage Access to Security Reports: tutorials/manage_access_to_security_reports.md


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
add webhook integration to main menu

## Related issues
- Close #70

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
