### PR TITLE
Added ability to use secrets to scan private repo

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.operator.webhookBroadcastURL | quote }}
             - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
               value: {{ .Values.operator.webhookBroadcastTimeout | quote }}
+            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
+              value: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
             {{- if gt (int .Values.operator.replicas) 1 }}
             - name: OPERATOR_LEADER_ELECTION_ENABLED
               value: "true"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -78,6 +78,9 @@ operator:
   # webhookBroadcastTimeout the flag to set timeout for webhook requests if webhookBroadcastURL is enabled
   webhookBroadcastTimeout: 30s
 
+  # privateRegistryScanSecretsNames is map of namespace:secrets which can be used to authenticate in private registries in case if there no imagePullSecrets provided
+  privateRegistryScanSecretsNames: {}
+
 image:
   repository: "ghcr.io/aquasecurity/trivy-operator"
   # tag is an override of the image tag, which is by default set by the

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1300,6 +1300,8 @@ spec:
               value: ""
             - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
               value: "30s"
+            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
+              value: "{}"
           ports:
             - name: metrics
               containerPort: 8080

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -31,6 +31,7 @@ You can configure Trivy-Operator to control it's behavior and adapt it to your n
 | `OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED`                    | `true`                 | The flag to enable exposed secret scanner                                                                                                                                                                    |
 | `OPERATOR_WEBHOOK_BROADCAST_URL`                             | `""`                   | The flag to enable operator reports to be sent to a webhook endpoint. "" means that this feature is disabled                                                                                                 |
 | `OPERATOR_WEBHOOK_BROADCAST_TIMEOUT`                         | `30s`                  | The flag to set operator webhook timeouts, if webhook broadcast is enabled                                                                                                                                   |
+| `OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES`                | `{}`                  | The flag to provide information about names of the secrets for different namespaces to use them for authentication in private registries if there are no imagePullSecrets in Service Accounts and/or in Pod's Spec                                                                                                                                   |
 
 The values of the `OPERATOR_NAMESPACE` and `OPERATOR_TARGET_NAMESPACES` determine the install mode, which in turn determines the multitenancy support of the operator.
 

--- a/docs/tutorials/private-registries.md
+++ b/docs/tutorials/private-registries.md
@@ -29,7 +29,7 @@ trivy:
 
 By default, the command that trivy is supposed to run inside your cluster is `trivy image` for container image scanning. However, we want to change it to scan the filesystem in your nodes instead. Container images are ultimately stored as files on the node level of your cluster. This way, trivy is going to scan the files of your container images for vulnerabilities. This is a little bit of a work-around with the downside that the Trivy Operator will have to run as root. However, remember that security scanning already requires the operator to have lots of cluster privileges.
 
-Next, we will change the the `command` and the `trivyOperator.scanJobPodTemplateContainerSecurityContext`of the values.yaml manifest. For this, we can create a new values.yaml manifest with our desired modifiactions:
+Next, we will change the the `command` and the `trivyOperator.scanJobPodTemplateContainerSecurityContext`of the `values.yaml` manifest. For this, we can create a new values.yaml manifest with our desired modifiactions:
 ```
 trivy:
     command: fs
@@ -40,7 +40,7 @@ trivyOperator:
         runAsUser: 0
 ```
 
-Lastly, we can deploy the operator inside our cluster with referencing our new values.yaml manifest to override the default values:
+Lastly, we can deploy the operator inside our cluster with referencing our new `values.yaml` manifest to override the default values:
 
 ```
 helm upgrade --install trivy-operator aqua/trivy-operator \
@@ -89,7 +89,7 @@ And take the output of the previous command and parse it into the following to b
 echo -n  '{"auths":{"ghcr.io":{"auth":"OUTPUT"}}}' | base64
 ```
 
