### PR TITLE
fix: trivy-v0.37.x deprecate flags support

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -196,7 +196,7 @@ trivy:
   # repository of the Trivy image
   repository: ghcr.io/aquasecurity/trivy
   # tag version of the Trivy image
-  tag: 0.36.0
+  tag: 0.37.2
   # imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
   # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
   # imagePullSecret:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1824,7 +1824,7 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
-  trivy.tag: "0.36.0"
+  trivy.tag: "0.37.2"
   trivy.additionalVulnerabilityReportFields: ""
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.slow: "true"

--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -1,0 +1,82 @@
+package trivy
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+)
+
+func validVersion(currentTag string, contraint string) bool {
+	c, err := semver.NewConstraint(contraint)
+	if err != nil {
+		return false
+	}
+
+	v, err := semver.NewVersion(currentTag)
+	if err != nil {
+		return false
+	}
+	// Check if the version meets the constraints. The a variable will be true.
+	return c.Check(v)
+}
+
+func GetConfig(ctx trivyoperator.PluginContext) (Config, error) {
+	pluginConfig, err := ctx.GetConfig()
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{PluginConfig: pluginConfig}, nil
+}
+
+// Slow determine if to use the slow flag (improve memory footprint)
+func Slow(ctx trivyoperator.PluginContext) string {
+	c, err := GetConfig(ctx)
+	if err != nil {
+		return ""
+	}
+	tag, err := c.GetImageTag()
+	if err != nil {
+		return ""
+	}
+	// support backward competability with older tags
+	if !validVersion(tag, ">= 0.35.0") {
+		return ""
+	}
+	if c.GetSlow() {
+		return "--slow"
+	}
+	return ""
+}
+
+// Scanners use scanners flag
+func Scanners(ctx trivyoperator.PluginContext) string {
+	c, err := GetConfig(ctx)
+	if err != nil {
+		return "--scanners"
+	}
+	tag, err := c.GetImageTag()
+	if err != nil {
+		return "--scanners"
+	}
+	// support backward competability with older tags
+	if !validVersion(tag, ">= 0.37.0") {
+		return "--security-checks"
+	}
+	return "--scanners"
+}
+
+// SkipDBUpdate skip update flag
+func SkipDBUpdate(ctx trivyoperator.PluginContext) string {
+	c, err := GetConfig(ctx)
+	if err != nil {
+		return "--skip-db-update"
+	}
+	tag, err := c.GetImageTag()
+	if err != nil {
+		return "--skip-db-update"
+	}
+	// support backward competability with older tags
+	if !validVersion(tag, ">= 0.37.0") {
+		return "--skip-update"
+	}
+	return "--skip-db-update"
+}

