### PR TITLE
fix!: Helm chart: add missing quote filter in config template

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -145,18 +145,18 @@ data:
   {{- with .Values.trivy.resources }}
     {{- with .requests }}
       {{- if .cpu }}
-  trivy.resources.requests.cpu: {{ .cpu }}
+  trivy.resources.requests.cpu: {{ .cpu | quote }}
       {{- end }}
       {{- if hasKey . "memory" }}
-  trivy.resources.requests.memory: {{ .memory }}
+  trivy.resources.requests.memory: {{ .memory | quote }}
       {{- end }}
     {{- end }}
     {{- with .limits }}
       {{- if .cpu }}
-  trivy.resources.limits.cpu: {{ .cpu }}
+  trivy.resources.limits.cpu: {{ .cpu | quote }}
       {{- end }}
       {{- if .memory }}
-  trivy.resources.limits.memory: {{ .memory }}
+  trivy.resources.limits.memory: {{ .memory | quote }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1835,10 +1835,10 @@ data:
   trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"
   trivy.timeout: "5m0s"
   trivy.mode: "Standalone"
-  trivy.resources.requests.cpu: 100m
-  trivy.resources.requests.memory: 100M
-  trivy.resources.limits.cpu: 500m
-  trivy.resources.limits.memory: 500M
+  trivy.resources.requests.cpu: "100m"
+  trivy.resources.requests.memory: "100M"
+  trivy.resources.limits.cpu: "500m"
+  trivy.resources.limits.memory: "500M"
 ---
 # Source: trivy-operator/templates/deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
## Description

The values for `trivy.resources` were not quoted.
If the Helm value is a string containing only a number, e.g. `trivy.resources.requests.cpu: "2"`, the generated YAML for the config map is `trivy.resources.requests.cpu: 2`, which is of the type number, not string, which is not a valid value for a Kubernetes config map.
Adding the `| quote` filter should fix this bug.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
