### PR TITLE
fix Dockerfile to use numeric user

### DIFF
--- a/build/trivy-operator/Dockerfile
+++ b/build/trivy-operator/Dockerfile
@@ -4,6 +4,6 @@ RUN adduser -u 10000 -D -g '' trivyoperator trivyoperator
 
 COPY trivy-operator /usr/local/bin/trivy-operator
 
-USER trivyoperator
+USER 10000
 
 ENTRYPOINT ["trivy-operator"]


### PR DESCRIPTION
specify user numerically in Dockerfile

## Description
Simple change to Dockerfile so that the user is specified numerically.  This allows container orchestrators to know the container will run as non-root without inspecting the passwd file in the image (which most of them can't/won't do).

## Related issues
- Close #573

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
