### PR TITLE
fix: disable config-audit scanner cause operator to crash

### DIFF
--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -113,6 +113,9 @@ func (r *TTLReportReconciler) applicableForDeletion(report client.Object, ttlRep
 	if ttlReportAnnotationStr == "0h0m0s" { // check if it marked as historical report
 		return true
 	}
+	if !r.Config.ConfigAuditScannerEnabled {
+		return false
+	}
 	resourceKind, ok := report.GetLabels()[trivyoperator.LabelResourceKind]
 	if !ok {
 		return false


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
Disable config-audit scanner cause operator to crash

## Related issues
- Close #930

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
