### PR TITLE
fix: vulnerabilities report not created after k8s v1.27.x

### DIFF
--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -75,7 +75,7 @@ func (r *logsReader) podListLookup(ctx context.Context, namespace string, refres
 	matchingLableKey := "controller-uid"
 	matchingLabelValue := refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
 	if len(matchingLabelValue) == 0 {
-		matchingLableKey := "batch.kubernetes.io/controller-uid"
+		matchingLableKey = "batch.kubernetes.io/controller-uid"
 		matchingLabelValue = refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
 	}
 	selector := fmt.Sprintf("%s=%s", matchingLableKey, matchingLabelValue)

--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -75,7 +75,7 @@ func (r *logsReader) podListLookup(ctx context.Context, namespace string, refres
 	matchingLableKey := "controller-uid"
 	matchingLabelValue := refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
 	if len(matchingLabelValue) == 0 {
-		matchingLableKey = "batch.kubernetes.io/controller-uid"
+		matchingLableKey = "batch.kubernetes.io/controller-uid" // for k8s v1.27.x and above
 		matchingLabelValue = refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
 	}
 	selector := fmt.Sprintf("%s=%s", matchingLableKey, matchingLabelValue)

--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -61,9 +61,7 @@ func (r *logsReader) getPodByJob(ctx context.Context, job *batchv1.Job) (*corev1
 	if err != nil {
 		return nil, err
 	}
-	selector := fmt.Sprintf("controller-uid=%s", refreshedJob.Spec.Selector.MatchLabels["controller-uid"])
-	podList, err := r.clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: selector})
+	podList, err := r.podListLookup(ctx, job.Namespace, refreshedJob)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +69,23 @@ func (r *logsReader) getPodByJob(ctx context.Context, job *batchv1.Job) (*corev1
 		return &podList.Items[0], nil
 	}
 	return nil, nil
+}
+
+func (r *logsReader) podListLookup(ctx context.Context, namespace string, refreshedJob *batchv1.Job) (*corev1.PodList, error) {
+	label := "controller-uid"
+	selector := fmt.Sprintf("%s=%s", label, refreshedJob.Spec.Selector.MatchLabels[label])
+	podList, err := r.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if podList != nil && len(podList.Items) == 0 { // k8s controller label has changed after k8s v.1.27.x
+		label = "batch.kubernetes.io/controller-uid"
+		selector := fmt.Sprintf("%s=%s", label, refreshedJob.Spec.Selector.MatchLabels[label])
+		return r.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector})
+	}
+	return podList, nil
 }
 
 func GetTerminatedContainersStatusesByPod(pod *corev1.Pod) map[string]*corev1.ContainerStateTerminated {

--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -72,13 +72,13 @@ func (r *logsReader) getPodByJob(ctx context.Context, job *batchv1.Job) (*corev1
 }
 
 func (r *logsReader) podListLookup(ctx context.Context, namespace string, refreshedJob *batchv1.Job) (*corev1.PodList, error) {
-	matchingLableKey := "controller-uid"
-	matchingLabelValue := refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
+	matchingLabelKey := "controller-uid"
+	matchingLabelValue := refreshedJob.Spec.Selector.MatchLabels[matchingLabelKey]
 	if len(matchingLabelValue) == 0 {
-		matchingLableKey = "batch.kubernetes.io/controller-uid" // for k8s v1.27.x and above
-		matchingLabelValue = refreshedJob.Spec.Selector.MatchLabels[matchingLableKey]
+		matchingLabelKey = "batch.kubernetes.io/controller-uid" // for k8s v1.27.x and above
+		matchingLabelValue = refreshedJob.Spec.Selector.MatchLabels[matchingLabelKey]
 	}
-	selector := fmt.Sprintf("%s=%s", matchingLableKey, matchingLabelValue)
+	selector := fmt.Sprintf("%s=%s", matchingLabelKey, matchingLabelValue)
 	return r.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector})
 }


### PR DESCRIPTION
## Description
vulnerabilities report not created after k8s v1.27.x due to controller label has been change 

## Related issues
- Close #1194

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
