### PR TITLE
docs: add clustercompliancereports crd in Helm uninstall section

### DIFF
--- a/docs/getting-started/installation/helm.md
+++ b/docs/getting-started/installation/helm.md
@@ -80,6 +80,7 @@ You have to manually delete custom resource definitions created by the `helm ins
     kubectl delete crd rbacassessmentreports.aquasecurity.github.io
     kubectl delete crd infraassessmentreports.aquasecurity.github.io
     kubectl delete crd clusterrbacassessmentreports.aquasecurity.github.io
+    kubectl delete crd clustercompliancereports.aquasecurity.github.io
     ```
 
 [Helm]: https://helm.sh/


### PR DESCRIPTION
Signed-off-by: ollide <hg.otothel@gmail.com>

## Description

Adds the `clustercompliancereports.aquasecurity.github.io` CRD in the Helm Uninstall documentation.

The upgrade doc suggests to uninstall the previous version before installing the latest version. Coming from 0.4.0, I followed the Helm Uninstall doc, but the installation of 0.10.1 failed, because `helm.md` was missing the clustercompliancereports CRD.

See also #795, where another user had the same problem.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
