### PR TITLE
fix: fixing auth issues when accessing private registries using mirroring

### DIFF
--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -588,8 +588,23 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 	if err != nil {
 		return corev1.PodSpec{}, nil, err
 	}
-	if len(credentials) > 0 {
-		secret = p.newSecretWithAggregateImagePullCredentials(workload, spec, credentials)
+
+	containersSpec := getContainers(spec)
+	for i := 0; i < len(containersSpec); i++ {
+		c := &containersSpec[i]
+		optionalMirroredImage, err := GetMirroredImage(c.Image, config.GetMirrors())
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		c.Image = optionalMirroredImage
+	}
+
+	containersCredentials, err := kube.MapContainerNamesToDockerAuths(kube.GetContainerImagesFromPodSpec(spec), credentials)
+	if err != nil {
+		return corev1.PodSpec{}, nil, err
+	}
+	if len(containersCredentials) > 0 {
+		secret = p.newSecretWithAggregateImagePullCredentials(workload, spec, containersCredentials)
 		secrets = append(secrets, secret)
 	}
 
@@ -669,7 +684,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}
 
-	for _, c := range getContainers(spec) {
+	for _, c := range containersSpec {
 		env := []corev1.EnvVar{
 			{
 				Name: "TRIVY_SEVERITY",
@@ -802,7 +817,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 			})
 		}
 
-		if _, ok := credentials[c.Name]; ok && secret != nil {
+		if _, ok := containersCredentials[c.Name]; ok && secret != nil {
 			registryUsernameKey := fmt.Sprintf("%s.username", c.Name)
 			registryPasswordKey := fmt.Sprintf("%s.password", c.Name)
 
@@ -844,11 +859,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx trivyoperator.PluginContext, co
 			return corev1.PodSpec{}, nil, err
 		}
 
-		optionalMirroredImage, err := GetMirroredImage(c.Image, config.GetMirrors())
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
-		}
-		imageRef, err := containerimage.ParseReference(optionalMirroredImage)
+		imageRef, err := containerimage.ParseReference(c.Image)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
@@ -965,8 +976,22 @@ func (p *plugin) getPodSpecForClientServerMode(ctx trivyoperator.PluginContext, 
 		return corev1.PodSpec{}, nil, err
 	}
 
-	if len(credentials) > 0 {
-		secret = p.newSecretWithAggregateImagePullCredentials(workload, spec, credentials)
+	containersSpec := getContainers(spec)
+	for i := 0; i < len(containersSpec); i++ {
+		c := &containersSpec[i]
+		optionalMirroredImage, err := GetMirroredImage(c.Image, config.GetMirrors())
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		c.Image = optionalMirroredImage
+	}
+
+	containersCredentials, err := kube.MapContainerNamesToDockerAuths(kube.GetContainerImagesFromPodSpec(spec), credentials)
+	if err != nil {
+		return corev1.PodSpec{}, nil, err
+	}
+	if len(containersCredentials) > 0 {
+		secret = p.newSecretWithAggregateImagePullCredentials(workload, spec, containersCredentials)
 		secrets = append(secrets, secret)
 	}
 
@@ -995,7 +1020,7 @@ func (p *plugin) getPodSpecForClientServerMode(ctx trivyoperator.PluginContext, 
 	}
 	volumes = append(volumes, getScanResultVolume())
 
-	for _, container := range getContainers(spec) {
+	for _, container := range containersSpec {
 		env := []corev1.EnvVar{
 			{
 				Name: "HTTP_PROXY",
@@ -1156,7 +1181,7 @@ func (p *plugin) getPodSpecForClientServerMode(ctx trivyoperator.PluginContext, 
 			})
 		}
 
-		if _, ok := credentials[container.Name]; ok && secret != nil {
+		if _, ok := containersCredentials[container.Name]; ok && secret != nil {
 			registryUsernameKey := fmt.Sprintf("%s.username", container.Name)
 			registryPasswordKey := fmt.Sprintf("%s.password", container.Name)
 
@@ -1214,15 +1239,11 @@ func (p *plugin) getPodSpecForClientServerMode(ctx trivyoperator.PluginContext, 
 			return corev1.PodSpec{}, nil, err
 		}
 
-		optionalMirroredImage, err := GetMirroredImage(container.Image, config.GetMirrors())
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
-		}
 		encodedTrivyServerURL, err := url.Parse(trivyServerURL)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
-		imageRef, err := containerimage.ParseReference(optionalMirroredImage)
+		imageRef, err := containerimage.ParseReference(container.Image)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -231,7 +231,7 @@ func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Obj
 			return err
 		}
 		multiSecretSupport := trivy.MultiSecretSupport(trivy.Config{PluginConfig: pConfig})
-		credentials, err = r.CredentialsByWorkloadAndEnv(ctx, owner, privateRegistrySecrets, multiSecretSupport)
+		credentials, err = r.CredentialsByServer(ctx, owner, privateRegistrySecrets, multiSecretSupport)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This change is fixing the authentication issues when accessing private registries using mirroring. The focus here is the mirror image mapping should happen before the credentials and AWS region are discovered.

Looking into the code, currently the credentials are being mapped per container at workload level in the `submitScanJob` function [here](https://github.com/aquasecurity/trivy-operator/blob/v0.12.1/pkg/vulnerabilityreport/controller/workload.go#L224-L238), however the mirror mapping is only happening afterwards at plugin `GetScanJobSpec` level [here](https://github.com/aquasecurity/trivy-operator/blob/v0.12.1/pkg/plugins/trivy/plugin.go#L847), so the credential is being mapped for the original registry server instead of the target mirrored repository. In my humble opinion this logic should be updated, from the workload perspective the credentials should be passed to the plugin in a raw mapping, containing the registry server and the auth credentials, then from inside the public, once the mirroring mapping is done, the logic of mapping each container can be executed.

## Related issues
- Close #1064 
- Close #1065 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
