### PR TITLE
chore: bump golang version 1.20.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ on:
       - LICENSE
       - NOTICE
 env:
-  GO_VERSION: 1.19.1
+  GO_VERSION: 1.20.3
   KIND_VERSION: v0.17.0
   KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 permissions: {}

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -12,7 +12,7 @@ on:
     paths:
       - deploy/**
 env:
-  GO_VERSION: 1.19.1
+  GO_VERSION: 1.20.3
   KIND_VERSION: v0.17.0
   KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 permissions: {}

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -13,7 +13,7 @@ on:
       - NOTICE
 
 env:
-  GO_VERSION: 1.19.1
+  GO_VERSION: 1.20.3
   KIND_VERSION: v0.17.0
   KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 permissions: {}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  GO_VERSION: 1.19.1
+  GO_VERSION: 1.20.3
 
 # Disable permissions granted to the GITHUB_TOKEN for all the available scopes.
 permissions: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
     tags:
       - "v*"
 env:
-  GO_VERSION: 1.19.1
+  GO_VERSION: 1.20.3
   KIND_VERSION: v0.17.0
   KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aquasecurity/defsec v0.85.0


### PR DESCRIPTION
## Description
fix Golang runtime CVEs
## Related issues
- Close #1171

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
