### PR TITLE
feat: record only failed checks on misconfiguration reports

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -44,6 +44,9 @@ data:
   report.resourceLabels: {{ .Values.trivyOperator.reportResourceLabels | quote }}
   metrics.resourceLabelsPrefix: {{ .Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
   {{- end }}
+  {{- if .Values.trivyOperator.reportRecordFailedChecksOnly }}
+  report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -173,6 +173,8 @@ trivyOperator:
   # metrics report. Example: `owner,app`
   reportResourceLabels: ""
 
+  # reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
+  reportRecordFailedChecksOnly: false
   # metricsResourceLabelsPrefix Prefix that will be prepended to the labels names indicated in `reportResourceLabels`
   # when including them in the Prometheus metrics
   metricsResourceLabelsPrefix: "k8s_label_"

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -62,6 +62,8 @@ To change the target namespace from all namespaces to the `default` namespace ed
 | `scanJob.podTemplateContainerSecurityContext`| N/A| One-line JSON representation of the template securityContext which the user wants the scanner containers (and their initContainers) to be amended with. Example: `{"allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"]},"privileged": false, "readOnlyRootFilesystem": true }` |
 | `report.resourceLabels`| N/A| One-line comma-separated representation of the scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app,tier`|
 | `metrics.resourceLabelsPrefix`| `k8s_label`| Prefix that will be prepended to the labels names indicated in `report.ResourceLabels` when including them in the Prometheus metrics|
+|`report.recordFailedChecksOnly`| `"false"`| this flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
+
 
 ## Example - patch ConfigMap
 

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -353,6 +353,9 @@ func (r *ResourceController) evaluate(ctx context.Context, policies *policy.Poli
 		if strings.HasPrefix(id, "KCV") || strings.HasPrefix(id, "AVD-KCV") || strings.HasPrefix(id, "N/A") {
 			continue
 		}
+		if r.ConfigData.ReportRecordFailedChecksOnly() && result.Status() == scan.StatusPassed {
+			continue
+		}
 		checks = append(checks, v1alpha1.Check{
 			ID:          id,
 			Title:       result.Rule().Summary,

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -241,7 +241,7 @@ func (c ConfigData) GetReportResourceLabels() []string {
 	if !found || strings.TrimSpace(ResourceLabelsStr) == "" {
 		return []string{}
 	}
-	
+
 	return strings.Split(ResourceLabelsStr, ",")
 }
 

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -67,6 +67,7 @@ const (
 	keyScanJobPodTemplateLabels            = "scanJob.podTemplateLabels"
 	keyComplianceFailEntriesLimit          = "compliance.failEntriesLimit"
 	KeyReportResourceLabels                = "report.resourceLabels"
+	KeyReportRecordFailedChecksOnly        = "report.recordFailedChecksOnly"
 	KeyMetricsResourceLabelsPrefix         = "metrics.resourceLabelsPrefix"
 )
 
@@ -236,12 +237,15 @@ func (c ConfigData) GetScanJobPodTemplateLabels() (labels.Set, error) {
 }
 
 func (c ConfigData) GetReportResourceLabels() []string {
-	ResourceLabelsStr, found := c[KeyReportResourceLabels]
-	if !found || strings.TrimSpace(ResourceLabelsStr) == "" {
+	resourceLabelsStr, found := c[KeyReportResourceLabels]
+	if !found || strings.TrimSpace(resourceLabelsStr) == "" {
 		return []string{}
 	}
+	return strings.Split(resourceLabelsStr, ",")
+}
 
-	return strings.Split(ResourceLabelsStr, ",")
+func (c ConfigData) ReportRecordFailedChecksOnly() bool {
+	return c.getBoolKey(KeyReportRecordFailedChecksOnly)
 }
 
 func (c ConfigData) GetMetricsResourceLabelsPrefix() string {

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -241,6 +241,7 @@ func (c ConfigData) GetReportResourceLabels() []string {
 	if !found || strings.TrimSpace(ResourceLabelsStr) == "" {
 		return []string{}
 	}
+	
 	return strings.Split(ResourceLabelsStr, ",")
 }
 

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -237,11 +237,11 @@ func (c ConfigData) GetScanJobPodTemplateLabels() (labels.Set, error) {
 }
 
 func (c ConfigData) GetReportResourceLabels() []string {
-	resourceLabelsStr, found := c[KeyReportResourceLabels]
-	if !found || strings.TrimSpace(resourceLabelsStr) == "" {
+	ResourceLabelsStr, found := c[KeyReportResourceLabels]
+	if !found || strings.TrimSpace(ResourceLabelsStr) == "" {
 		return []string{}
 	}
-	return strings.Split(resourceLabelsStr, ",")
+	return strings.Split(ResourceLabelsStr, ",")
 }
 
 func (c ConfigData) ReportRecordFailedChecksOnly() bool {


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
Record only failed checks on misconfiguration reports

## Related issues
- Close #495 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