-Lastly, we are going to store the output in a Kubernetes Secrete YAML manifest:
+Lastly, we are going to store the output in a Kubernetes Secret YAML manifest:
 
 `imagepullsecret.yaml`
 ```
@@ -164,7 +164,88 @@ spec:
     serviceAccountName: cns-website
 ```
 
-## Fourth Option: Grant access through managed registries
+## Fourth Option: Define Secrets through Trivy-Operator configuration
+
+If there are no ImagePullSecret on pod or Service Account level (for example, valid credentials are placed in container runtime configuration) you can add them in Trivy-Operator configuration.
+
+It's very similar to `Second Option`. First of all you need to create a secret. To do it, we first need an access token to our private registry. For GitHub private registries, you can create a new access token under the [following link.](https://github.com/settings/tokens/new) In comparison, the official Kubernetes coumentation shows how to create the [ImagePullSecret for the DockerHub.](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+
+Next, we will base64 encode the access token:
+
+```
+echo -n "YOUR_GH_ACCOUNT_NAME:YOUR_TOKEN" | base64
+```
+
+And take the output of the previous command and parse it into the following to base64 encode it again:
+```
+echo -n  '{"auths":{"ghcr.io":{"auth":"OUTPUT"}}}' | base64
+```
+
+Lastly, we are going to store the output in a Kubernetes Secret YAML manifest:
+
+`imagepullsecret.yaml`
+```
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+apiVersion: v1
+metadata:
+  name: dockerconfigjson-github-com
+  labels:
+    app: app-name
+data:
+  .dockerconfigjson: OUTPUT
+```
+
+Note that base64 encoding is not encryption, thust, you should not commit this file. If you are looking to store secrets in Kubernetes, have a look at e.g. [Hashicorp Secret Vault](https://www.vaultproject.io/use-cases/kubernetes), or with an [External Secrets Operator (ESO)](https://youtu.be/SyRZe5YVCVk).
+
+And finally, we can apply the secret to the same namespace as our application:
+```
+kubectl apply -f imagepullsecret.yaml -n app
+```
+
+Next, we will change the `privateRegistryScanSecretsNames` of the `values.yaml` manifest. For this, we can create a new `values.yaml` manifest with our desired modifiactions. We need to provide desired namespace and secret name. In our example they are `app` and `dockerconfigjson-github-com` accordingly.
+
+```
+operator:
+    privateRegistryScanSecretsNames: {"app":"dockerconfigjson-github-com"}
+```
+
+If you want you can add additional namespaces and secret names to `privateRegistryScanSecretsNames` separated by comma.
+
+Lastly, we can deploy the operator inside our cluster with referencing our new `values.yaml` manifest to override the default values:
+
+```
+helm upgrade --install trivy-operator aqua/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version 0.3.0
+  --values ./values.yaml
+```
+
+Alternatively, it is possible to set the values directly through Helm instead of referencing an additional `values.yaml` file:
+```
+helm upgrade --install trivy-operator aqua/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version 0.3.0
+  --set-json='operator.privateRegistryScanSecretsNames={"app":"dockerconfigjson-github-com"}'
+```
+
+Works only with helm 3.10+, because `--set-json` flag was added in 3.10.0. Otherwise you can use `values.yaml` instead.
+
+Once installed, make sure that 
+
+1. the operator is running in your cluster
+2. the operator has created a VulnerabilitReport for the container image from the private registry
+
+```
+❯ kubectl get deployment -n trivy-system
+
+NAME             READY   UP-TO-DATE   AVAILABLE   AGE
+trivy-operator   1/1     1            1           99s
+```
+
+## Fifth Option: Grant access through managed registries
 
 The last way that you could give the Trivy operator access to your private container registry is through managed registries. In this case, the container registry and your Kubernetes cluster would have to be on the same cloud provider; then you can define access to your container namespace as part of the IAM account. Once defined, trivy will already have the permissions for the registry.
 

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -188,8 +188,13 @@ func (r *secretsReader) CredentialsByWorkloadAndEnv(ctx context.Context, workloa
 	if err != nil {
 		return nil, err
 	}
+
 	secretsInfoMap := map[string]string{}
-	json.Unmarshal([]byte(secretsInfo), &secretsInfoMap)
+	err = json.Unmarshal([]byte(secretsInfo), &secretsInfoMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing incorrectly formatted information about namespaces and secrets: %s", secretsInfo)
+	}
+
 	for ns, secretName := range secretsInfoMap {
 		var envSecret corev1.Secret
 		err = r.client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: ns}, &envSecret)

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	WebhookBroadcastURL                          string         `env:"OPERATOR_WEBHOOK_BROADCAST_URL"`
 	WebhookBroadcastTimeout                      *time.Duration `env:"OPERATOR_WEBHOOK_BROADCAST_TIMEOUT" envDefault:"30s"`
 	TargetWorkloads                              string         `env:"OPERATOR_TARGET_WORKLOADS" envDefault:"Pod,ReplicaSet,ReplicationController,StatefulSet,DaemonSet,CronJob,Job"`
+	PrivateRegistryScanSecretsNames              string         `env:"OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES"`
 }
 
 // GetOperatorConfig loads Config from environment variables.

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -1,6 +1,7 @@
 package etc
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -67,6 +68,18 @@ func (c Config) GetTargetNamespaces() []string {
 		return strings.Split(namespaces, ",")
 	}
 	return []string{}
