### PR TITLE
fix: Add tolerations to trivy-server template

### DIFF
--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -135,6 +135,10 @@ spec:
       volumes:
         - name: tmp-data
           emptyDir: {}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}


### PR DESCRIPTION
## Description

It is sometimes essential defining tolerations. There's a `nodeSelector` field but no tolerations settings. For us it is causing pod to be in a "Pending" state.

## Related issues
Is still not opened, seems like simple fix.
