### PR TITLE
chore: encode trivy token built-in server

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -179,7 +179,7 @@ data:
   {{- if .Values.trivy.githubToken }}
   trivy.githubToken: {{ .Values.trivy.githubToken | b64enc | quote }}
   {{- end }}
-  {{- if eq .Values.trivy.mode "ClientServer" }}
+  {{- if or (eq .Values.trivy.mode "ClientServer") .Values.operator.builtInTrivyServer }}
   {{- if .Values.trivy.serverToken }}
   trivy.serverToken: {{ .Values.trivy.serverToken | b64enc | quote }}
   {{- end }}
@@ -192,11 +192,11 @@ data:
 {{- end }}
 {{- if .Values.operator.builtInTrivyServer }}
   {{- if .Values.trivy.githubToken }}
-  GITHUB_TOKEN: {{ .Values.trivy.githubToken | quote }}
+  GITHUB_TOKEN: {{ .Values.trivy.githubToken | b64enc | quote }}
   {{- end }}
   {{- if .Values.trivy.serverToken }}
-  TRIVY_TOKEN: {{ .Values.trivy.serverToken  | quote }}
+  TRIVY_TOKEN: {{ .Values.trivy.serverToken | b64enc | quote }}
   {{- end }}
-  TRIVY_USERNAME: {{ .Values.trivy.serverUser  | quote }}
-  TRIVY_PASSWORD: {{ .Values.trivy.serverPassword  | quote }}
+  TRIVY_USERNAME: {{ .Values.trivy.serverUser  | b64enc | quote }}
+  TRIVY_PASSWORD: {{ .Values.trivy.serverPassword  | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
encode trivy token on built-in server
## Related issues
- Close #897 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.

