### PR TITLE
Bugfix - Changing scanner type for RoleBindings and ClusterRoleBindings

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -227,7 +227,7 @@ func (r *Policies) GetResultID(result scan.Result) string {
 }
 
 func scannerByType(resourceKind string, scannerOptions []options.ScannerOption) scanners.FSScanner {
-	if strings.Contains(resourceKind, "Role") {
+	if resourceKind == "Role" || resourceKind == "ClusterRole" {
 		return rbac.NewScanner(scannerOptions...)
 	}
 	return kubernetes.NewScanner(scannerOptions...)


### PR DESCRIPTION
## Description
In this change we are setting the kubernetes scanner for rolebinding and clusterrolebinding resources. The rbac scanner is to be used for roles and clusterroles. 



## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
