### PR TITLE
fix: pod spec hash issues when using image mirroring

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -33,6 +33,18 @@ func GetContainerImagesFromPodSpec(spec corev1.PodSpec) ContainerImages {
 	return images
 }
 
+// GetContainerImagesFromContainersList returns a map of container names
+// to container images from the specified corev1.Container array.
+func GetContainerImagesFromContainersList(containers []corev1.Container) ContainerImages {
+	images := ContainerImages{}
+
+	for _, container := range containers {
+		images[container.Name] = container.Image
+	}
+
+	return images
+}
+
 // GetContainerImagesFromJob returns a map of container names
 // to container images from the specified v1.Job.
 // The mapping is encoded as JSON value of the AnnotationContainerImages

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -52,6 +52,40 @@ func TestGetContainerImagesFromPodSpec(t *testing.T) {
 	}, images)
 }
 
+func TestGetContainerImagesFromContainersList(t *testing.T) {
+	images := kube.GetContainerImagesFromContainersList(
+		[]corev1.Container{
+			{
+				Name:  "nginx",
+				Image: "nginx:1.16",
+			},
+			{
+				Name:  "sidecar",
+				Image: "sidecar:1.32.7",
+			},
+			{
+				Name:  "init",
+				Image: "init:1.0.0",
+			},
+			{
+				Name:  "init2",
+				Image: "init:1.0.0",
+			},
+			{
+				Name:  "debug",
+				Image: "debug:1.0.0",
+			},
+		},
+	)
+	assert.Equal(t, kube.ContainerImages{
+		"nginx":   "nginx:1.16",
+		"sidecar": "sidecar:1.32.7",
+		"init":    "init:1.0.0",
+		"init2":   "init:1.0.0",
+		"debug":   "debug:1.0.0",
+	}, images)
+}
+
 func TestGetContainerImagesFromJob(t *testing.T) {
 
 	t.Run("Should return error when annotation is not set", func(t *testing.T) {

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6843,6 +6843,7 @@ default ignore = false`,
 			for i := 0; i < len(secrets); i++ {
 				assert.Equal(t, tc.expectedSecretsData[i], secrets[i].Data)
 			}
+
 		})
 	}
 

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -113,6 +113,11 @@ func (r *ScanJobController) processCompleteScanJob(ctx context.Context, job *bat
 		return fmt.Errorf("expected label %s not set", trivyoperator.LabelResourceSpecHash)
 	}
 
+	log = log.WithValues("kind", owner.GetObjectKind().GroupVersionKind().Kind,
+		"name", owner.GetName(), "namespace", owner.GetNamespace(), "podSpecHash", podSpecHash)
+
+	log.V(1).Info("Job complete")
+
 	hasReports, err := hasReports(ctx, r.ExposedSecretReadWriter, r.VulnerabilityReadWriter, ownerRef, podSpecHash, containerImages)
 	if err != nil {
 		return err

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -172,6 +172,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 				return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
 			}
 		}
+		log.V(1).Info("Submitting a scan for the workload")
 		// sync all potential workload for scanning
 		r.SubmitScanJobChan <- ScanJobRequest{Workload: workloadObj, Context: ctx}
 		// collect scan job processing results
@@ -307,6 +308,9 @@ func (r *WorkloadController) submitScanJob(ctx context.Context, owner client.Obj
 		}
 	}
 
+	log = log.WithValues("podSpecHash", scanJob.Labels[trivyoperator.LabelResourceSpecHash])
+
+	log.V(1).Info("Creating scan job for the workload")
 	err = r.Client.Create(ctx, scanJob)
 	if err != nil {
 		if k8sapierror.IsAlreadyExists(err) {


### PR DESCRIPTION
## Description
This change is fixing the mismatch between the real and stored pod spec hash when using image mirroring, this issue was introduced in #1066 when the original container image is modified and stored in the runtime cache.

## Related issues
- Close #1204

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
