### PR TITLE
feat: migrate rbac policies to kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy-operator
 go 1.19
 
 require (
-	github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c
+	github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59
 	github.com/aquasecurity/trivy v0.36.1
 	github.com/bluele/gcache v0.0.2
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c h1:Z7Uj3+zo6NJa9SFtMgGItZSqDMT3F7fPfCfXTdS3hKI=
-github.com/aquasecurity/defsec v0.82.7-0.20221229120130-2bc18528da1c/go.mod h1:sUdW6pzASralDcs+CDOE+QpWfBJt3/PY1Qbg8CS5flg=
+github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59 h1:03Sb8/AX5zWuSE6OIOk0eWoCgYkFuYIbUTw4+NGDfu8=
+github.com/aquasecurity/defsec v0.82.7-0.20230120014503-046ee90ace59/go.mod h1:f/acz2sBQzfTcnaPxSjVnkRhCQ9hUbC6qwQCaHQwrFc=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230105081339-fe9e63bf16bf h1:r7OsibIkchbBlbRd0HhyHnL8GkELo8WrHu2wRAx8a9M=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230105081339-fe9e63bf16bf/go.mod h1:sVaiFgCEAOD3REZ8yamINqBf+BKiV/jt60DhG2rvKEo=
 github.com/aquasecurity/table v1.8.0 h1:9ntpSwrUfjrM6/YviArlx/ZBGd6ix8W+MtojQcM7tv0=

--- a/pkg/operator/envtest/testdata/fixture/role-rbacassessment-expected.yaml
+++ b/pkg/operator/envtest/testdata/fixture/role-rbacassessment-expected.yaml
@@ -25,6 +25,14 @@ report:
       severity: CRITICAL
       success: false
       title: Do not allow management of secrets
+    - category: Kubernetes Security Check
+      checkID: KSV110
+      description: ensure that default namespace should not be used
+      messages:
+        - Role 'proxy' should not be set with 'default' namespace
+      severity: LOW
+      success: false
+      title: The default namespace should not be used
   scanner:
     name: Trivy
     vendor: Aqua Security
@@ -32,5 +40,5 @@ report:
   summary:
     criticalCount: 1
     highCount: 0
-    lowCount: 0
+    lowCount: 1
     mediumCount: 0

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/aquasecurity/trivy-operator/pkg/configauditreport"
 
-	"github.com/aquasecurity/defsec/pkg/scanners"
-	"github.com/aquasecurity/defsec/pkg/scanners/rbac"
 	"github.com/go-logr/logr"
 	"github.com/liamg/memoryfs"
 
@@ -205,7 +203,7 @@ func (p *Policies) Eval(ctx context.Context, resource client.Object) (scan.Resul
 	if err != nil {
 		return nil, err
 	}
-	scanner := scannerByType(resourceKind, getScannerOptions(hasExternalPolicies, p.cac.GetUseBuiltinRegoPolicies(), policiesFolder))
+	scanner := kubernetes.NewScanner(getScannerOptions(hasExternalPolicies, p.cac.GetUseBuiltinRegoPolicies(), policiesFolder)...)
 	scanResult, err := scanner.ScanFS(ctx, memfs, inputFolder)
 	if err != nil {
 		return nil, err
@@ -224,13 +222,6 @@ func (r *Policies) GetResultID(result scan.Result) string {
 		id = result.Rule().Aliases[0]
 	}
 	return id
-}
-
-func scannerByType(resourceKind string, scannerOptions []options.ScannerOption) scanners.FSScanner {
-	if resourceKind == "Role" || resourceKind == "ClusterRole" {
-		return rbac.NewScanner(scannerOptions...)
-	}
-	return kubernetes.NewScanner(scannerOptions...)
 }
 
 func getScannerOptions(hasExternalPolicies bool, useDefaultPolicies bool, policiesFolder string) []options.ScannerOption {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -748,7 +748,12 @@ deny[res] {
 				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(getPolicyResults(checks)).To(Equal(tc.results))
+				results := getPolicyResults(checks)
+				r, _ := json.Marshal(results)
+				rr, _ := json.Marshal(tc.results)
+				fmt.Println(string(r))
+				fmt.Println(string(rr))
+				g.Expect(results).To(Equal(tc.results))
 			}
 		})
 	}

