### PR TITLE
Add metrics about CVE vulnerability ID

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,9 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
-      {{- if .Values.operator.podLabels }}
-      {{- toYaml .Values.operator.podLabels | nindent 6 }}
-      {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -23,6 +20,9 @@ spec:
       {{- end }}
       labels:
         {{- include "trivy-operator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.operator.podLabels }}
+        {{- toYaml .Values.operator.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trivy-operator.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: ":8080"
             - name: OPERATOR_METRICS_FINDINGS_ENABLED
               value: {{ .Values.operator.metricsFindingsEnabled | quote }}
+            - name: OPERATOR_METRICS_VULN_ID_ENABLED
+              value: {{ .Values.operator.metricsVulnIdEnabled | quote }}
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -69,6 +69,9 @@ operator:
   # metricsFindingsEnabled the flag to enable metrics for findings
   metricsFindingsEnabled: true
 
+  # metricsVulnIdEnabled the flag to enable metrics about cve vulns id
+  metricsVulnIdEnabled: true
+
   # exposedSecretScannerEnabled the flag to enable exposed secret scanner
   exposedSecretScannerEnabled: true
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -70,7 +70,8 @@ operator:
   metricsFindingsEnabled: true
 
   # metricsVulnIdEnabled the flag to enable metrics about cve vulns id
-  metricsVulnIdEnabled: true
+  # be aware of metrics cardinality is significantly increased with this feature enabled.
+  metricsVulnIdEnabled: false
 
   # exposedSecretScannerEnabled the flag to enable exposed secret scanner
   exposedSecretScannerEnabled: true

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1278,6 +1278,8 @@ spec:
               value: ":8080"
             - name: OPERATOR_METRICS_FINDINGS_ENABLED
               value: "true"
+            - name: OPERATOR_METRICS_VULN_ID_ENABLED
+              value: "true"
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1279,7 +1279,7 @@ spec:
             - name: OPERATOR_METRICS_FINDINGS_ENABLED
               value: "true"
             - name: OPERATOR_METRICS_VULN_ID_ENABLED
-              value: "true"
+              value: "false"
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
               value: ":9090"
             - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 Trivy has a native [Kubernetes Operator](operator) which continuously scans your Kubernetes cluster for security issues, and generates security reports as Kubernetes [Custom Resources](crd). It does it by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.
 
-> Trivy Operator is based on existing Aqua OSS project - [Starboard], and shares some of the design, principles and code with it. Existing content that relates to Starboard Operator might also be relevant for Trivy Operator. To learn more about the transition from Starboard from Trivy, see the [announcement discussion](starboard-announcement).
+> Trivy Operator is based on existing Aqua OSS project - [Starboard], and shares some of the design, principles and code with it. Existing content that relates to Starboard Operator might also be relevant for Trivy Operator. To learn more about the transition from Starboard from Trivy, see the [announcement discussion](https://github.com/aquasecurity/starboard/discussions/1173).
 
 <figure>
   <img src="./images/operator/trivy-operator-workloads.png" />

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	BatchDeleteDelay                             time.Duration  `env:"OPERATOR_BATCH_DELETE_DELAY" envDefault:"10s"`
 	MetricsBindAddress                           string         `env:"OPERATOR_METRICS_BIND_ADDRESS" envDefault:":8080"`
 	MetricsFindingsEnabled                       bool           `env:"OPERATOR_METRICS_FINDINGS_ENABLED" envDefault:"true"`
+	MetricsVulnerabilityId                       bool           `env:"OPERATOR_METRICS_VULN_ID_ENABLED" envDefault:"true"`
 	HealthProbeBindAddress                       string         `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
 	VulnerabilityScannerEnabled                  bool           `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`
 	VulnerabilityScannerScanOnlyCurrentRevisions bool           `env:"OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS" envDefault:"true"`

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	BatchDeleteDelay                             time.Duration  `env:"OPERATOR_BATCH_DELETE_DELAY" envDefault:"10s"`
 	MetricsBindAddress                           string         `env:"OPERATOR_METRICS_BIND_ADDRESS" envDefault:":8080"`
 	MetricsFindingsEnabled                       bool           `env:"OPERATOR_METRICS_FINDINGS_ENABLED" envDefault:"true"`
-	MetricsVulnerabilityId                       bool           `env:"OPERATOR_METRICS_VULN_ID_ENABLED" envDefault:"true"`
+	MetricsVulnerabilityId                       bool           `env:"OPERATOR_METRICS_VULN_ID_ENABLED" envDefault:"false"`
 	HealthProbeBindAddress                       string         `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
 	VulnerabilityScannerEnabled                  bool           `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`
 	VulnerabilityScannerScanOnlyCurrentRevisions bool           `env:"OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS" envDefault:"true"`


### PR DESCRIPTION
## Description
This is a proposition about feature request [562](https://github.com/aquasecurity/trivy-operator/issues/562).

Which permit to expose new metrics (enable by default but disabled via operator env variable) about CVE vulnerabilities find in VulnerabilityReports

## Related issues
- Close #562


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
