### PR TITLE
fix: get the data of the specified severity

### DIFF
--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -45,6 +45,10 @@ func evaluate(ctx context.Context, policies *policy.Policies, resource client.Ob
 	infraChecks := make([]v1alpha1.Check, 0)
 	checks := make([]v1alpha1.Check, 0)
 	for _, result := range results {
+		if !policies.HasSeverity(result) {
+			continue
+		}
+
 		id := policies.GetResultID(result)
 
 		// record only misconfig failed checks

--- a/pkg/configauditreport/plugin.go
+++ b/pkg/configauditreport/plugin.go
@@ -21,4 +21,7 @@ type ConfigAuditConfig interface {
 	GetUseBuiltinRegoPolicies() bool
 	// GetSupportedConfigAuditKinds list of supported kinds to be scanned by the config audit scanner
 	GetSupportedConfigAuditKinds() []string
+
+	// GetSeverity get security level
+	GetSeverity() string
 }

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -50,7 +50,7 @@ const (
 	keyTrivyMode                                = "trivy.mode"
 	keyTrivyAdditionalVulnerabilityReportFields = "trivy.additionalVulnerabilityReportFields"
 	keyTrivyCommand                             = "trivy.command"
-	keyTrivySeverity                            = "trivy.severity"
+	KeyTrivySeverity                            = "trivy.severity"
 	keyTrivySlow                                = "trivy.slow"
 	keyTrivyIgnoreUnfixed                       = "trivy.ignoreUnfixed"
 	keyTrivyOfflineScan                         = "trivy.offlineScan"
@@ -232,6 +232,14 @@ func (c Config) GetUseBuiltinRegoPolicies() bool {
 		return true
 	}
 	return boolVal
+}
+
+func (c Config) GetSeverity() string {
+	val, ok := c.Data[KeyTrivySeverity]
+	if !ok {
+		return ""
+	}
+	return val
 }
 
 func (c Config) GetSlow() bool {
@@ -488,7 +496,7 @@ func (p *plugin) Init(ctx trivyoperator.PluginContext) error {
 		Data: map[string]string{
 			keyTrivyImageRepository:           "ghcr.io/aquasecurity/trivy",
 			keyTrivyImageTag:                  "0.35.0",
-			keyTrivySeverity:                  "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+			KeyTrivySeverity:                  "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 			keyTrivySlow:                      "true",
 			keyTrivyMode:                      string(Standalone),
 			keyTrivyTimeout:                   "5m0s",
@@ -681,7 +689,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: trivyConfigName,
 						},
-						Key:      keyTrivySeverity,
+						Key:      KeyTrivySeverity,
 						Optional: pointer.Bool(true),
 					},
 				},
@@ -1043,7 +1051,7 @@ func (p *plugin) getPodSpecForClientServerMode(ctx trivyoperator.PluginContext, 
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: trivyConfigName,
 						},
-						Key:      keyTrivySeverity,
+						Key:      KeyTrivySeverity,
 						Optional: pointer.Bool(true),
 					},
 				},
@@ -1467,7 +1475,7 @@ func (p *plugin) getPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, 
 
 	for _, c := range getContainers(spec) {
 		env := []corev1.EnvVar{
-			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, keyTrivySeverity),
+			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, KeyTrivySeverity),
 			constructEnvVarSourceFromConfigMap("TRIVY_SKIP_FILES", trivyConfigName, keyTrivySkipFiles),
 			constructEnvVarSourceFromConfigMap("TRIVY_SKIP_DIRS", trivyConfigName, keyTrivySkipDirs),
 			constructEnvVarSourceFromConfigMap("HTTP_PROXY", trivyConfigName, keyTrivyHTTPProxy),
@@ -1650,7 +1658,7 @@ func (p *plugin) getPodSpecForClientServerFSMode(ctx trivyoperator.PluginContext
 
 	for _, c := range getContainers(spec) {
 		env := []corev1.EnvVar{
-			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, keyTrivySeverity),
+			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, KeyTrivySeverity),
 			constructEnvVarSourceFromConfigMap("TRIVY_SKIP_FILES", trivyConfigName, keyTrivySkipFiles),
 			constructEnvVarSourceFromConfigMap("TRIVY_SKIP_DIRS", trivyConfigName, keyTrivySkipDirs),
 			constructEnvVarSourceFromConfigMap("HTTP_PROXY", trivyConfigName, keyTrivyHTTPProxy),

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -236,6 +236,10 @@ func (r *Policies) GetResultID(result scan.Result) string {
 	return id
 }
 
+func (r *Policies) HasSeverity(result scan.Result) bool {
+	return strings.Contains(r.cac.GetSeverity(), string(result.Rule().Severity))
+}
+
 func getScannerOptions(hasExternalPolicies bool, useDefaultPolicies bool, policiesFolder string) []options.ScannerOption {
 	optionsArray := []options.ScannerOption{options.ScannerWithEmbeddedPolicies(useDefaultPolicies)}
 	if hasExternalPolicies {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1168,3 +1168,7 @@ func (tc testConfig) GetUseBuiltinRegoPolicies() bool {
 func (tc testConfig) GetSupportedConfigAuditKinds() []string {
 	return utils.MapKinds(strings.Split(trivy.SupportedConfigAuditKinds, ","))
 }
+
+func (tc testConfig) GetSeverity() string {
+	return trivy.KeyTrivySeverity
+}


### PR DESCRIPTION
Signed-off-by: fengshunli <1171313930@qq.com>

## Description

https://github.com/aquasecurity/trivy-operator/issues/849#event-8498354536

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