--- a/pkg/policy/testdata/fixture/builtin_role_result.json
+++ b/pkg/policy/testdata/fixture/builtin_role_result.json
@@ -1,6 +1,1350 @@
 [
   {
     "Metadata": {
+      "ID": "AVD-KSV-0108",
+      "Title": "Service with External IP",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Services with external IP addresses allows direct access from the internet and might expose risk for CVE-2020-8554"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "AVD-KSV-0109",
+      "Title": "ConfigMap with secrets",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Storing secrets in configMaps is unsafe"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "AVD-KSV-0110",
+      "Title": "ConfigMap with sensitive content",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Storing sensitive content such as usernames and email addresses in configMaps is unsafe"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0001",
+      "Title": "Ensure that the --anonymous-auth argument is set to false",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable anonymous requests to the API server."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0002",
+      "Title": "Ensure that the --token-auth-file parameter is not set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not use token based authentication."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0003",
+      "Title": "Ensure that the --DenyServiceExternalIPs is not set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "This admission controller rejects all net-new usage of the Service field externalIPs."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0004",
+      "Title": "Ensure that the --kubelet-https argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Use https for kubelet connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0005",
+      "Title": "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable certificate based kubelet authentication."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0006",
+      "Title": "Ensure that the --kubelet-certificate-authority argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Verify kubelet's certificate before establishing connection."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0007",
+      "Title": "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not always authorize all requests."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0008",
+      "Title": "Ensure that the --authorization-mode argument includes Node",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Restrict kubelet nodes to reading only objects associated with them."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0009",
+      "Title": "Ensure that the --authorization-mode argument includes RBAC",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Turn on Role Based Access Control."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0010",
+      "Title": "Ensure that the admission control plugin EventRateLimit is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Limit the rate at which the API server accepts requests."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0011",
+      "Title": "Ensure that the admission control plugin AlwaysAdmit is not set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not allow all requests."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0013",
+      "Title": "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "The SecurityContextDeny admission controller can be used to deny pods which make use of some SecurityContext fields which could allow for privilege escalation in the cluster. This should be used where PodSecurityPolicy is not in place within the cluster."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0014",
+      "Title": "Ensure that the admission control plugin ServiceAccount is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Automate service accounts management."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0015",
+      "Title": "Ensure that the admission control plugin NamespaceLifecycle is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Reject creating objects in a namespace that is undergoing termination."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0016",
+      "Title": "Ensure that the admission control plugin NodeRestriction is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Limit the Node and Pod objects that a kubelet could modify."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0017",
+      "Title": "Ensure that the --secure-port argument is not set to 0",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not disable the secure port."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0018",
+      "Title": "Ensure that the --profiling argument is set to false",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable profiling, if not needed."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0019",
+      "Title": "Ensure that the --audit-log-path argument is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable auditing on the Kubernetes API Server and set the desired audit log path."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0020",
+      "Title": "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Retain the logs for at least 30 days or as appropriate."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0021",
+      "Title": "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Retain 10 or an appropriate number of old log files."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0022",
+      "Title": "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Rotate log files on reaching 100 MB or as appropriate."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0024",
+      "Title": "Ensure that the --service-account-lookup argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Validate service account before validating token."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0025",
+      "Title": "Ensure that the --service-account-key-file argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Explicitly set a service account public key file for service accounts on the apiserver."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0026",
+      "Title": "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "etcd should be configured to make use of TLS encryption for client connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0027",
+      "Title": "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Setup TLS connection on the API server."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0028",
+      "Title": "Ensure that the --client-ca-file argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Setup TLS connection on the API server."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0029",
+      "Title": "Ensure that the --etcd-cafile argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "etcd should be configured to make use of TLS encryption for client connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0030",
+      "Title": "Ensure that the --encryption-provider-config argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Encrypt etcd key-value store."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0033",
+      "Title": "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Activate garbage collector on pod termination, as appropriate."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0034",
+      "Title": "Ensure that the --profiling argument is set to false",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable profiling, if not needed."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0036",
+      "Title": "Ensure that the --service-account-private-key-file argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Explicitly set a service account private key file for service accounts on the controller manager."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0037",
+      "Title": "Ensure that the --root-ca-file argument is set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Allow pods to verify the API server's serving certificate before establishing connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0038",
+      "Title": "Ensure that the RotateKubeletServerCertificate argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable kubelet server certificate rotation on controller-manager."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0039",
+      "Title": "Ensure that the --bind-address argument is set to 127.0.0.1",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not bind the scheduler service to non-loopback insecure addresses."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0040",
+      "Title": "Ensure that the --profiling argument is set to false",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable profiling, if not needed."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0041",
+      "Title": "Ensure that the --bind-address argument is set to 127.0.0.1",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not bind the scheduler service to non-loopback insecure addresses."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0042",
+      "Title": "Ensure that the --cert-file and --key-file arguments are set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Configure TLS encryption for the etcd service."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0043",
+      "Title": "Ensure that the --client-cert-auth argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable client authentication on etcd service."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0044",
+      "Title": "Ensure that the --auto-tls argument is not set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not use self-signed certificates for TLS."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0045",
+      "Title": "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "etcd should be configured to make use of TLS encryption for peer connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0046",
+      "Title": "Ensure that the --peer-client-cert-auth argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "etcd should be configured for peer authentication."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0047",
+      "Title": "Ensure that the --peer-auto-tls argument is not set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not use self-signed certificates for TLS."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0048",
+      "Title": "Ensure that the API server pod specification file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the API server pod specification file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0049",
+      "Title": "Ensure that the API server pod specification file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the API server pod specification file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0050",
+      "Title": "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the controller manager pod specification file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0051",
+      "Title": "Ensure that the controller manager pod specification file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the controller manager pod specification file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0052",
+      "Title": "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the scheduler pod specification file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0053",
+      "Title": "Ensure that the scheduler pod specification file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the scheduler pod specification file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0054",
+      "Title": "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the etcd pod specification file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0055",
+      "Title": "Ensure that the etcd pod specification file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the etcd pod specification file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0056",
+      "Title": "Ensure that the container network interface file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the container network interface file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0057",
+      "Title": "Ensure that the container network interface file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the container network interface file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0058",
+      "Title": "Ensure that the etcd data directory permissions are set to 700 or more restrictive",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the etcd data directory has permissions of 700 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0059",
+      "Title": "Ensure that the etcd data directory ownership is set to etcd:etcd",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the etcd data directory ownership is set to etcd:etcd."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0060",
+      "Title": "Ensure that the admin config file permissions are set to 600 or more restrictive",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the admin config file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0061",
+      "Title": "Ensure that the admin config  file ownership is set to root:root",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the admin config  file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0062",
+      "Title": "Ensure that the scheduler config file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the scheduler config file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0063",
+      "Title": "Ensure that the scheduler config  file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the scheduler config  file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0064",
+      "Title": "Ensure that the controller-manager config file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the controller-manager config file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0065",
+      "Title": "Ensure that the controller-manager config  file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the controller-manager config  file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0066",
+      "Title": "Ensure that the Kubernetes PKI directory and file file ownership is set to root:root",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the Kubernetes PKI directory and file file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0067",
+      "Title": "Ensure that the Kubernetes PKI key file permission is set to 600",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the Kubernetes PKI key file permission is set to 600."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0068",
+      "Title": "Ensure that the Kubernetes PKI certificate file permission is set to 600",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the Kubernetes PKI certificate file permission is set to 600."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0069",
+      "Title": "Ensure that the kubelet service file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the kubelet service file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0070",
+      "Title": "Ensure that the kubelet service file ownership is set to root:root",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the kubelet service file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0071",
+      "Title": "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "If kube-proxy is running, and if it is using a file-based kubeconfig file, ensure that the proxy kubeconfig file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0072",
+      "Title": "if proxy kubeconfig file exists ensure ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "If kube-proxy is running, ensure that the file ownership of its kubeconfig file is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0073",
+      "Title": "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the kubelet.conf file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0074",
+      "Title": "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the kubelet.conf file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0075",
+      "Title": "Ensure that the certificate authorities file permissions are set to 600 or more restrictive",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the certificate authorities file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0076",
+      "Title": "Ensure that the client certificate authorities file ownership is set to root:root",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the certificate authorities file ownership is set to root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0077",
+      "Title": "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file has permissions of 600 or more restrictive."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0078",
+      "Title": "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root ",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that if the kubelet refers to a configuration file with the --config argument, that file is owned by root:root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0079",
+      "Title": "Ensure that the --anonymous-auth argument is set to false",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable anonymous requests to the Kubelet server."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0080",
+      "Title": "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not allow all requests. Enable explicit authorization."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0081",
+      "Title": "Ensure that the --client-ca-file argument is set as appropriate",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable Kubelet authentication using certificates."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0082",
+      "Title": "Verify that the --read-only-port argument is set to 0",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Disable the read-only port."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0083",
+      "Title": "Ensure that the --protect-kernel-defaults is set to true",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Protect tuned kernel parameters from overriding kubelet default kernel parameter values."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0084",
+      "Title": "Ensure that the --make-iptables-util-chains argument is set to true",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Allow Kubelet to manage iptables."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0085",
+      "Title": "Ensure that the --streaming-connection-idle-timeout argument is not set to 0",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not disable timeouts on streaming connections."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0086",
+      "Title": "Ensure that the --hostname-override argument is not set",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Do not override node hostnames."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0087",
+      "Title": "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Security relevant information should be captured. The --event-qps flag on the Kubelet can be used to limit the rate at which events are gathered"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0088",
+      "Title": "Ensure that the --tls-cert-file argument are set as appropriate",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Setup TLS connection on the Kubelets."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0089",
+      "Title": "Ensure that the --tls-key-file argument are set as appropriate",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Setup TLS connection on the Kubelets."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0090",
+      "Title": "Ensure that the --rotate-certificates argument is not set to false",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable kubelet client certificate rotation."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0091",
+      "Title": "Verify that the RotateKubeletServerCertificate argument is set to true",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enable kubelet server certificate rotation."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0092",
+      "Title": "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Ensure that the Kubelet is configured to only use strong cryptographic ciphers."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KCV0135",
+      "Title": "Ensure that the --use-service-account-credentials argument is set to true",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Use individual service account credentials for each controller."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV001",
+      "Title": "Process can elevate its own privileges",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "A program inside the container can elevate its own privileges and run as root, which might give the program control over the container and node."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV0012",
+      "Title": "Ensure that the admission control plugin AlwaysPullImages is set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Always pull images."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV002",
+      "Title": "Default AppArmor profile not set",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "A program inside the container can bypass AppArmor protection policies."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV003",
+      "Title": "Default capabilities not dropped",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "The container should drop all default capabilities and add only those that are needed for its execution."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV005",
+      "Title": "SYS_ADMIN capability added",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "SYS_ADMIN gives the processes running inside the container privileges that are equivalent to root."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV006",
+      "Title": "hostPath volume mounted with docker.sock",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Mounting docker.sock from the host can give the container full root access to the host."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV008",
+      "Title": "Access to host IPC namespace",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Sharing the host’s IPC namespace allows container processes to communicate with processes on the host."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV009",
+      "Title": "Access to host network",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Sharing the host’s network namespace permits processes in the pod to communicate with processes bound to the host’s loopback adapter."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV010",
+      "Title": "Access to host PID",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Sharing the host’s PID namespace allows visibility on host processes, potentially leaking information such as environment variables and configuration."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV011",
+      "Title": "CPU not limited",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enforcing CPU limits prevents DoS via resource exhaustion."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV012",
+      "Title": "Runs as root user",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "'runAsNonRoot' forces the running image to run as a non-root user to ensure least privileges."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV013",
+      "Title": "Image tag ':latest' used",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "It is best to avoid using the ':latest' image tag when deploying containers in production. Doing so makes it hard to track which version of the image is running, and hard to roll back the version."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV014",
+      "Title": "Root file system is not read-only",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "An immutable root file system prevents applications from writing to their local disk. This can limit intrusions, as attackers will not be able to tamper with the file system or write foreign executables to disk."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV015",
+      "Title": "CPU requests not specified",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "When containers have resource requests specified, the scheduler can make better decisions about which nodes to place pods on, and how to deal with resource contention."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV016",
+      "Title": "Memory requests not specified",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "When containers have memory requests specified, the scheduler can make better decisions about which nodes to place pods on, and how to deal with resource contention."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV017",
+      "Title": "Privileged container",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Privileged containers share namespaces with the host system and do not offer any security. They should be used exclusively for system containers that require high privileges."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV018",
+      "Title": "Memory not limited",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Enforcing memory limits prevents DoS via resource exhaustion."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV020",
+      "Title": "Runs with low user ID",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Force the container to run with user ID > 10000 to avoid conflicts with the host’s user table."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV021",
+      "Title": "Runs with low group ID",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Force the container to run with group ID > 10000 to avoid conflicts with the host’s user table."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV022",
+      "Title": "Non-default capabilities added",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "Adding NET_RAW or capabilities beyond the default set must be disallowed."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV023",
+      "Title": "hostPath volumes mounted",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "HostPath volumes must be forbidden."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV024",
+      "Title": "Access to host ports",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "HostPorts should be disallowed, or at minimum restricted to a known list."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV025",
+      "Title": "SELinux custom options set",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "Setting a custom SELinux user or role option should be forbidden."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV026",
+      "Title": "Unsafe sysctl options set",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "Sysctls can disable security mechanisms or affect all containers on a host, and should be disallowed except for an allowed 'safe' subset. A sysctl is considered safe if it is namespaced in the container or the Pod, and it is isolated from other Pods or processes on the same Node."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV027",
+      "Title": "Non-default /proc masks set",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "The default /proc masks are set up to reduce attack surface, and should be required."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV028",
+      "Title": "Non-ephemeral volume types used",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "In addition to restricting HostPath volumes, usage of non-ephemeral volume types should be limited to those defined through PersistentVolumes."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV030",
+      "Title": "Default Seccomp profile not set",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "The RuntimeDefault/Localhost seccomp profile must be required, or allow specific additional profiles."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV036",
+      "Title": "Protecting Pod service account tokens",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "ensure that Pod specifications disable the secret token being mounted by setting automountServiceAccountToken: false"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV037",
+      "Title": "User Pods should not be placed in kube-system namespace",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "ensure that User pods are not placed in kube-system namespace"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV038",
+      "Title": "Selector usage in network policies",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "ensure that network policies selectors are applied to pods or namespaces to restricted ingress and egress traffic within the pod network"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV041",
+      "Title": "Do not allow management of secrets",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Check whether role permits managing secrets"
+    },
+    "Success": false,
+    "Messages": [
+      "Role permits management of secret(s)"
+    ]
+  },
+  {
+    "Metadata": {
       "ID": "KSV042",
       "Title": "Do not allow deletion of pod logs",
       "Severity": "MEDIUM",
@@ -12,11 +1356,33 @@
   },
   {
     "Metadata": {
-      "ID": "KSV049",
-      "Title": "Do not allow management of configmaps",
-      "Severity": "MEDIUM",
+      "ID": "KSV043",
+      "Title": "Do not allow impersonation of privileged groups",
+      "Severity": "CRITICAL",
       "Type": "Kubernetes Security Check",
-      "Description": "Some workloads leverage configmaps to store sensitive data or configuration parameters that affect runtime behavior that can be modified by an attacker or combined with another issue to potentially lead to compromise."
+      "Description": "Check whether role permits impersonating privileged groups"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV044",
+      "Title": "No wildcard verb and resource roles",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Check whether role permits wildcard verb on wildcard resource"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV045",
+      "Title": "No wildcard verb roles",
+      "Severity": "CRITICAL",
+      "Type": "Kubernetes Security Check",
+      "Description": "Check whether role permits wildcard verb on specific resources"
     },
     "Success": true,
     "Messages": null
@@ -34,17 +1400,6 @@
   },
   {
     "Metadata": {
-      "ID": "KSV054",
-      "Title": "Do not allow attaching to shell on pods",
-      "Severity": "HIGH",
-      "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits attaching to shell on pods"
-    },
-    "Success": true,
-    "Messages": null
-  },
-  {
-    "Metadata": {
       "ID": "KSV047",
       "Title": "Do not allow privilege escalation from node proxy",
       "Severity": "HIGH",
@@ -56,38 +1411,25 @@
   },
   {
     "Metadata": {
-      "ID": "KSV056",
-      "Title": "Do not allow management of networking resources",
+      "ID": "KSV048",
+      "Title": "Do not allow update/create of a malicious pod",
       "Severity": "HIGH",
       "Type": "Kubernetes Security Check",
-      "Description": "The ability to control which pods get service traffic directed to them allows for interception attacks. Controlling network policy allows for bypassing lateral movement restrictions."
+      "Description": "Check whether role permits update/create of a malicious pod"
     },
     "Success": true,
     "Messages": null
   },
   {
     "Metadata": {
-      "ID": "KSV052",
-      "Title": "Do not allow role to create ClusterRoleBindings and association with privileged role",
-      "Severity": "HIGH",
+      "ID": "KSV049",
+      "Title": "Do not allow management of configmaps",
+      "Severity": "MEDIUM",
       "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits creating role ClusterRoleBindings and association with privileged cluster role"
+      "Description": "Some workloads leverage configmaps to store sensitive data or configuration parameters that affect runtime behavior that can be modified by an attacker or combined with another issue to potentially lead to compromise."
     },
     "Success": true,
     "Messages": null
-  },
-  {
-    "Metadata": {
-      "ID": "KSV041",
-      "Title": "Do not allow management of secrets",
-      "Severity": "CRITICAL",
-      "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits managing secrets"
-    },
-    "Success": false,
-    "Messages": [
-      "Role permits management of secret(s)"
-    ]
   },
   {
     "Metadata": {
@@ -113,6 +1455,17 @@
   },
   {
     "Metadata": {
+      "ID": "KSV052",
+      "Title": "Do not allow role to create ClusterRoleBindings and association with privileged role",
+      "Severity": "HIGH",
+      "Type": "Kubernetes Security Check",
+      "Description": "Check whether role permits creating role ClusterRoleBindings and association with privileged cluster role"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
       "ID": "KSV053",
       "Title": "Do not allow getting shell on pods",
       "Severity": "HIGH",
@@ -124,11 +1477,11 @@
   },
   {
     "Metadata": {
-      "ID": "KSV048",
-      "Title": "Do not allow update/create of a malicious pod",
+      "ID": "KSV054",
+      "Title": "Do not allow attaching to shell on pods",
       "Severity": "HIGH",
       "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits update/create of a malicious pod"
+      "Description": "Check whether role permits attaching to shell on pods"
     },
     "Success": true,
     "Messages": null
@@ -146,33 +1499,99 @@
   },
   {
     "Metadata": {
-      "ID": "KSV044",
-      "Title": "No wildcard verb and resource roles",
-      "Severity": "CRITICAL",
+      "ID": "KSV056",
+      "Title": "Do not allow management of networking resources",
+      "Severity": "HIGH",
       "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits wildcard verb on wildcard resource"
+      "Description": "The ability to control which pods get service traffic directed to them allows for interception attacks. Controlling network policy allows for bypassing lateral movement restrictions."
     },
     "Success": true,
     "Messages": null
   },
   {
     "Metadata": {
-      "ID": "KSV043",
-      "Title": "Do not allow impersonation of privileged groups",
+      "ID": "KSV102",
+      "Title": "Tiller Is Deployed",
       "Severity": "CRITICAL",
       "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits impersonating privileged groups"
+      "Description": "Check if Helm Tiller component is deployed."
     },
     "Success": true,
     "Messages": null
   },
   {
     "Metadata": {
-      "ID": "KSV045",
-      "Title": "No wildcard verb roles",
-      "Severity": "CRITICAL",
+      "ID": "KSV103",
+      "Title": "HostProcess container defined",
+      "Severity": "MEDIUM",
       "Type": "Kubernetes Security Check",
-      "Description": "Check whether role permits wildcard verb on specific resources"
+      "Description": "Windows pods offer the ability to run HostProcess containers which enable privileged access to the Windows node."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV104",
+      "Title": "Seccomp profile unconfined",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "Seccomp profile must not be explicitly set to 'Unconfined'."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV105",
+      "Title": "Containers must not set runAsUser to 0",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Containers should be forbidden from running with a root UID."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV106",
+      "Title": "Container capabilities must only include NET_BIND_SERVICE",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "Containers must drop ALL capabilities, and are only permitted to add back the NET_BIND_SERVICE capability."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV110",
+      "Title": "The default namespace should not be used",
+      "Severity": "LOW",
+      "Type": "Kubernetes Security Check",
+      "Description": "ensure that default namespace should not be used"
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "KSV111",
+      "Title": "Ensure that the cluster-admin role is only used where required",
+      "Severity": "MEDIUM",
+      "Type": "Kubernetes Security Check",
+      "Description": "The RBAC role cluster-admin provides wide-ranging powers over the environment and should be used only where and when needed."
+    },
+    "Success": true,
+    "Messages": null
+  },
+  {
+    "Metadata": {
+      "ID": "N/A",
+      "Title": "N/A",
+      "Severity": "UNKNOWN",
+      "Type": "Kubernetes Security Check",
+      "Description": "Rego module: data.defsec.kubernetes.KSV107"
     },
     "Success": true,
     "Messages": null


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
migrate rbac policies to kubernetes

## Related issues
- Close #879

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
