### PR TITLE
feat: increase the priority of imagePullSecret from the pod spec

### DIFF
--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -164,7 +164,7 @@ func (r *secretsReader) ListImagePullSecretsByPodSpec(ctx context.Context, spec 
 	if err != nil && !k8sapierror.IsNotFound(err) {
 		return nil, err
 	}
-	imagePullSecrets = append(imagePullSecrets, sa.ImagePullSecrets...)
+	imagePullSecrets = append(sa.ImagePullSecrets, imagePullSecrets...)
 
 	secrets, err := r.ListByLocalObjectReferences(ctx, imagePullSecrets, ns)
 	if err != nil {

--- a/pkg/kube/testdata/fixture/sa_secret_same_domain.json
+++ b/pkg/kube/testdata/fixture/sa_secret_same_domain.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    ".dockerconfigjson": "eyJhdXRocyI6eyJxdWF5LmlvIjp7ImF1dGgiOiJjbTl2ZERwek0yTnlaWFE9In19fQ=="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2022-07-10T08:36:58Z",
+    "name": "myregistrykey",
+    "namespace": "default",
+    "resourceVersion": "317629",
+    "uid": "ab0f9c59-dab8-4c2d-98f6-a6fac0e9a35d"
+  },
+  "type": "kubernetes.io/dockerconfigjson"
+}

--- a/pkg/kube/testdata/fixture/sa_with_image_pull_secret_same_domain.json
+++ b/pkg/kube/testdata/fixture/sa_with_image_pull_secret_same_domain.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "ServiceAccount",
+  "metadata": {
+    "creationTimestamp": "2022-07-05T09:28:13Z",
+    "name": "default",
+    "namespace": "default",
+    "resourceVersion": "390",
+    "uid": "c5af80da-d909-44be-851c-8f68278d59f5"
+  },
+  "secrets": [
+    {
+      "name": "default-token-uudge"
+    }
+  ],
+  "imagePullSecrets": [
+    {
+      "name": "myregistrykey"
+    }
+  ]
+}

--- a/pkg/kube/testdata/fixture/secret_same_domain.json
+++ b/pkg/kube/testdata/fixture/secret_same_domain.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    ".dockerconfigjson": "eyJhdXRocyI6eyJxdWF5LmlvIjp7ImF1dGgiOiJkWE5sY2pwQlpHMXBiakV5TXpRMSJ9fX0="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2022-07-10T08:36:58Z",
+    "name": "regcred",
+    "namespace": "default",
+    "resourceVersion": "317629",
+    "uid": "ab0f9c59-dab8-4c2d-98f6-a6fac0e9a35d"
+  },
+  "type": "kubernetes.io/dockerconfigjson"
+}


### PR DESCRIPTION
## Description
Then the values of the domains for docker registry in the pod imagePullSecret and service account imagePullSecret are the same, then in the final structure, the credentials from the secret specified in the Service Account will "overwrite" the values from the secret specified in the Pod specification.

I increase priority of the imagePullSecret from Pod priority. This coincides with the principle of how kubelet working with imagePullSecret.

## Related issues
- Close #575 