### PR TITLE
fix: disable ingress caching by client

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
 	"github.com/aquasecurity/trivy-operator/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -56,6 +57,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		ClientDisableCacheFor: []client.Object{
 			&corev1.Secret{},
 			&corev1.ServiceAccount{},
+			&networkingv1.Ingress{},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
Disable ingress caching by client
## Related issues
- Close #654 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
