### PR TITLE
fix: specify confirmation in cosign invocation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -248,6 +248,7 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - "sign-blob"
+      - "--yes"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
@@ -259,6 +260,7 @@ docker_signs:
   - cmd: cosign
     args:
       - "sign"
+      - "--yes"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "${artifact}"
     artifacts: all


### PR DESCRIPTION
## Description

cosign needs the `--yes` parameter when running as a script. This
specifies it to fix the signing steps.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
