### PR TITLE
fix: disable vuln-plugin crash-operator

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -43,7 +43,7 @@ data:
   {{- with .Values.trivyOperator.scanJobCompressLogs }}
   scanJob.compressLogs: {{ . | toJson | quote }}
   {{- end }}
-  {{- if .Values.operator.vulnerabilityScannerEnabled }}
+  {{- if or .Values.operator.vulnerabilityScannerEnabled .Values.operator.exposedSecretScannerEnabled .Values.operator.scannerReportTTL }}
   vulnerabilityReports.scanner: {{ .Values.trivyOperator.vulnerabilityReportsPlugin | quote }}
   {{- end }}
   {{- if .Values.operator.configAuditScannerEnabled }}


### PR DESCRIPTION
## Description
Disabling vulnerability plugin crash operator

## Related issues
- Close #1165 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
