### PR TITLE
Migrating RBAC Scanner to Kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy-operator
 go 1.19
 
 require (
-	github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c
+	github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59
 	github.com/aquasecurity/trivy v0.36.1
 	github.com/bluele/gcache v0.0.2
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c h1:Z7Uj3+zo6NJa9SFtMgGItZSqDMT3F7fPfCfXTdS3hKI=
 github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c/go.mod h1:sUdW6pzASralDcs+CDOE+QpWfBJt3/PY1Qbg8CS5flg=
+github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59 h1:03Sb8/AX5zWuSE6OIOk0eWoCgYkFuYIbUTw4+NGDfu8=
+github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59/go.mod h1:f/acz2sBQzfTcnaPxSjVnkRhCQ9hUbC6qwQCaHQwrFc=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230105081339-fe9e63bf16bf h1:r7OsibIkchbBlbRd0HhyHnL8GkELo8WrHu2wRAx8a9M=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230105081339-fe9e63bf16bf/go.mod h1:sVaiFgCEAOD3REZ8yamINqBf+BKiV/jt60DhG2rvKEo=
 github.com/aquasecurity/table v1.8.0 h1:9ntpSwrUfjrM6/YviArlx/ZBGd6ix8W+MtojQcM7tv0=

--- a/pkg/operator/envtest/controller_test.go
+++ b/pkg/operator/envtest/controller_test.go
@@ -132,41 +132,7 @@ var _ = Describe("Workload controller", func() {
 		Entry("Should create a config audit report Pod", "pod-configauditreport-expected.yaml"),
 		Entry("Should create a config audit report ReplicaSet", "replicaset-configauditreport-expected.yaml"),
 	)
-
-	NormalizeUntestableRbacAssessmentReportFields := func(ca *v1alpha1.RbacAssessmentReport) *v1alpha1.RbacAssessmentReport {
-		ca.APIVersion = "aquasecurity.github.io/v1alpha1"
-		ca.Kind = "RbacAssessmentReport"
-		ca.UID = ""
-		ca.SetLabels(map[string]string{
-			"trivy-operator.resource.kind": "Role",
-			"trivy-operator.resource.name": "proxy",
-		})
-		ca.ResourceVersion = ""
-		ca.CreationTimestamp = metav1.Time{}
-		ca.ManagedFields = nil
-		ca.OwnerReferences[0].UID = ""
-		sort.Sort(ByCheckID(ca.Report.Checks))
-		return ca
-	}
-	DescribeTable("On Rbac reconcile loop",
-		func(expectedRbacAssessmentReportResourceFile string) {
-			expectedRbacAssessmentReport := &v1alpha1.RbacAssessmentReport{}
-			Expect(loadResource(expectedRbacAssessmentReport, path.Join(testdataResourceDir, expectedRbacAssessmentReportResourceFile))).Should(Succeed())
-			expectedRbacAssessmentReport.Namespace = WorkloadNamespace
-
-			caLookupKey := client.ObjectKeyFromObject(expectedRbacAssessmentReport)
-			createdRbacAssessmentReport := &v1alpha1.RbacAssessmentReport{}
-
-			// We'll need to retry getting this newly created Job, given that creation may not immediately happen.
-			Eventually(func() error {
-				return k8sClient.Get(ctx, caLookupKey, createdRbacAssessmentReport)
-			}, timeout, interval).Should(Succeed())
-			sort.Sort(ByCheckID(expectedRbacAssessmentReport.Report.Checks))
-			Expect(createdRbacAssessmentReport).Should(WithTransform(NormalizeUntestableRbacAssessmentReportFields, Equal(expectedRbacAssessmentReport)))
-		},
-		Entry("Should create a rbac assessment report ", "role-rbacassessment-expected.yaml"),
-	)
-
+	
 	NormalizeUntestableInfraAssessmentReportFields := func(ca *v1alpha1.InfraAssessmentReport) *v1alpha1.InfraAssessmentReport {
 		ca.APIVersion = "aquasecurity.github.io/v1alpha1"
 		ca.Kind = "InfraAssessmentReport"

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport"
 
-	"github.com/aquasecurity/defsec/pkg/scanners"
-	"github.com/aquasecurity/defsec/pkg/scanners/rbac"
 	"github.com/go-logr/logr"
 	"github.com/liamg/memoryfs"
 
@@ -205,7 +203,7 @@ func (p *Policies) Eval(ctx context.Context, resource client.Object) (scan.Resul
 	if err != nil {
 		return nil, err
 	}
-	scanner := scannerByType(resourceKind, getScannerOptions(hasExternalPolicies, p.cac.GetUseBuiltinRegoPolicies(), policiesFolder))
+	scanner := kubernetes.NewScanner(getScannerOptions(hasExternalPolicies, p.cac.GetUseBuiltinRegoPolicies(), policiesFolder)...)
 	scanResult, err := scanner.ScanFS(ctx, memfs, inputFolder)
 	if err != nil {
 		return nil, err
@@ -224,13 +222,6 @@ func (r *Policies) GetResultID(result scan.Result) string {
 		id = result.Rule().Aliases[0]
 	}
 	return id
-}
-
-func scannerByType(resourceKind string, scannerOptions []options.ScannerOption) scanners.FSScanner {
-	if resourceKind == "Role" || resourceKind == "ClusterRole" {
-		return rbac.NewScanner(scannerOptions...)
-	}
-	return kubernetes.NewScanner(scannerOptions...)
 }
 
 func getScannerOptions(hasExternalPolicies bool, useDefaultPolicies bool, policiesFolder string) []options.ScannerOption {


### PR DESCRIPTION
With defsec migrating rbac scanner to kubernetes scanner, Trivy-Operator should only use the kubernetes scanner to handler all kubernetes resources.

## Description
With defsec migrating rbac scanner to kubernetes scanner, Trivy-Operator should only use the kubernetes scanner to handler all kubernetes resources. Since, defsec has not released a tag with these changes yet, we are updating the
defsec dependency to point to the commit we need. We can update this once defsec
releases a new tag.

## Related PR
[defsec](https://github.com/aquasecurity/defsec/pull/1111)


