### PR TITLE
fix: requeue  non-ready nodes

### DIFF
--- a/pkg/configauditreport/controller/node.go
+++ b/pkg/configauditreport/controller/node.go
@@ -100,6 +100,15 @@ func (r *NodeReconciler) reconcileNodes() reconcile.Func {
 			log.V(1).Info("Pushing back node collector job", "count", jobsCount, "retryAfter", r.ScanJobRetryAfter)
 			return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
 		}
+		// requeue nodes non-ready nodes
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				if !(condition.Status == corev1.ConditionTrue) {
+					log.V(1).Info("Pushing back node collector job", "count", jobsCount, "retryAfter", r.ScanJobRetryAfter)
+					return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
+				}
+			}
+		}
 		cluster, err := k8s.GetCluster()
 		if err != nil {
 			return ctrl.Result{}, nil

--- a/pkg/configauditreport/controller/node.go
+++ b/pkg/configauditreport/controller/node.go
@@ -67,7 +67,15 @@ func (r *NodeReconciler) reconcileNodes() reconcile.Func {
 			}
 			return ctrl.Result{}, fmt.Errorf("getting node from cache: %w", err)
 		}
-
+		// requeue nodes non-ready nodes
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				if !(condition.Status == corev1.ConditionTrue) {
+					log.V(1).Info("Pushing back node collector job", "retryAfter", r.ScanJobRetryAfter)
+					return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
+				}
+			}
+		}
 		log.V(1).Info("Checking whether cluster Infra assessments report exists")
 		hasReport, err := hasInfraReport(ctx, node, r.InfraReadWriter)
 		if err != nil {
@@ -99,15 +107,6 @@ func (r *NodeReconciler) reconcileNodes() reconcile.Func {
 		if limitExceeded {
 			log.V(1).Info("Pushing back node collector job", "count", jobsCount, "retryAfter", r.ScanJobRetryAfter)
 			return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
-		}
-		// requeue nodes non-ready nodes
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == corev1.NodeReady {
-				if !(condition.Status == corev1.ConditionTrue) {
-					log.V(1).Info("Pushing back node collector job", "count", jobsCount, "retryAfter", r.ScanJobRetryAfter)
-					return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
-				}
-			}
 		}
 		cluster, err := k8s.GetCluster()
 		if err != nil {


### PR DESCRIPTION
## Description
re-queue nodes reconciliation non-ready status

## Related issues
- Close #1021 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
