### PR TITLE
feat(helm): allow users to define an external secrets for tokens

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -134,6 +134,7 @@ data:
     {{- end }}
   {{- end }}
 ---
+{{- if not .existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -153,6 +154,7 @@ data:
   trivy.serverCustomHeaders: {{ .serverCustomHeaders | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -276,7 +276,7 @@ trivy:
 
   # existingSecret if an existing secret has been created outside the chart.
   # Overrides gitHubToken, serverToken, serverCustomHeaders
-  # existingSecret: ""
+  # existingSecret: "my-trivy-secret"
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -274,9 +274,11 @@ trivy:
   #
   # serverCustomHeaders: "foo=bar"
 
-  # existingSecret if an existing secret has been created outside the chart.
+  # existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
+  # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
   # Overrides gitHubToken, serverToken, serverCustomHeaders
-  # existingSecret: "my-trivy-secret"
+  # Note: The secret has to be named "trivy-operator-trivy-config".
+  # existingSecret: true
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -85,6 +85,12 @@ operator:
   # privateRegistryScanSecretsNames is map of namespace:secrets which can be used to authenticate in private registries in case if there no imagePullSecrets provided
   privateRegistryScanSecretsNames: {}
 
+  # existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
+  # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
+  # Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values.
+  # Note: The secret has to be named "trivy-operator-trivy-config".
+  # existingSecret: true
+
 image:
   repository: "ghcr.io/aquasecurity/trivy-operator"
   # tag is an override of the image tag, which is by default set by the
@@ -273,12 +279,6 @@ trivy:
   # Trivy client to Trivy server. Only applicable in ClientServer mode.
   #
   # serverCustomHeaders: "foo=bar"
-
-  # existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
-  # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
-  # Overrides gitHubToken, serverToken, serverCustomHeaders
-  # Note: The secret has to be named "trivy-operator-trivy-config".
-  # existingSecret: true
 
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -274,6 +274,10 @@ trivy:
   #
   # serverCustomHeaders: "foo=bar"
 
+  # existingSecret if an existing secret has been created outside the chart.
+  # Overrides gitHubToken, serverToken, serverCustomHeaders
+  # existingSecret: ""
+
   dbRepository: "ghcr.io/aquasecurity/trivy-db"
 
   # The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)


### PR DESCRIPTION
## Description

With this PR, we can set `trivy.gitHubToken`, `trivy.serverToken` and `trivy.serverCustomHeaders` within a secret defined outside of the chart, by using `trivy.existingSecret` value.
This is useful to avoid having those in plain text as values, notably for those who are using solutions like external-secrets for example.

## Related issues
- Close #638

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [n/a] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [n/a] I've included a "before" and "after" example to the description (if the PR is a user interface change).
