### PR TITLE
[fix] typo in sample rego for custom audit policy

### DIFF
--- a/docs/tutorials/recommended_labels.rego
+++ b/docs/tutorials/recommended_labels.rego
@@ -1,4 +1,4 @@
-package trivy-operator.policy.k8s.custom
+package trivyoperator.policy.k8s.custom
 
 __rego_metadata__ := {
 	"id": "recommended_labels",


### PR DESCRIPTION
## Description
This is a trivial fix for the sample Rego file linked in the tutorial, [Writing Custom Configuration Audit Policies](https://aquasecurity.github.io/trivy-operator/v0.3.0/tutorials/writing-custom-configuration-audit-policies/).

This code contains an unnecessary hyphen in the package name, which when applied, prevents Configuration Audit from running.

The content is also different, but the package name which the Rego code embedded in the docs has are normal.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