+}
+
+func (c Config) GetPrivateRegistryScanSecretsNames() (map[string]string, error) {
+	privateRegistryScanSecretsNames := c.PrivateRegistryScanSecretsNames
+	secretsInfoMap := map[string]string{}
+	if privateRegistryScanSecretsNames != "" {
+		err := json.Unmarshal([]byte(privateRegistryScanSecretsNames), &secretsInfoMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing incorrectly formatted information about namespaces and secrets: %s", privateRegistryScanSecretsNames)
+		}
+	}
+	return secretsInfoMap, nil
 }
 
 func (c Config) GetTargetWorkloads() []string {

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -249,7 +249,13 @@ func (r *WorkloadController) hasActiveScanJob(ctx context.Context, owner kube.Ob
 func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Object) error {
 	log := r.Logger.WithValues("kind", owner.GetObjectKind().GroupVersionKind().Kind,
 		"name", owner.GetName(), "namespace", owner.GetNamespace())
-	credentials, err := r.CredentialsByWorkloadAndEnv(ctx, owner, r.Config.PrivateRegistryScanSecretsNames)
+
+	privateRegistrySecrets, err := r.Config.GetPrivateRegistryScanSecretsNames()
+	if err != nil {
+		return err
+	}
+
+	credentials, err := r.CredentialsByWorkloadAndEnv(ctx, owner, privateRegistrySecrets)
 	if err != nil {
 		return err
 	}

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
@@ -17,7 +19,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -248,7 +249,7 @@ func (r *WorkloadController) hasActiveScanJob(ctx context.Context, owner kube.Ob
 func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Object) error {
 	log := r.Logger.WithValues("kind", owner.GetObjectKind().GroupVersionKind().Kind,
 		"name", owner.GetName(), "namespace", owner.GetNamespace())
-	credentials, err := r.CredentialsByWorkload(ctx, owner)
+	credentials, err := r.CredentialsByWorkloadAndEnv(ctx, owner, r.Config.PrivateRegistryScanSecretsNames)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Added the ability to use secrets form namespaces rather than from imagePullSecrets to authenticate in private repositories. For example if there is no such secrets (imagePull) and credentials are "stored" in container runtime configuration.

New field - `privateRegistryScanSecretsNames` can be used to set namespaces and secret names. For example: `privateRegistryScanSecretsNames: {"default":"mysecret"}`


## Related issues
- Close #556 

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've added tests that prove my fix is effective or that my feature works. Tested it locally in my environment
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
