### PR TITLE
fix: remove null checks in clustercompliancereports

### DIFF
--- a/deploy/specs/cis-1.23.yaml
+++ b/deploy/specs/cis-1.23.yaml
@@ -306,20 +306,17 @@ spec:
         authentication. However as there is no way to revoke these certificates
         when a user leaves an organization or loses their credential, they are
         not suitable for this purpose.
-      checks: 
       severity: HIGH
     - id: '3.2.1'
       name: Ensure that a minimal audit policy is created (Manual)
       description: Kubernetes can audit the details of requests made to the API
         server. The --audit- policy-file flag must be set for this logging to be
         enabled.
-      checks: 
       severity: HIGH
     - id: '3.2.2'
       name: Ensure that the audit policy covers key security concerns (Manual)
       description: Ensure that the audit policy created for the cluster covers key
         security concerns.
-      checks: 
       severity: HIGH
     - id: '5.1.1'
       name: Ensure that the cluster-admin role is only used where required
@@ -450,7 +447,6 @@ spec:
       description: There are a variety of CNI plugins available for Kubernetes. If the
         CNI in use does not support Network Policies it may not be possible to
         effectively restrict traffic in the cluster.
-      checks: 
       severity: MEDIUM
     - id: '5.3.2'
       name: Ensure that all Namespaces have Network Policies defined
@@ -463,26 +459,22 @@ spec:
         (Manual)
       description: Kubernetes supports mounting secrets as data volumes or as
         environment variables. Minimize the use of environment variable secrets.
-      checks: 
       severity: MEDIUM
     - id: '5.4.2'
       name: Consider external secret storage (Manual)
       description: Consider the use of an external secrets storage and management
         system, instead of using Kubernetes Secrets directly, if you have more
         complex secret management needs.
-      checks: 
       severity: MEDIUM
     - id: '5.5.1'
       name: Configure Image Provenance using ImagePolicyWebhook admission controller
         (Manual)
       description: Configure Image Provenance for your deployment.
-      checks: 
       severity: MEDIUM
     - id: '5.7.1'
       name: Create administrative boundaries between resources using namespaces
         (Manual)
       description: Use namespaces to isolate your Kubernetes objects.
-      checks: 
       severity: MEDIUM
     - id: '5.7.2'
       name: Ensure that the seccomp profile is set to docker/default in your pod

--- a/deploy/specs/nsa-1.0.yaml
+++ b/deploy/specs/nsa-1.0.yaml
@@ -109,7 +109,6 @@ spec:
         description: 'Control check whether check cni plugin installed'
         id: '3.0'
         defaultStatus: 'FAIL'
-        checks:
         severity: 'CRITICAL'
       - name: Use ResourceQuota policies to limit resources
         description: 'Control check the use of ResourceQuota policy to limit aggregate resource usage within namespace'
@@ -129,7 +128,6 @@ spec:
         description: 'Control check whether control plan disable insecure port'
         id: '5.0'
         defaultStatus: 'FAIL'
-        checks:
         severity: 'CRITICAL'
       - name: Encrypt etcd communication
         description: 'Control check whether etcd communication is encrypted'
@@ -141,7 +139,6 @@ spec:
         description: 'Control check whether kube config file permissions'
         id: '6.0'
         defaultStatus: 'FAIL'
-        checks:
         severity: 'CRITICAL'
       - name: Check that encryption resource has been set
         description: 'Control checks whether encryption resource has been set'
@@ -171,7 +168,6 @@ spec:
         description: 'Control check whether audit policy is configure'
         id: '8.0'
         defaultStatus: 'FAIL'
-        checks:
         severity: 'HIGH'
       - name: Audit log path is configure
         description: 'Control check whether audit log path is configure'


### PR DESCRIPTION
## Description
The specs for the ClusterComplianceReports of nsa and cis (https://github.com/aquasecurity/trivy-operator/tree/main/deploy/specs) currently contain empty `checks`, which should be an array and not null (from my understanding of the current CRD, feel free to correct me).

## Related issues
- Close #881

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
