### PR TITLE
fix: specify trivy-server persistent volume claim for argocd sync

### DIFF
--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -38,7 +38,9 @@ spec:
       app.kubernetes.io/name: trivy-server
       app.kubernetes.io/instance: trivy-server
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         resources:


### PR DESCRIPTION
## Description
Explicitly specify the kind and apiVersion for the volumeClaimTemplates of trivy-server
## Related issues
- Close #1206

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
