### PR TITLE
fix(helm): operator.podLabels on operator pod

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,9 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
-      {{- if .Values.operator.podLabels }}
-      {{- toYaml .Values.operator.podLabels | nindent 6 }}
-      {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -23,6 +20,9 @@ spec:
       {{- end }}
       labels:
         {{- include "trivy-operator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.operator.podLabels }}
+        {{- toYaml .Values.operator.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trivy-operator.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}


### PR DESCRIPTION
operator.podLabels value should be provide deployement .spec.template.metadata.labels

 #558

Signed-off-by: MatthieuFin <matthieu2717@gmail.com>

## Description

## Related issues
- Close #558

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