--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-func validVersion(currentTag string, contraint string) bool {
+func compareTagVersion(currentTag string, contraint string) bool {
 	c, err := semver.NewConstraint(contraint)
 	if err != nil {
 		return false
@@ -25,7 +25,7 @@ func Slow(c Config) string {
 		return ""
 	}
 	// support backward competability with older tags
-	if !validVersion(tag, ">= 0.35.0") {
+	if compareTagVersion(tag, "< 0.35.0") {
 		return ""
 	}
 	if c.GetSlow() {
@@ -41,7 +41,7 @@ func Scanners(c Config) string {
 		return "--scanners"
 	}
 	// support backward competability with older tags
-	if validVersion(tag, "< 0.37.0") {
+	if compareTagVersion(tag, "< 0.37.0") {
 		return "--security-checks"
 	}
 	return "--scanners"
@@ -54,7 +54,7 @@ func SkipDBUpdate(c Config) string {
 		return "--skip-db-update"
 	}
 	// support backward competability with older tags
-	if !validVersion(tag, ">= 0.37.0") {
+	if compareTagVersion(tag, "< 0.37.0") {
 		return "--skip-update"
 	}
 	return "--skip-db-update"

--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -2,7 +2,6 @@ package trivy
 
 import (
 	"github.com/Masterminds/semver"
-	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 )
 
 func validVersion(currentTag string, contraint string) bool {
@@ -19,20 +18,8 @@ func validVersion(currentTag string, contraint string) bool {
 	return c.Check(v)
 }
 
-func GetConfig(ctx trivyoperator.PluginContext) (Config, error) {
-	pluginConfig, err := ctx.GetConfig()
-	if err != nil {
-		return Config{}, err
-	}
-	return Config{PluginConfig: pluginConfig}, nil
-}
-
 // Slow determine if to use the slow flag (improve memory footprint)
-func Slow(ctx trivyoperator.PluginContext) string {
-	c, err := GetConfig(ctx)
-	if err != nil {
-		return ""
-	}
+func Slow(c Config) string {
 	tag, err := c.GetImageTag()
 	if err != nil {
 		return ""
@@ -48,11 +35,7 @@ func Slow(ctx trivyoperator.PluginContext) string {
 }
 
 // Scanners use scanners flag
-func Scanners(ctx trivyoperator.PluginContext) string {
-	c, err := GetConfig(ctx)
-	if err != nil {
-		return "--scanners"
-	}
+func Scanners(c Config) string {
 	tag, err := c.GetImageTag()
 	if err != nil {
 		return "--scanners"
@@ -65,11 +48,7 @@ func Scanners(ctx trivyoperator.PluginContext) string {
 }
 
 // SkipDBUpdate skip update flag
-func SkipDBUpdate(ctx trivyoperator.PluginContext) string {
-	c, err := GetConfig(ctx)
-	if err != nil {
-		return "--skip-db-update"
-	}
+func SkipDBUpdate(c Config) string {
 	tag, err := c.GetImageTag()
 	if err != nil {
 		return "--skip-db-update"

--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -41,7 +41,7 @@ func Scanners(c Config) string {
 		return "--scanners"
 	}
 	// support backward competability with older tags
-	if !validVersion(tag, ">= 0.37.0") {
+	if validVersion(tag, "< 0.37.0") {
 		return "--security-checks"
 	}
 	return "--scanners"

--- a/pkg/plugins/trivy/flags_test.go
+++ b/pkg/plugins/trivy/flags_test.go
@@ -1,0 +1,147 @@
+package trivy_test
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlow(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configData trivyoperator.ConfigData
+		want       string
+	}{{
+
+		name: "slow param set to true",
+		configData: map[string]string{
+			"trivy.tag":  "0.35.0",
+			"trivy.slow": "true",
+		},
+		want: "--slow",
+	},
+		{
+			name: "slow param set to false",
+			configData: map[string]string{
+				"trivy.tag":  "0.35.0",
+				"trivy.slow": "false",
+			},
+			want: "",
+		},
+		{
+			name: "slow param set to no valid value",
+			configData: map[string]string{
+				"trivy.tag":  "0.35.0",
+				"trivy.slow": "false2",
+			},
+			want: "--slow",
+		},
+		{
+			name: "slow param set to true and trivy tag is less then 0.35.0",
+			configData: map[string]string{
+				"trivy.slow": "true",
+				"trivy.tag":  "0.33.0",
+			},
+			want: "",
+		},
+
+		{
+			name: "slow param set to true and trivy tag is bigger then 0.35.0",
+			configData: map[string]string{
+				"trivy.slow": "true",
+				"trivy.tag":  "0.36.0",
+			},
+			want: "--slow",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trivy.Slow(trivy.Config{trivyoperator.PluginConfig{Data: tc.configData}})
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+func TestScanner(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configData trivyoperator.ConfigData
+		want       string
+	}{{
+
+		name: "scanner with trivy tag lower then v0.37.0",
+		configData: map[string]string{
+			"trivy.tag": "0.36.0",
+		},
+		want: "--security-checks",
+	},
+		{
+			name: "scanner with trivy tag equal then v0.37.0",
+			configData: map[string]string{
+				"trivy.tag": "0.37.0",
+			},
+			want: "--scanners",
+		},
+		{
+			name: "scanner with trivy tag higher then v0.38.0",
+			configData: map[string]string{
+				"trivy.tag": "0.38.0",
+			},
+			want: "--scanners",
+		},
+		{
+			name:       "scanner with no trivy tag lower",
+			configData: map[string]string{},
+			want:       "--scanners",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trivy.Scanners(trivy.Config{trivyoperator.PluginConfig{Data: tc.configData}})
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+func TestSkipDBUpdate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configData trivyoperator.ConfigData
+		want       string
+	}{{
+
+		name: "skip update DB with trivy tag lower then v0.37.0",
+		configData: map[string]string{
+			"trivy.tag": "0.36.0",
+		},
+		want: "--skip-update",
+	},
+		{
+			name: "skip update DB with trivy tag equal then v0.37.0",
+			configData: map[string]string{
+				"trivy.tag": "0.37.0",
+			},
+			want: "--skip-db-update",
+		},
+		{
+			name: "skip update DB with trivy tag higher then v0.38.0",
+			configData: map[string]string{
+				"trivy.tag": "0.38.0",
+			},
+			want: "--skip-db-update",
+		},
+		{
+			name:       "skip update DB with no trivy tag lower",
+			configData: map[string]string{},
+			want:       "--skip-db-update",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trivy.SkipDBUpdate(trivy.Config{trivyoperator.PluginConfig{Data: tc.configData}})
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -205,7 +205,6 @@ func TestGetSlow(t *testing.T) {
 			name: "slow param set to true",
 			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
 				Data: map[string]string{
-					"trivy.tag":  "0.35.0",
 					"trivy.slow": "true",
 				},
 			}},
@@ -215,7 +214,6 @@ func TestGetSlow(t *testing.T) {
 			name: "slow param set to false",
 			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
 				Data: map[string]string{
-					"trivy.tag":  "0.35.0",
 					"trivy.slow": "false",
 				},
 			}},
@@ -225,29 +223,15 @@ func TestGetSlow(t *testing.T) {
 			name: "slow param set to no valid value",
 			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
 				Data: map[string]string{
-					"trivy.tag":  "0.35.0",
 					"trivy.slow": "false2",
 				},
 			}},
 			want: true,
 		},
 		{
-			name: "slow param set to true and trivy tag is less then 0.35.0",
+			name: "slow param set to no  value",
 			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
-				Data: map[string]string{
-					"trivy.slow": "true",
-					"trivy.tag":  "0.33.0",
-				},
-			}},
-			want: false,
-		},
-		{
-			name: "slow param set to true and trivy tag is bigger then 0.35.0",
-			configData: trivy.Config{PluginConfig: trivyoperator.PluginConfig{
-				Data: map[string]string{
-					"trivy.slow": "true",
-					"trivy.tag":  "0.36.0",
-				},
+				Data: map[string]string{},
 			}},
 			want: true,
 		},

--- a/tests/e2e/client-server/workload/00-assert.yaml
+++ b/tests/e2e/client-server/workload/00-assert.yaml
@@ -14,4 +14,3 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.36.0

--- a/tests/e2e/fs-mode/workload/00-assert.yaml
+++ b/tests/e2e/fs-mode/workload/00-assert.yaml
@@ -14,4 +14,3 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.36.0

--- a/tests/e2e/image-mode/workload/00-assert.yaml
+++ b/tests/e2e/image-mode/workload/00-assert.yaml
@@ -14,4 +14,3 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.36.0


### PR DESCRIPTION
Signed-off-by: chenk <hen.keinan@gmail.com>

## Description
trivy-v0.37.x deprecate flag support

## Related issues
- Close #948
- Close #942

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
