### PR TITLE
fix(helm): fixes the install failure when using an existing trivy-operator-trivy-config secret

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -140,7 +140,7 @@ data:
     {{- end }}
   {{- end }}
 ---
-{{- if not $.Values.operator.existingSecret }}
+{{- if not .existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -140,7 +140,7 @@ data:
     {{- end }}
   {{- end }}
 ---
-{{- if not .existingSecret }}
+{{- if not $.Values.operator.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -87,12 +87,6 @@ operator:
   # privateRegistryScanSecretsNames is map of namespace:secrets which can be used to authenticate in private registries in case if there no imagePullSecrets provided
   privateRegistryScanSecretsNames: {}
 
-  # existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
-  # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
-  # Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values.
-  # Note: The secret has to be named "trivy-operator-trivy-config".
-  # existingSecret: true
-
 image:
   repository: "ghcr.io/aquasecurity/trivy-operator"
   # tag is an override of the image tag, which is by default set by the
@@ -278,6 +272,12 @@ trivy:
   # applicable in ClientServer mode.
   #
   # serverToken: "*****"
+
+  # existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
+  # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
+  # Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values.
+  # Note: The secret has to be named "trivy-operator-trivy-config".
+  # existingSecret: true
 
   # serverTokenHeader is the name of the HTTP header used to send the authentication
   # token to Trivy server. Only application in ClientServer mode when


### PR DESCRIPTION
## Description
The value that controls the creation of the trivy-operator-trivy-config secret was wrong. This fixes it.

After review, I moved the value from the trivy to the operator section, without readdressing it in the config.yaml file

This aims at fixing this.

[Gist: Helm rendered with defaults](https://gist.github.com/cebidhem/378ea3d9ee6e7e23f1d7737716ab4a90)

[Gist: Helm rendered with existing secret](https://gist.github.com/cebidhem/ecb461be3f0588e71b7fd5778e03a0a3)

## Related issues
- Close #690 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [-] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [-] I've added usage information (if the PR introduces new options)
- [-] I've included a "before" and "after" example to the description (if the PR is a user interface change).
