### PR TITLE
feat: skip workload scanning by resource label

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -45,11 +45,11 @@ data:
   metrics.resourceLabelsPrefix: {{ .Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
   {{- end }}
   {{- if .Values.trivyOperator.reportRecordFailedChecksOnly }}
-    report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
-    {{- end }}
+  report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
+  {{- end }}
   {{- if .Values.trivyOperator.skipResourceByLabels }}
-    skipResourceByLabels: {{ .Values.trivyOperator.skipResourceByLabels | quote }}
-   {{- end }}
+  skipResourceByLabels: {{ .Values.trivyOperator.skipResourceByLabels | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -45,8 +45,11 @@ data:
   metrics.resourceLabelsPrefix: {{ .Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
   {{- end }}
   {{- if .Values.trivyOperator.reportRecordFailedChecksOnly }}
-  report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
-  {{- end }}
+    report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
+    {{- end }}
+  {{- if .Values.trivyOperator.skipResourceByLabels }}
+    skipResourceByLabels: {{ .Values.trivyOperator.skipResourceByLabels | quote }}
+   {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -177,7 +177,9 @@ trivyOperator:
 
 # reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
   reportRecordFailedChecksOnly: false
-  
+
+  #skipResourceByLabels  comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels
+  skipResourceByLabels: ""
   # metricsResourceLabelsPrefix Prefix that will be prepended to the labels names indicated in `reportResourceLabels`
   # when including them in the Prometheus metrics
   metricsResourceLabelsPrefix: "k8s_label_"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -180,6 +180,7 @@ trivyOperator:
 
   #skipResourceByLabels  comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels
   skipResourceByLabels: ""
+  
   # metricsResourceLabelsPrefix Prefix that will be prepended to the labels names indicated in `reportResourceLabels`
   # when including them in the Prometheus metrics
   metricsResourceLabelsPrefix: "k8s_label_"

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -63,6 +63,8 @@ To change the target namespace from all namespaces to the `default` namespace ed
 | `report.resourceLabels`| N/A| One-line comma-separated representation of the scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app,tier`|
 | `metrics.resourceLabelsPrefix`| `k8s_label`| Prefix that will be prepended to the labels names indicated in `report.ResourceLabels` when including them in the Prometheus metrics|
 |`report.recordFailedChecksOnly`| `"false"`| this flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
+| `skipResourceByLabels`| N/A| One-line comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels. Example: `test,transient`|
+
 ## Example - patch ConfigMap
 
 By default Trivy displays vulnerabilities with all severity levels (`UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`). To display only `HIGH` and `CRITICAL` vulnerabilities by patching the `trivy.severity` value in the `trivy-operator-trivy-config` ConfigMap:

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/exp v0.0.0-20221109205753-fc8884afc316
 	golang.org/x/oauth2 v0.1.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221109205753-fc8884afc316 h1:FedCSp0+vayF11p3wAQndIgu+JTcW2nLp5M+HSefjlM=
+golang.org/x/exp v0.0.0-20221109205753-fc8884afc316/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/configauditreport/controller/controller.go
+++ b/pkg/configauditreport/controller/controller.go
@@ -191,7 +191,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		}
 		// validate if workload require continuing with processing
 		if skip, err := workload.SkipProcessing(ctx, resource, r.ObjectResolver,
-			r.Config.ConfigAuditScannerScanOnlyCurrentRevisions, log); skip {
+			r.Config.ConfigAuditScannerScanOnlyCurrentRevisions, log, r.ConfigData.GetSkipResourceByLabels()); skip {
 			return ctrl.Result{}, err
 		}
 		cac, err := r.NewConfigForConfigAudit(r.PluginContext)

--- a/pkg/operator/workload/helper.go
+++ b/pkg/operator/workload/helper.go
@@ -21,10 +21,12 @@ import (
 )
 
 func SkipProcessing(ctx context.Context, resource client.Object, or kube.ObjectResolver, scanOnlyCurrentRevisions bool, log logr.Logger, skipResourceLabels []string) (bool, error) {
-	resourceLabelKeys := maps.Keys(resource.GetLabels())
-	for _, skipResourceLabel := range skipResourceLabels {
-		if slices.Contains(resourceLabelKeys, skipResourceLabel) {
-			return true, nil
+	if len(skipResourceLabels) > 0 {
+		resourceLabelKeys := maps.Keys(resource.GetLabels())
+		for _, skipResourceLabel := range skipResourceLabels {
+			if slices.Contains(resourceLabelKeys, skipResourceLabel) {
+				return true, nil
+			}
 		}
 	}
 	switch r := resource.(type) {

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -66,6 +66,7 @@ const (
 	keyScanJobPodSecurityContext           = "scanJob.podTemplatePodSecurityContext"
 	keyScanJobPodTemplateLabels            = "scanJob.podTemplateLabels"
 	keyComplianceFailEntriesLimit          = "compliance.failEntriesLimit"
+	keySkipResourceByLabels                = "skipResourceByLabels"
 	KeyReportResourceLabels                = "report.resourceLabels"
 	KeyReportRecordFailedChecksOnly        = "report.recordFailedChecksOnly"
 	KeyMetricsResourceLabelsPrefix         = "metrics.resourceLabelsPrefix"
@@ -243,6 +244,15 @@ func (c ConfigData) GetReportResourceLabels() []string {
 	}
 
 	return strings.Split(resourceLabelsStr, ",")
+}
+
+func (c ConfigData) GetSkipResourceByLabels() []string {
+	scanSkipResourceLabels, found := c[keySkipResourceByLabels]
+	if !found || strings.TrimSpace(scanSkipResourceLabels) == "" {
+		return []string{}
+	}
+
+	return strings.Split(scanSkipResourceLabels, ",")
 }
 
 func (c ConfigData) GetMetricsResourceLabelsPrefix() string {

--- a/pkg/vulnerabilityreport/controller.go
+++ b/pkg/vulnerabilityreport/controller.go
@@ -119,7 +119,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 
 		// Skip processing if it's a Pod controlled by a built-in K8s workload.
 		if skip, err := workload.SkipProcessing(ctx, workloadObj, r.ObjectResolver,
-			r.Config.VulnerabilityScannerScanOnlyCurrentRevisions, log); skip {
+			r.Config.VulnerabilityScannerScanOnlyCurrentRevisions, log, r.ConfigData.GetSkipResourceByLabels()); skip {
 			return ctrl.Result{}, err
 		}
 


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
Skip workload scanning by resource label)

## Related issues
- Close #585

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
