### PR TITLE
fix: check if re-scan required for misconfig reports

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/common_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/common_types.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	TTLReportAnnotation = "trivy-operator.aquasecurity.github.io/report-ttl"
+	TTLReportAnnotation        = "trivy-operator.aquasecurity.github.io/report-ttl"
+	HistoricalReportAnnotation = "trivy-operator.aquasecurity.github.io/report-historical"
 )
 
 // Severity level of a vulnerability or a configuration audit check.

--- a/pkg/apis/aquasecurity/v1alpha1/common_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/common_types.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	TTLReportAnnotation        = "trivy-operator.aquasecurity.github.io/report-ttl"
-	HistoricalReportAnnotation = "trivy-operator.aquasecurity.github.io/report-historical"
+	TTLReportAnnotation = "trivy-operator.aquasecurity.github.io/report-ttl"
 )
 
 // Severity level of a vulnerability or a configuration audit check.

--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func policies(ctx context.Context, config etc.Config, c client.Client, cac configauditreport.ConfigAuditConfig, log logr.Logger) (*policy.Policies, error) {
+func Policies(ctx context.Context, config etc.Config, c client.Client, cac configauditreport.ConfigAuditConfig, log logr.Logger) (*policy.Policies, error) {
 	cm := &corev1.ConfigMap{}
 
 	err := c.Get(ctx, client.ObjectKey{

--- a/pkg/configauditreport/controller/nodecollector.go
+++ b/pkg/configauditreport/controller/nodecollector.go
@@ -133,7 +133,7 @@ func (r *NodeCollectorJobController) processCompleteScanJob(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	policies, err := policies(ctx, r.Config, r.Client, cac, r.Logger)
+	policies, err := Policies(ctx, r.Config, r.Client, cac, r.Logger)
 	if err != nil {
 		return fmt.Errorf("getting policies: %w", err)
 	}

--- a/pkg/configauditreport/controller/policyconfig.go
+++ b/pkg/configauditreport/controller/policyconfig.go
@@ -118,7 +118,7 @@ func (r *PolicyConfigController) reconcileConfig(kind kube.Kind) reconcile.Func 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		policies, err := policies(ctx, r.Config, r.Client, cac, r.Logger)
+		policies, err := Policies(ctx, r.Config, r.Client, cac, r.Logger)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("getting policies: %w", err)
 		}
@@ -208,7 +208,7 @@ func (r *PolicyConfigController) reconcileClusterConfig(kind kube.Kind) reconcil
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		policies, err := policies(ctx, r.Config, r.Client, cac, r.Logger)
+		policies, err := Policies(ctx, r.Config, r.Client, cac, r.Logger)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("getting policies: %w", err)
 		}

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -165,7 +165,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		policies, err := policies(ctx, r.Config, r.Client, cac, r.Logger)
+		policies, err := Policies(ctx, r.Config, r.Client, cac, r.Logger)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("getting policies: %w", err)
 		}
@@ -180,7 +180,7 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 				"kind", resource.GetObjectKind())
 			return ctrl.Result{}, nil
 		}
-		applicable, reason, err := policies.Applicable(resource)
+		applicable, reason, err := policies.Applicable(resource.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("checking whether plugin is applicable: %w", err)
 		}

