### PR TITLE
fix: exclude node from client cache

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -58,6 +58,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		ClientDisableCacheFor: []client.Object{
 			&corev1.Secret{},
 			&corev1.ServiceAccount{},
+			&corev1.Node{},
 		},
 	}
 


### PR DESCRIPTION
## Description
Exclude node from client cache

## Related issues
- Close #956 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
