### PR TITLE
properly populate the target attribute of exposed secrets

### DIFF
--- a/docs/docs/crds/exposedsecret-report.md
+++ b/docs/docs/crds/exposedsecret-report.md
@@ -46,13 +46,13 @@ report:
     match: 'publishable_key: *****'
     ruleID: stripe-access-token
     severity: HIGH
-    target: ""
+    target: "/app/config/secret.yaml"
     title: Stripe
   - category: Stripe
     match: 'secret_key: *****'
     ruleID: stripe-access-token
     severity: HIGH
-    target: ""
+    target: "/app/config/secret.yaml"
     title: Stripe
   summary:
     criticalCount: 0

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -1933,7 +1933,7 @@ func getExposedSecretsFromScanResult(report ScanResult) []v1alpha1.ExposedSecret
 
 	for _, sr := range report.Secrets {
 		secrets = append(secrets, v1alpha1.ExposedSecret{
-			Target:   sr.Target,
+			Target:   report.Target,
 			RuleID:   sr.RuleID,
 			Title:    sr.Title,
 			Severity: sr.Severity,

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -5581,13 +5581,14 @@ var (
 			Tag:        "3.10.2",
 		},
 		Summary: v1alpha1.ExposedSecretSummary{
-			CriticalCount: 1,
+			CriticalCount: 3,
 			HighCount:     1,
 			MediumCount:   0,
 			LowCount:      0,
 		},
 		Secrets: []v1alpha1.ExposedSecret{
 			{
+				Target:   "/app/config/secret.yaml",
 				RuleID:   "stripe-access-token",
 				Category: "Stripe",
 				Severity: "HIGH",
@@ -5595,11 +5596,28 @@ var (
 				Match:    "publishable_key: *****",
 			},
 			{
+				Target:   "/app/config/secret.yaml",
 				RuleID:   "stripe-access-token",
 				Category: "Stripe",
 				Severity: "CRITICAL",
 				Title:    "Stripe",
 				Match:    "secret_key: *****",
+			},
+			{
+				Target:   "/etc/apt/s3auth.conf",
+				RuleID:   "aws-access-key-id",
+				Category: "AWS",
+				Severity: "CRITICAL",
+				Title:    "AWS Access Key ID",
+				Match:    "AccessKeyId = ********************",
+			},
+			{
+				Target:   "/etc/apt/s3auth.conf",
+				RuleID:   "aws-secret-access-key",
+				Category: "AWS",
+				Severity: "CRITICAL",
+				Title:    "AWS Secret Access Key",
+				Match:    "SecretAccessKey = ****************************************",
 			},
 		},
 	}

--- a/pkg/plugins/trivy/testdata/fixture/exposedsecret_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/exposedsecret_report.json
@@ -24,6 +24,30 @@
           "Match": "secret_key: *****"
         }
       ]
+    },
+    {
+      "Target": "/etc/apt/s3auth.conf",
+      "Class": "secret",
+      "Secrets": [
+        {
+          "RuleID": "aws-access-key-id",
+          "Category": "AWS",
+          "Severity": "CRITICAL",
+          "Title": "AWS Access Key ID",
+          "StartLine": 1,
+          "EndLine": 1,
+          "Match": "AccessKeyId = ********************"
+        },
+        {
+          "RuleID": "aws-secret-access-key",
+          "Category": "AWS",
+          "Severity": "CRITICAL",
+          "Title": "AWS Secret Access Key",
+          "StartLine": 2,
+          "EndLine": 2,
+          "Match": "SecretAccessKey = ****************************************"
+        }
+      ]
     }
   ]
 }

--- a/pkg/plugins/trivy/testdata/fixture/full_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/full_report.json
@@ -57,6 +57,30 @@
           "Match": "secret_key: *****"
         }
       ]
+    },
+    {
+      "Target": "/etc/apt/s3auth.conf",
+      "Class": "secret",
+      "Secrets": [
+        {
+          "RuleID": "aws-access-key-id",
+          "Category": "AWS",
+          "Severity": "CRITICAL",
+          "Title": "AWS Access Key ID",
+          "StartLine": 1,
+          "EndLine": 1,
+          "Match": "AccessKeyId = ********************"
+        },
+        {
+          "RuleID": "aws-secret-access-key",
+          "Category": "AWS",
+          "Severity": "CRITICAL",
+          "Title": "AWS Secret Access Key",
+          "StartLine": 2,
+          "EndLine": 2,
+          "Match": "SecretAccessKey = ****************************************"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

- properly populate the target attribute of exposed secrets
- update docs

Before:

```yaml
  secrets:
  - category: Stripe
    match: 'publishable_key: *****'
    ruleID: stripe-access-token
    severity: HIGH
    target: ""
    title: Stripe
  - category: Stripe
    match: 'secret_key: *****'
    ruleID: stripe-access-token
    severity: HIGH
    target: ""
    title: Stripe
```

After:
```yaml
  secrets:
  - category: Stripe
    match: 'publishable_key: *****'
    ruleID: stripe-access-token
    severity: HIGH
    target: "/app/config/secret.yaml"
    title: Stripe
  - category: Stripe
    match: 'secret_key: *****'
    ruleID: stripe-access-token
    severity: HIGH
    target: "/app/config/secret.yaml"
    title: Stripe
```

## Related issues
- Close #992

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
