### PR TITLE
feat: record misconfig failed checks only enable by default

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -175,7 +175,7 @@ trivyOperator:
   reportResourceLabels: ""
 
   # reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
-  reportRecordFailedChecksOnly: false
+  reportRecordFailedChecksOnly: true
 
   # skipResourceByLabels  comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels
   skipResourceByLabels: ""

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1369,6 +1369,7 @@ data:
   scanJob.compressLogs: "true"
   vulnerabilityReports.scanner: "Trivy"
   configAuditReports.scanner: "Trivy"
+  report.recordFailedChecksOnly: "true"
 ---
 # Source: trivy-operator/templates/config.yaml
 apiVersion: v1

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -66,7 +66,7 @@ To change the target namespace from all namespaces to the `default` namespace ed
 | `scanJob.podTemplateContainerSecurityContext`| N/A| One-line JSON representation of the template securityContext which the user wants the scanner containers (and their initContainers) to be amended with. Example: `{"allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"]},"privileged": false, "readOnlyRootFilesystem": true }` |
 | `report.resourceLabels`| N/A| One-line comma-separated representation of the scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app,tier`|
 | `metrics.resourceLabelsPrefix`| `k8s_label`| Prefix that will be prepended to the labels names indicated in `report.ResourceLabels` when including them in the Prometheus metrics|
-|`report.recordFailedChecksOnly`| `"false"`| this flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
+|`report.recordFailedChecksOnly`| `"true"`| this flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment)
 | `skipResourceByLabels`| N/A| One-line comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels. Example: `test,transient`|
 
 ## Example - patch ConfigMap

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -91,6 +91,7 @@ func GetDefaultConfig() ConfigData {
 		keyConfigAuditReportsScanner:   "Trivy",
 		KeyScanJobcompressLogs:         "true",
 		"compliance.failEntriesLimit":  "10",
+		KeyReportRecordFailedChecksOnly: "true",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
record misconfig failed checks only enable by default
## Related issues
- Related #495

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).

