### PR TITLE
Adding Service Kind For ConfigAuditReports

### DIFF
--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -719,7 +719,7 @@ func IsRoleTypes(kind Kind) bool {
 }
 
 func isValidNamespaceResource(kind Kind) bool {
-	if kind == KindConfigMap || kind == KindNetworkPolicy || kind == KindIngress || kind == KindResourceQuota || kind == KindLimitRange {
+	if kind == KindConfigMap || kind == KindNetworkPolicy || kind == KindIngress || kind == KindResourceQuota || kind == KindLimitRange || kind == KindService {
 		return true
 	}
 	return false


### PR DESCRIPTION
 In this change we have added the service kind of resources to be evaluated againt rego policies for service kinds and hence be able to create reports for service type of resources as well

## Description
Adding Service Kind For ConfigAuditReports

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
