### PR TITLE
bugfix: rbac resource with capital letter name

### DIFF
--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -74,7 +74,7 @@ func (b *ReportBuilder) reportName() string {
 	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
 	name := b.controller.GetName()
 	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
+	if len(validation.IsDNS1123Label(reportName)) == 0 {
 		return reportName
 	}
 	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))

--- a/pkg/rbacassessment/builder.go
+++ b/pkg/rbacassessment/builder.go
@@ -74,7 +74,7 @@ func (b *ReportBuilder) reportName() string {
 	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
 	name := b.controller.GetName()
 	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
+	if len(validation.IsDNS1123Label(reportName)) == 0 {
 		return reportName
 	}
 	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))


### PR DESCRIPTION
When rbac resources is having capital letter in its name then trivy-operator throws error for creating its configaudit report OR rbac report. 
This happens bcoz capital letter name is not allowed in majority of the resources except rbac. 

To resolve this, we will make sure that trivy-operator doesnot try create report with capital letter, if capital letter comes then we generate report with hashvalue name
- replace IsValidLabelValue to IsDNS1123Label which allows only lower case value and other similar constraint on length

resolve: #343

