### PR TITLE
fix(helm): Aligns config with the values for the existingSecret value

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -157,7 +157,7 @@ data:
   TRIVY_DB_REPOSITORY: {{ .Values.trivy.dbRepository | quote }}
   {{- end }}
 ---
-{{- if not .Values.operator.existingSecret }}
+{{- if not .Values.trivy.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Signed-off-by: cebidhem <cebidhem@pm.me>

## Description

As described in the issue, a regression has been introduced. This aims at aligning the config with the values for using an existingSecret.

## Related issues
- Close #715 


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [-] I've added tests that prove my fix is effective or that my feature works.
- [-] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [-] I've added usage information (if the PR introduces new options)
- [-] I've included a "before" and "after" example to the description (if the PR is a user interface change).
