### PR TITLE
incorrect check of ttlReportAnnotationStr in TTLReportReconciler

### DIFF
--- a/pkg/operator/envtest/testdata/fixture/config-audit-ttl-historical.yaml
+++ b/pkg/operator/envtest/testdata/fixture/config-audit-ttl-historical.yaml
@@ -3,7 +3,7 @@ apiVersion: aquasecurity.github.io/v1alpha1
 kind: ConfigAuditReport
 metadata:
   annotations:
-    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m0s
+    trivy-operator.aquasecurity.github.io/report-ttl: 0s
     trivy-operator.aquasecurity.github.io/report-historical: true
   creationTimestamp: 2022-12-08T15:50:37Z
   generation: 1

--- a/pkg/operator/envtest/testdata/fixture/vulnerability-ttl.yaml
+++ b/pkg/operator/envtest/testdata/fixture/vulnerability-ttl.yaml
@@ -3,7 +3,7 @@ apiVersion: aquasecurity.github.io/v1alpha1
 kind: VulnerabilityReport
 metadata:
   annotations:
-    trivy-operator.aquasecurity.github.io/report-ttl: 0h0m0s
+    trivy-operator.aquasecurity.github.io/report-ttl: 0s
   creationTimestamp: 2022-12-08T15:50:37Z
   generation: 1
   labels:

--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -110,7 +110,7 @@ func (r *TTLReportReconciler) applicableForDeletion(report client.Object, ttlRep
 	if reportKind == "VulnerabilityReport" || reportKind == "ExposedSecretReport" {
 		return true
 	}
-	if ttlReportAnnotationStr == "0h0m0s" { // check if it marked as historical report
+	if ttlReportAnnotationStr == time.Duration(0).String() { // check if it marked as historical report
 		return true
 	}
 	if !r.Config.ConfigAuditScannerEnabled {


### PR DESCRIPTION
## Related issues
- Close #1059 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
