### PR TITLE
fix: sanitize k8s metrics labels

### DIFF
--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -148,7 +148,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
 			return cas.LowCount
 		},
 	}
-
+	dynamicLabels := getDynamicConfigLabels(config)
 	imageVulnLabels := []string{
 		namespace,
 		name,
@@ -158,7 +158,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
 		image_digest,
 		severity,
 	}
-	imageVulnLabels = includeDynamicConfigLabels(imageVulnLabels, config)
+	imageVulnLabels = append(imageVulnLabels, dynamicLabels...)
 	vulnIdLabels := []string{
 		namespace,
 		name,
@@ -169,7 +169,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
 		severity,
 		vuln_id,
 	}
-	vulnIdLabels = includeDynamicConfigLabels(vulnIdLabels, config)
+	vulnIdLabels = append(vulnIdLabels, dynamicLabels...)
 	exposedSecretLabels := []string{
 		namespace,
 		name,
@@ -179,19 +179,19 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
 		image_digest,
 		severity,
 	}
-	exposedSecretLabels = includeDynamicConfigLabels(exposedSecretLabels, config)
+	exposedSecretLabels = append(exposedSecretLabels, dynamicLabels...)
 	configAuditLabels := []string{
 		namespace,
 		name,
 		severity,
 	}
-	configAuditLabels = includeDynamicConfigLabels(configAuditLabels, config)
+	configAuditLabels = append(configAuditLabels, dynamicLabels...)
 	rbacAssessmentLabels := []string{
 		namespace,
 		name,
 		severity,
 	}
-	rbacAssessmentLabels = includeDynamicConfigLabels(rbacAssessmentLabels, config)
+	rbacAssessmentLabels = append(rbacAssessmentLabels, dynamicLabels...)
 
 	imageVulnDesc := prometheus.NewDesc(
 		prometheus.BuildFQName("trivy", "image", "vulnerabilities"),
@@ -251,10 +251,11 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
 	}
 }
 
-func includeDynamicConfigLabels(labels []string, config trivyoperator.ConfigData) []string {
+func getDynamicConfigLabels(config trivyoperator.ConfigData) []string {
+	labels := make([]string, 0)
 	resourceLabels := config.GetReportResourceLabels()
 	for _, label := range resourceLabels {
-		labels = append(labels, config.GetMetricsResourceLabelsPrefix()+label)
+		labels = append(labels, config.GetMetricsResourceLabelsPrefix()+sanitizeLabelName(label))
 	}
 	return labels
 }

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	matchAllCap        = regexp.MustCompile("([a-z0-9])([A-Z])")
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
+
+func toSnakeCase(s string) string {
+	snake := matchAllCap.ReplaceAllString(s, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func sanitizeLabelName(s string) string {
+	return toSnakeCase(invalidLabelCharRE.ReplaceAllString(s, "_"))
+}

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeLabelName(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{name: "valid label", label: "owner", want: "owner"},
+		{name: "label with slash", label: "app/name", want: "app_name"},
+		{name: "label with dot", label: "app.name", want: "app_name"},
+		{name: "label with dot and slash", label: "app.kubernetes.io/name", want: "app_kubernetes_io_name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabelName(tt.label)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
sanitize k8s metrics labels

## Related issues
- Close #646

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
