### PR TITLE
prefer nvd score if both nvd and vendor cvss v3 scores exist

### DIFF
--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -2048,11 +2048,11 @@ func GetScoreFromCVSS(CVSSs map[string]*CVSS) *float64 {
 		}
 	}
 
-	if vendorScore != nil {
-		return vendorScore
+	if nvdScore != nil {
+		return nvdScore
 	}
 
-	return nvdScore
+	return vendorScore
 }
 
 func GetMirroredImage(image string, mirrors map[string]string) (string, error) {

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -5780,7 +5780,7 @@ func TestGetScoreFromCVSS(t *testing.T) {
 		expectedScore *float64
 	}{
 		{
-			name: "Should return vendor score when vendor v3 score exist",
+			name: "Should return nvd score when nvd and vendor v3 score exist",
 			cvss: dbtypes.VendorCVSS{
 				"nvd": {
 					V3Score: 8.1,
@@ -5789,7 +5789,7 @@ func TestGetScoreFromCVSS(t *testing.T) {
 					V3Score: 8.3,
 				},
 			},
-			expectedScore: pointer.Float64(8.3),
+			expectedScore: pointer.Float64(8.1),
 		},
 		{
 			name: "Should return nvd score when vendor v3 score is nil",
@@ -5807,6 +5807,15 @@ func TestGetScoreFromCVSS(t *testing.T) {
 			name: "Should return nvd score when vendor doesn't exist",
 			cvss: dbtypes.VendorCVSS{
 				"nvd": {
+					V3Score: 8.1,
+				},
+			},
+			expectedScore: pointer.Float64(8.1),
+		},
+		{
+			name: "Should return vendor score when nvd doesn't exist",
+			cvss: dbtypes.VendorCVSS{
+				"redhat": {
 					V3Score: 8.1,
 				},
 			},


### PR DESCRIPTION
## Description

Updates the `VulnerabilityReport`'s `Score` field logic to prefer NVD score if both NVD and Vendor V3 CVSS scores exist, using Vendor score as fallback in case no NVD score is available.

## Related issues
- Close #1079

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
