### PR TITLE
Read object before compare to avoid wrong cached data

### DIFF
--- a/pkg/webhook/webhookreporter.go
+++ b/pkg/webhook/webhookreporter.go
@@ -71,14 +71,11 @@ func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *WebhookReconciler) reconcileReport(reportType client.Object) reconcile.Func {
 	return func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+		err := r.Client.Get(ctx, request.NamespacedName, reportType)
 		log := r.Logger.WithValues("report", request.NamespacedName)
-		if ignoreHistoricalReport(reportType) {
-			log.V(1).Info("Ignoring historical report")
-			return ctrl.Result{}, nil
-		}
+		
 		verb := Update
 
-		err := r.Client.Get(ctx, request.NamespacedName, reportType)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("getting report from cache: %w", err)
@@ -88,6 +85,11 @@ func (r *WebhookReconciler) reconcileReport(reportType client.Object) reconcile.
 				return ctrl.Result{}, nil
 			}
 			verb = Delete
+		}
+		
+		if ignoreHistoricalReport(reportType) {
+			log.V(1).Info("Ignoring historical report")
+			return ctrl.Result{}, nil
 		}
 
 		if r.WebhookSendDeletedReports {


### PR DESCRIPTION
#1208 Reading the object before checking if historical to avoid reading cached annotation.

## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
