### PR TITLE
feat: Add support fo legacy dockercfg in scan jobs

### DIFF
--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -55,9 +55,21 @@ type Config struct {
 	Auths map[string]Auth `json:"auths"`
 }
 
-func (c *Config) Read(contents []byte) error {
-	if err := json.Unmarshal(contents, c); err != nil {
-		return err
+func (c *Config) Read(contents []byte, isLegacy bool) error {
+	if isLegacy {
+		// Because ~/.dockercfg contents is "auths" field in ~/.docker/config.json
+		// we can simply pass it to "Auths" field of Config
+		auths := make(map[string]Auth)
+		if err := json.Unmarshal(contents, &auths); err != nil {
+			return err
+		}
+		*c = Config{
+			Auths: auths,
+		}
+	} else {
+		if err := json.Unmarshal(contents, c); err != nil {
+			return err
+		}
 	}
 	var err error
 	c.Auths, err = decodeAuths(c.Auths)

--- a/pkg/docker/config_test.go
+++ b/pkg/docker/config_test.go
@@ -21,6 +21,8 @@ func TestConfig_Read(t *testing.T) {
 
 		expectedAuth  map[string]docker.Auth
 		expectedError error
+
+		isLegacy bool
 	}{
 		{
 			name:         "Should return empty credentials when content is empty JSON object",
@@ -92,7 +94,7 @@ func TestConfig_Read(t *testing.T) {
 			givenJSON: `{
 						"auths": {
 						"https://index.docker.io/v1/": {
-							
+
 						},
 						"harbor.domain": {
 							"auth": "YWRtaW46SGFyYm9yMTIzNDU="
@@ -118,12 +120,36 @@ func TestConfig_Read(t *testing.T) {
 						}`,
 			expectedError: errors.New("expected username and password concatenated with a colon (:)"),
 		},
+		{
+			name:     "Should process legacy .dockercfg json",
+			isLegacy: true,
+			givenJSON: `{
+							"https://index.docker.io/v1/": {
+								"auth": "ZG9ja2VyOmh1Yg=="
+							},
+							"harbor.domain": {
+								"auth": "YWRtaW46SGFyYm9yMTIzNDU="
+							}
+						}`,
+			expectedAuth: map[string]docker.Auth{
+				"https://index.docker.io/v1/": {
+					Auth:     "ZG9ja2VyOmh1Yg==",
+					Username: "docker",
+					Password: "hub",
+				},
+				"harbor.domain": {
+					Auth:     "YWRtaW46SGFyYm9yMTIzNDU=",
+					Username: "admin",
+					Password: "Harbor12345",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dockerConfig := &docker.Config{}
-			err := dockerConfig.Read([]byte(tc.givenJSON))
+			err := dockerConfig.Read([]byte(tc.givenJSON), tc.isLegacy)
 			switch {
 			case tc.expectedError != nil:
 				assert.EqualError(t, err, tc.expectedError.Error())

--- a/pkg/kube/secrets_test.go
+++ b/pkg/kube/secrets_test.go
@@ -72,7 +72,13 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
 		auths, err := kube.MapDockerRegistryServersToAuths([]corev1.Secret{
 			{
 				Type: corev1.SecretTypeDockercfg,
-				Data: map[string][]byte{},
+				Data: map[string][]byte{
+					corev1.DockerConfigKey: []byte(`{
+  "quay.io": {
+	"auth": "dXNlcjpBZG1pbjEyMzQ1"
+  }
+}`),
+				},
 			},
 			{
 				Type: corev1.SecretTypeDockerConfigJson,
@@ -95,6 +101,11 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
 				Auth:     "cm9vdDpzM2NyZXQ=",
 				Username: "root",
 				Password: "s3cret",
+			}),
+			"quay.io": Equal(docker.Auth{
+				Auth:     "dXNlcjpBZG1pbjEyMzQ1",
+				Username: "user",
+				Password: "Admin12345",
 			}),
 		}))
 	})


### PR DESCRIPTION
## Description
Now pods `imagePullSecrets` with secret type `kubernetes.io/dockercfg` are ignored when generating `imagePullSecrets` for scan jobs. This PR adds functionality to treat legacy `kubernetes.io/dockercfg` secrets and converts them to newer version (`kubernetes.io/dockerconfigjson`) for operator scan jobs.

I think it's not too bad to support the old types of secrets since both types (`kubernetes.io/dockerconfigjson` and `kubernetes.io/dockercfg`) perform the same function and are still supported by kubernetes.
If you don't think so - could you please explain why we can't support both types of secrets in the operator? 
## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
