### PR TITLE
fix: re-generate config audit report following to cm change

### DIFF
--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -718,6 +718,13 @@ func IsRoleTypes(kind Kind) bool {
 	return false
 }
 
+func IsRoleRelatedKinds(kind Kind) bool {
+	if kind == KindRole || kind == KindClusterRole || kind == KindClusterRoleBindings || kind == KindRoleBinding  {
+		return true
+	}
+	return false
+}
+
 func isValidNamespaceResource(kind Kind) bool {
 	if kind == KindConfigMap || kind == KindNetworkPolicy || kind == KindIngress || kind == KindResourceQuota || kind == KindLimitRange {
 		return true

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -718,13 +718,6 @@ func IsRoleTypes(kind Kind) bool {
 	return false
 }
 
-func IsRoleRelatedKinds(kind Kind) bool {
-	if kind == KindRole || kind == KindClusterRole || kind == KindClusterRoleBindings || kind == KindRoleBinding {
-		return true
-	}
-	return false
-}
-
 func isValidNamespaceResource(kind Kind) bool {
 	if kind == KindConfigMap || kind == KindNetworkPolicy || kind == KindIngress || kind == KindResourceQuota || kind == KindLimitRange {
 		return true

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -719,7 +719,7 @@ func IsRoleTypes(kind Kind) bool {
 }
 
 func IsRoleRelatedKinds(kind Kind) bool {
-	if kind == KindRole || kind == KindClusterRole || kind == KindClusterRoleBindings || kind == KindRoleBinding  {
+	if kind == KindRole || kind == KindClusterRole || kind == KindClusterRoleBindings || kind == KindRoleBinding {
 		return true
 	}
 	return false

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -92,7 +92,7 @@ func (p *Policies) PoliciesByKind(kind string) (map[string]string, error) {
 			if k != kindAny && k != kindWorkload && k != kind {
 				continue
 			}
-			if !(kube.IsRoleRelatedKinds(kube.Kind(k)) && k == kind)  {
+			if !(kube.IsRoleRelatedKinds(kube.Kind(k)) && k == kind) {
 				continue
 			}
 			policyKey := strings.TrimSuffix(key, keySuffixKinds) + keySuffixRego

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -92,9 +92,6 @@ func (p *Policies) PoliciesByKind(kind string) (map[string]string, error) {
 			if k != kindAny && k != kindWorkload && k != kind {
 				continue
 			}
-			if !(kube.IsRoleRelatedKinds(kube.Kind(k)) && k == kind) {
-				continue
-			}
 			policyKey := strings.TrimSuffix(key, keySuffixKinds) + keySuffixRego
 			var ok bool
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -92,7 +92,9 @@ func (p *Policies) PoliciesByKind(kind string) (map[string]string, error) {
 			if k != kindAny && k != kindWorkload && k != kind {
 				continue
 			}
-
+			if !(kube.IsRoleRelatedKinds(kube.Kind(k)) && k == kind)  {
+				continue
+			}
 			policyKey := strings.TrimSuffix(key, keySuffixKinds) + keySuffixRego
 			var ok bool
 


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
 re-generate config audit report following to cm change

## Related issues
- Close #642 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