--- a/pkg/operator/envtest/suite_test.go
+++ b/pkg/operator/envtest/suite_test.go
@@ -166,10 +166,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&operator.TTLReportReconciler{
-		Logger: ctrl.Log.WithName("reconciler").WithName("ttlreport"),
-		Config: config,
-		Client: k8sClient,
-		Clock:  ext.NewSystemClock(),
+		Logger:         ctrl.Log.WithName("reconciler").WithName("ttlreport"),
+		Config:         config,
+		Client:         k8sClient,
+		PluginContext:  pluginContext,
+		PluginInMemory: pluginca,
+		Clock:          ext.NewSystemClock(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/operator/envtest/testdata/fixture/config-audit-ttl-historical.yaml
+++ b/pkg/operator/envtest/testdata/fixture/config-audit-ttl-historical.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ConfigAuditReport
+metadata:
+  annotations:
+    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m0s
+    trivy-operator.aquasecurity.github.io/report-historical: true
+  creationTimestamp: 2022-12-08T15:50:37Z
+  generation: 1
+  labels:
+    resource-spec-hash: 65df6ff459
+    plugin-config-hash: 659b7b9c47
+    trivy-operator.container.name: coredns
+    trivy-operator.resource.kind: ReplicaSet
+    trivy-operator.resource.name: coredns-558bd4d5db
+    trivy-operator.resource.namespace: kube-system
+  name: replicaset-coredns-558bd4d5db-coredns
+  namespace: kube-system
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: false
+      controller: true
+      kind: ReplicaSet
+      name: coredns-558bd4d5db
+      uid: 1136b574-9f3f-49af-adaf-ba35d78ea57b
+  uid: 66e3e613-9655-4330-aee7-45e283be2339
+report:
+  checks:
+    - category: Kubernetes Security Check
+      checkID: KSV110
+      description: ensure that default namespace should not be used
+      messages:
+        - Service 'kubernetes' should not be set with 'default' namespace
+      severity: LOW
+      success: false
+      title: The default namespace should not be used
+  scanner:
+    name: Trivy
+    vendor: Aqua Security
+    version: dev
+  summary:
+    criticalCount: 0
+    highCount: 0
+    lowCount: 1
+    mediumCount: 0
+  updateTimestamp: 2023-01-29T19:01:44Z

--- a/pkg/operator/envtest/testdata/fixture/config-audit-ttl.yaml
+++ b/pkg/operator/envtest/testdata/fixture/config-audit-ttl.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ConfigAuditReport
+metadata:
+  annotations:
+    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m0s
+  creationTimestamp: 2022-12-08T15:50:37Z
+  generation: 1
+  labels:
+    resource-spec-hash: 65df6ff459
+    plugin-config-hash: 659b7b9c47
+    trivy-operator.container.name: coredns
+    trivy-operator.resource.kind: ReplicaSet
+    trivy-operator.resource.name: coredns-558bd4d5db
+    trivy-operator.resource.namespace: kube-system
+  name: replicaset-coredns-558bd4d5db-coredns
+  namespace: kube-system
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: false
+      controller: true
+      kind: ReplicaSet
+      name: coredns-558bd4d5db
+      uid: 1136b574-9f3f-49af-adaf-ba35d78ea57b
+  uid: 66e3e613-9655-4330-aee7-45e283be2339
+report:
+  checks:
+    - category: Kubernetes Security Check
+      checkID: KSV110
+      description: ensure that default namespace should not be used
+      messages:
+        - Service 'kubernetes' should not be set with 'default' namespace
+      severity: LOW
+      success: false
+      title: The default namespace should not be used
+  scanner:
+    name: Trivy
+    vendor: Aqua Security
+    version: dev
+  summary:
+    criticalCount: 0
+    highCount: 0
+    lowCount: 1
+    mediumCount: 0
+  updateTimestamp: 2023-01-29T19:01:44Z

--- a/pkg/operator/envtest/testdata/fixture/config-audit-ttl.yaml
+++ b/pkg/operator/envtest/testdata/fixture/config-audit-ttl.yaml
@@ -3,7 +3,7 @@ apiVersion: aquasecurity.github.io/v1alpha1
 kind: ConfigAuditReport
 metadata:
   annotations:
-    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m0s
+    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m01
   creationTimestamp: 2022-12-08T15:50:37Z
   generation: 1
   labels:

--- a/pkg/operator/envtest/testdata/fixture/policy.yaml
+++ b/pkg/operator/envtest/testdata/fixture/policy.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator-policies-config
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+data:
+  library.kubernetes.rego:
+    "package lib.kubernetes\n\ndefault is_gatekeeper = false\n\nis_gatekeeper
+    {\n\thas_field(input, \"review\")\n\thas_field(input.review, \"object\")\n}\n\nobject
+    = input {\n\tnot is_gatekeeper\n}\n\nobject = input.review.object {\n\tis_gatekeeper\n}\n\nformat(msg)
+    = gatekeeper_format {\n\tis_gatekeeper\n\tgatekeeper_format = {\"msg\": msg}\n}\n\nformat(msg)
+    = msg {\n\tnot is_gatekeeper\n}\n\nname = object.metadata.name\n\ndefault namespace
+    = \"default\"\n\nnamespace = object.metadata.namespace\n\n#annotations = object.metadata.annotations\n\nkind
+    = object.kind\n\nis_pod {\n\tkind = \"Pod\"\n}\n\nis_cronjob {\n\tkind = \"CronJob\"\n}\n\ndefault
+    is_controller = false\n\nis_controller {\n\tkind = \"Deployment\"\n}\n\nis_controller
+    {\n\tkind = \"StatefulSet\"\n}\n\nis_controller {\n\tkind = \"DaemonSet\"\n}\n\nis_controller
+    {\n\tkind = \"ReplicaSet\"\n}\n\nis_controller {\n\tkind = \"ReplicationController\"\n}\n\nis_controller
+    {\n\tkind = \"Job\"\n}\n\nsplit_image(image) = [image, \"latest\"] {\n\tnot contains(image,
+    \":\")\n}\n\nsplit_image(image) = [image_name, tag] {\n\t[image_name, tag] = split(image,
+    \":\")\n}\n\npod_containers(pod) = all_containers {\n\tkeys = {\"containers\",
+    \"initContainers\"}\n\tall_containers = [c | keys[k]; c = pod.spec[k][_]]\n}\n\ncontainers[container]
+    {\n\tpods[pod]\n\tall_containers = pod_containers(pod)\n\tcontainer = all_containers[_]\n}\n\ncontainers[container]
+    {\n\tall_containers = pod_containers(object)\n\tcontainer = all_containers[_]\n}\n\npods[pod]
+    {\n\tis_pod\n\tpod = object\n}\n\npods[pod] {\n\tis_controller\n\tpod = object.spec.template\n}\n\npods[pod]
+    {\n\tis_cronjob\n\tpod = object.spec.jobTemplate.spec.template\n}\n\nvolumes[volume]
+    {\n\tpods[pod]\n\tvolume = pod.spec.volumes[_]\n}\n\ndropped_capability(container,
+    cap) {\n\tcontainer.securityContext.capabilities.drop[_] == cap\n}\n\nadded_capability(container,
+    cap) {\n\tcontainer.securityContext.capabilities.add[_] == cap\n}\n\nhas_field(obj,
+    field) {\n\tobj[field]\n}\n\nno_read_only_filesystem(c) {\n\tnot has_field(c,
+    \"securityContext\")\n}\n\nno_read_only_filesystem(c) {\n\thas_field(c, \"securityContext\")\n\tnot
+    has_field(c.securityContext, \"readOnlyRootFilesystem\")\n}\n\npriviledge_escalation_allowed(c)
+    {\n\tnot has_field(c, \"securityContext\")\n}\n\npriviledge_escalation_allowed(c)
+    {\n\thas_field(c, \"securityContext\")\n\thas_field(c.securityContext, \"allowPrivilegeEscalation\")\n}\n\nannotations[annotation]
+    {\n\tpods[pod]\n\tannotation = pod.metadata.annotations\n}\n\nhost_ipcs[host_ipc]
+    {\n\tpods[pod]\n\thost_ipc = pod.spec.hostIPC\n}\n\nhost_networks[host_network]
+    {\n\tpods[pod]\n\thost_network = pod.spec.hostNetwork\n}\n\nhost_pids[host_pid]
+    {\n\tpods[pod]\n\thost_pid = pod.spec.hostPID\n}\n\nhost_aliases[host_alias] {\n\tpods[pod]\n\thost_alias
+    = pod.spec\n}\n"
+  library.utils.rego: "package lib.utils\n\nhas_key(x, k) {\n\t_ = x[k]\n}\n"
+  policy.1_host_ipc.kinds: Workload
+  policy.1_host_ipc.rego:
+    "package appshield.kubernetes.KSV008\n\nimport data.lib.kubernetes\n\ndefault
+    failHostIPC = false\n\n__rego_metadata__ := {\n\t\"id\": \"KSV008\",\n\t\"avd_id\":
+    \"AVD-KSV-0008\",\n\t\"title\": \"Access to host IPC namespace\",\n\t\"short_code\":
+    \"no-shared-ipc-namespace\",\n\t\"version\": \"v1.0.0\",\n\t\"severity\": \"HIGH\",\n\t\"type\":
+    \"Kubernetes Security Check\",\n\t\"description\": \"Sharing the host’s IPC namespace
+    allows container processes to communicate with processes on the host.\",\n\t\"recommended_actions\":
+    \"Do not set 'spec.template.spec.hostIPC' to true.\",\n\t\"url\": \"https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline\",\n}\n\n__rego_input__
+    := {\n\t\"combine\": false,\n\t\"selector\": [{\"type\": \"kubernetes\"}],\n}\n\n#
+    failHostIPC is true if spec.hostIPC is set to true (on all resources)\nfailHostIPC
+    {\n\tkubernetes.host_ipcs[_] == true\n}\n\ndeny[res] {\n\tfailHostIPC\n\n\tmsg
+    := kubernetes.format(sprintf(\"%s '%s' should not set 'spec.template.spec.hostIPC'
+    to true\", [kubernetes.kind, kubernetes.name]))\n\n\tres := {\n\t\t\"msg\": msg,\n\t\t\"id\":
+    __rego_metadata__.id,\n\t\t\"title\": __rego_metadata__.title,\n\t\t\"severity\":
+    __rego_metadata__.severity,\n\t\t\"type\": __rego_metadata__.type,\n\t}\n}\n"
+  

--- a/pkg/operator/envtest/testdata/fixture/policy.yaml
+++ b/pkg/operator/envtest/testdata/fixture/policy.yaml
@@ -7,53 +7,229 @@ metadata:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
 data:
-  library.kubernetes.rego:
-    "package lib.kubernetes\n\ndefault is_gatekeeper = false\n\nis_gatekeeper
-    {\n\thas_field(input, \"review\")\n\thas_field(input.review, \"object\")\n}\n\nobject
-    = input {\n\tnot is_gatekeeper\n}\n\nobject = input.review.object {\n\tis_gatekeeper\n}\n\nformat(msg)
-    = gatekeeper_format {\n\tis_gatekeeper\n\tgatekeeper_format = {\"msg\": msg}\n}\n\nformat(msg)
-    = msg {\n\tnot is_gatekeeper\n}\n\nname = object.metadata.name\n\ndefault namespace
-    = \"default\"\n\nnamespace = object.metadata.namespace\n\n#annotations = object.metadata.annotations\n\nkind
-    = object.kind\n\nis_pod {\n\tkind = \"Pod\"\n}\n\nis_cronjob {\n\tkind = \"CronJob\"\n}\n\ndefault
-    is_controller = false\n\nis_controller {\n\tkind = \"Deployment\"\n}\n\nis_controller
-    {\n\tkind = \"StatefulSet\"\n}\n\nis_controller {\n\tkind = \"DaemonSet\"\n}\n\nis_controller
-    {\n\tkind = \"ReplicaSet\"\n}\n\nis_controller {\n\tkind = \"ReplicationController\"\n}\n\nis_controller
-    {\n\tkind = \"Job\"\n}\n\nsplit_image(image) = [image, \"latest\"] {\n\tnot contains(image,
-    \":\")\n}\n\nsplit_image(image) = [image_name, tag] {\n\t[image_name, tag] = split(image,
-    \":\")\n}\n\npod_containers(pod) = all_containers {\n\tkeys = {\"containers\",
-    \"initContainers\"}\n\tall_containers = [c | keys[k]; c = pod.spec[k][_]]\n}\n\ncontainers[container]
-    {\n\tpods[pod]\n\tall_containers = pod_containers(pod)\n\tcontainer = all_containers[_]\n}\n\ncontainers[container]
-    {\n\tall_containers = pod_containers(object)\n\tcontainer = all_containers[_]\n}\n\npods[pod]
-    {\n\tis_pod\n\tpod = object\n}\n\npods[pod] {\n\tis_controller\n\tpod = object.spec.template\n}\n\npods[pod]
-    {\n\tis_cronjob\n\tpod = object.spec.jobTemplate.spec.template\n}\n\nvolumes[volume]
-    {\n\tpods[pod]\n\tvolume = pod.spec.volumes[_]\n}\n\ndropped_capability(container,
-    cap) {\n\tcontainer.securityContext.capabilities.drop[_] == cap\n}\n\nadded_capability(container,
-    cap) {\n\tcontainer.securityContext.capabilities.add[_] == cap\n}\n\nhas_field(obj,
-    field) {\n\tobj[field]\n}\n\nno_read_only_filesystem(c) {\n\tnot has_field(c,
-    \"securityContext\")\n}\n\nno_read_only_filesystem(c) {\n\thas_field(c, \"securityContext\")\n\tnot
-    has_field(c.securityContext, \"readOnlyRootFilesystem\")\n}\n\npriviledge_escalation_allowed(c)
-    {\n\tnot has_field(c, \"securityContext\")\n}\n\npriviledge_escalation_allowed(c)
-    {\n\thas_field(c, \"securityContext\")\n\thas_field(c.securityContext, \"allowPrivilegeEscalation\")\n}\n\nannotations[annotation]
-    {\n\tpods[pod]\n\tannotation = pod.metadata.annotations\n}\n\nhost_ipcs[host_ipc]
-    {\n\tpods[pod]\n\thost_ipc = pod.spec.hostIPC\n}\n\nhost_networks[host_network]
-    {\n\tpods[pod]\n\thost_network = pod.spec.hostNetwork\n}\n\nhost_pids[host_pid]
-    {\n\tpods[pod]\n\thost_pid = pod.spec.hostPID\n}\n\nhost_aliases[host_alias] {\n\tpods[pod]\n\thost_alias
-    = pod.spec\n}\n"
-  library.utils.rego: "package lib.utils\n\nhas_key(x, k) {\n\t_ = x[k]\n}\n"
+  library.kubernetes.rego: |
+    package lib.kubernetes
+
+    default is_gatekeeper = false
+
+    is_gatekeeper {
+    	has_field(input, "review")
+    	has_field(input.review, "object")
+    }
+
+    object = input {
+    	not is_gatekeeper
+    }
+
+    object = input.review.object {
+    	is_gatekeeper
+    }
+
+    format(msg) = gatekeeper_format {
+    	is_gatekeeper
+    	gatekeeper_format = {"msg": msg}
+    }
+
+    format(msg) = msg {
+    	not is_gatekeeper
+    }
+
+    name = object.metadata.name
+
+    default namespace = "default"
+
+    namespace = object.metadata.namespace
+
+    #annotations = object.metadata.annotations
+
+    kind = object.kind
+
+    is_pod {
+    	kind = "Pod"
+    }
+
+    is_cronjob {
+    	kind = "CronJob"
+    }
+
+    default is_controller = false
+
+    is_controller {
+    	kind = "Deployment"
+    }
+
+    is_controller {
+    	kind = "StatefulSet"
+    }
+
+    is_controller {
+    	kind = "DaemonSet"
+    }
+
+    is_controller {
+    	kind = "ReplicaSet"
+    }
+
+    is_controller {
+    	kind = "ReplicationController"
+    }
+
+    is_controller {
+    	kind = "Job"
+    }
+
+    split_image(image) = [image, "latest"] {
+    	not contains(image, ":")
+    }
+
+    split_image(image) = [image_name, tag] {
+    	[image_name, tag] = split(image, ":")
+    }
+
+    pod_containers(pod) = all_containers {
+    	keys = {"containers", "initContainers"}
+    	all_containers = [c | keys[k]; c = pod.spec[k][_]]
+    }
+
+    containers[container] {
+    	pods[pod]
+    	all_containers = pod_containers(pod)
+    	container = all_containers[_]
+    }
+
+    containers[container] {
+    	all_containers = pod_containers(object)
+    	container = all_containers[_]
+    }
+
+    pods[pod] {
+    	is_pod
+    	pod = object
+    }
+
+    pods[pod] {
+    	is_controller
+    	pod = object.spec.template
+    }
+
+    pods[pod] {
+    	is_cronjob
+    	pod = object.spec.jobTemplate.spec.template
+    }
+
+    volumes[volume] {
+    	pods[pod]
+    	volume = pod.spec.volumes[_]
+    }
+
+    dropped_capability(container, cap) {
+    	container.securityContext.capabilities.drop[_] == cap
+    }
+
+    added_capability(container, cap) {
+    	container.securityContext.capabilities.add[_] == cap
+    }
+
+    has_field(obj, field) {
+    	obj[field]
+    }
+
+    no_read_only_filesystem(c) {
+    	not has_field(c, "securityContext")
+    }
+
+    no_read_only_filesystem(c) {
+    	has_field(c, "securityContext")
+    	not has_field(c.securityContext, "readOnlyRootFilesystem")
+    }
+
+    priviledge_escalation_allowed(c) {
+    	not has_field(c, "securityContext")
+    }
+
+    priviledge_escalation_allowed(c) {
+    	has_field(c, "securityContext")
+    	has_field(c.securityContext, "allowPrivilegeEscalation")
+    }
+
+    annotations[annotation] {
+    	pods[pod]
+    	annotation = pod.metadata.annotations
+    }
+
+    host_ipcs[host_ipc] {
+    	pods[pod]
+    	host_ipc = pod.spec.hostIPC
+    }
+
+    host_networks[host_network] {
+    	pods[pod]
+    	host_network = pod.spec.hostNetwork
+    }
+
+    host_pids[host_pid] {
+    	pods[pod]
+    	host_pid = pod.spec.hostPID
+    }
+
+    host_aliases[host_alias] {
+    	pods[pod]
+    	host_alias = pod.spec
+    }
+  library.utils.rego: |
+    package lib.utils
+
+    has_key(x, k) {
+    	_ = x[k]
+    }
   policy.1_host_ipc.kinds: Workload
-  policy.1_host_ipc.rego:
-    "package appshield.kubernetes.KSV008\n\nimport data.lib.kubernetes\n\ndefault
-    failHostIPC = false\n\n__rego_metadata__ := {\n\t\"id\": \"KSV008\",\n\t\"avd_id\":
-    \"AVD-KSV-0008\",\n\t\"title\": \"Access to host IPC namespace\",\n\t\"short_code\":
-    \"no-shared-ipc-namespace\",\n\t\"version\": \"v1.0.0\",\n\t\"severity\": \"HIGH\",\n\t\"type\":
-    \"Kubernetes Security Check\",\n\t\"description\": \"Sharing the host’s IPC namespace
-    allows container processes to communicate with processes on the host.\",\n\t\"recommended_actions\":
-    \"Do not set 'spec.template.spec.hostIPC' to true.\",\n\t\"url\": \"https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline\",\n}\n\n__rego_input__
-    := {\n\t\"combine\": false,\n\t\"selector\": [{\"type\": \"kubernetes\"}],\n}\n\n#
-    failHostIPC is true if spec.hostIPC is set to true (on all resources)\nfailHostIPC
-    {\n\tkubernetes.host_ipcs[_] == true\n}\n\ndeny[res] {\n\tfailHostIPC\n\n\tmsg
-    := kubernetes.format(sprintf(\"%s '%s' should not set 'spec.template.spec.hostIPC'
-    to true\", [kubernetes.kind, kubernetes.name]))\n\n\tres := {\n\t\t\"msg\": msg,\n\t\t\"id\":
-    __rego_metadata__.id,\n\t\t\"title\": __rego_metadata__.title,\n\t\t\"severity\":
-    __rego_metadata__.severity,\n\t\t\"type\": __rego_metadata__.type,\n\t}\n}\n"
-  
+  policy.1_host_ipc.rego: >
+    package appshield.kubernetes.KSV008
+
+
+    import data.lib.kubernetes
+
+
+    default failHostIPC = false
+
+
+    __rego_metadata__ := {
+    	"id": "KSV008",
+    	"avd_id": "AVD-KSV-0008",
+    	"title": "Access to host IPC namespace",
+    	"short_code": "no-shared-ipc-namespace",
+    	"version": "v1.0.0",
+    	"severity": "HIGH",
+    	"type": "Kubernetes Security Check",
+    	"description": "Sharing the host’s IPC namespace allows container processes to communicate with processes on the host.",
+    	"recommended_actions": "Do not set 'spec.template.spec.hostIPC' to true.",
+    	"url": "https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline",
+    }
+
+
+    __rego_input__ := {
+    	"combine": false,
+    	"selector": [{"type": "kubernetes"}],
+    }
+
+
+    # failHostIPC is true if spec.hostIPC is set to true (on all resources)
+
+    failHostIPC {
+    	kubernetes.host_ipcs[_] == true
+    }
+
+
+    deny[res] {
+    	failHostIPC
+
+    	msg := kubernetes.format(sprintf("%s '%s' should not set 'spec.template.spec.hostIPC' to true", [kubernetes.kind, kubernetes.name]))
+
+    	res := {
+    		"msg": msg,
+    		"id": __rego_metadata__.id,
+    		"title": __rego_metadata__.title,
+    		"severity": __rego_metadata__.severity,
+    		"type": __rego_metadata__.type,
+    	}
+    }

--- a/pkg/operator/envtest/testdata/fixture/vulnerability-ttl.yaml
+++ b/pkg/operator/envtest/testdata/fixture/vulnerability-ttl.yaml
@@ -8,6 +8,7 @@ metadata:
   generation: 1
   labels:
     resource-spec-hash: 65df6ff459
+    plugin-config-hash: 659b7b9c47
     trivy-operator.container.name: coredns
     trivy-operator.resource.kind: ReplicaSet
     trivy-operator.resource.name: coredns-558bd4d5db

--- a/pkg/operator/workload/helper.go
+++ b/pkg/operator/workload/helper.go
@@ -106,7 +106,10 @@ func GetReportsByLabel(ctx context.Context, resolver kube.ObjectResolver, object
 
 // MarkOldReportForImmediateDeletion set old (historical replicaSets) reports with TTL = 0 for immediate deletion
 func MarkOldReportForImmediateDeletion(ctx context.Context, resolver kube.ObjectResolver, namespace string, resourceName string) error {
-	annotation := map[string]string{v1alpha1.TTLReportAnnotation: time.Duration(0).String()}
+	annotation := map[string]string{
+		v1alpha1.TTLReportAnnotation:        time.Duration(0).String(),
+		v1alpha1.HistoricalReportAnnotation: "true",
+	}
 	resourceNameLabels := map[string]string{trivyoperator.LabelResourceName: resourceName}
 	err := markOldVulnerabilityReports(ctx, resolver, namespace, resourceNameLabels, annotation)
 	if err != nil {

--- a/pkg/operator/workload/helper.go
+++ b/pkg/operator/workload/helper.go
@@ -107,8 +107,7 @@ func GetReportsByLabel(ctx context.Context, resolver kube.ObjectResolver, object
 // MarkOldReportForImmediateDeletion set old (historical replicaSets) reports with TTL = 0 for immediate deletion
 func MarkOldReportForImmediateDeletion(ctx context.Context, resolver kube.ObjectResolver, namespace string, resourceName string) error {
 	annotation := map[string]string{
-		v1alpha1.TTLReportAnnotation:        time.Duration(0).String(),
-		v1alpha1.HistoricalReportAnnotation: "true",
+		v1alpha1.TTLReportAnnotation: time.Duration(0).String(),
 	}
 	resourceNameLabels := map[string]string{trivyoperator.LabelResourceName: resourceName}
 	err := markOldVulnerabilityReports(ctx, resolver, namespace, resourceNameLabels, annotation)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -217,7 +217,7 @@ deny[res] {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			log := ctrl.Log.WithName("resourcecontroller")
-			ready, _, err := policy.NewPolicies(tc.data, testConfig{builtInPolicies: false}, log).Applicable(tc.resource)
+			ready, _, err := policy.NewPolicies(tc.data, testConfig{builtInPolicies: false}, log).Applicable(tc.resource.GetObjectKind().GroupVersionKind().Kind)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ready).To(Equal(tc.expected))
 		})


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
check if re-scan required for mis-config reports on ttl

## Related issues
- Close #884

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).