### PR TITLE
feat: create "trivy_vulerability_id" metric for each occurence

### DIFF
--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -566,9 +566,6 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
 				}
 				var vulnList = make(map[string]bool)
 				for _, vuln := range r.Report.Vulnerabilities {
-					if vulnList[vuln.VulnerabilityID] {
-						continue
-					}
 					vulnList[vuln.VulnerabilityID] = true
 					vulnLabelValues[9] = vuln.InstalledVersion
 					vulnLabelValues[10] = vuln.FixedVersion


### PR DESCRIPTION
## Description
Currently the metric `trivy_vulerability_id` will only be created once per image and CVE, even if the CVE occurs in multiple packages/libs.

With the changes in this PR, there will be one `trivy_vulnerability_id` metric for each occurence in an image (see example below).

### tested in k3d cluster 
```
$ kubectl version --short
Client Version: v1.27.2
Server Version: v1.26.4+k3s1

# deploy external dns with image from https://github.com/aquasecurity/trivy-operator/issues/1035#issue-1616780401
$ helm upgrade --install external-dns external-dns/external-dns --set image.tag=v0.12.0
Release "external-dns" does not exist. Installing it now.
NAME: external-dns
LAST DEPLOYED: Thu Jul  6 22:41:52 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
***********************************************************************
* External DNS                                                        *
***********************************************************************
  Chart version: 1.13.0
  App version:   0.13.5
  Image tag:     registry.k8s.io/external-dns/external-dns:v0.12.0
***********************************************************************

# deploy trivy-operator with "latest" image
$ helm upgrade --install trivy-operator ./deploy/helm --set targetNamespaces="default" --set operator.metricsVulnIdEnabled=true
Release "trivy-operator" does not exist. Installing it now.
NAME: trivy-operator
LAST DEPLOYED: Thu Jul  6 22:43:04 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You have installed Trivy Operator in the default namespace.
It is configured to discover Kubernetes workloads and resources in
default namespace(s).

Inspect created VulnerabilityReports by:

    kubectl get vulnerabilityreports --all-namespaces -o wide

Inspect created ConfigAuditReports by:

    kubectl get configauditreports --all-namespaces -o wide

Inspect the work log of trivy-operator by:

    kubectl logs -n default deployment/trivy-operator

# trivy creates only one metric for the CVE-2022-4450, even though it occurs multiple times in the image   (I am using CVE-2022-4450 as an example here)
$ kubectl get deploy -ojson | jq '.items[].spec.template.spec.containers[].image' &&\
kubectl exec -it svc/external-dns -- wget http://trivy-operator:8080/metrics -O - | grep CVE-2022-4450
"registry.k8s.io/external-dns/external-dns:v0.12.0"
"ghcr.io/aquasecurity/trivy-operator:0.14.1"
trivy_vulnerability_id{class="",container_name="external-dns",fixed_version="1.1.1t-r0",image_digest="",image_registry="registry.k8s.io",image_repository="external-dns/external-dns",image_tag="v0.12.0",installed_version="1.1.1n-r0",name="replicaset-external-dns-6cb567959b-external-dns",namespace="default",package_type="",resource="libcrypto1.1",resource_kind="ReplicaSet",resource_name="external-dns-6cb567959b",severity="High",vuln_id="CVE-2022-4450",vuln_score="7.5",vuln_title="double free after calling PEM_read_bio_ex"} 1

# update trivy-operator to use the locally built image with the change from this PR
$  helm upgrade --install trivy-operator ./deploy/helm --set targetNamespaces="default" --set operator.metricsVulnIdEnabled=true --set image.tag=dev
Release "trivy-operator" has been upgraded. Happy Helming!
NAME: trivy-operator
LAST DEPLOYED: Thu Jul  6 22:47:18 2023
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
You have installed Trivy Operator in the default namespace.
It is configured to discover Kubernetes workloads and resources in
default namespace(s).

Inspect created VulnerabilityReports by:

    kubectl get vulnerabilityreports --all-namespaces -o wide

Inspect created ConfigAuditReports by:

    kubectl get configauditreports --all-namespaces -o wide

Inspect the work log of trivy-operator by:

    kubectl logs -n default deployment/trivy-operator

# the new trivy-operator will create one metric for each resource the CVE occurs in
$  kubectl get deploy -ojson | jq '.items[].spec.template.spec.containers[].image' &&\
kubectl exec -it svc/external-dns -- wget http://trivy-operator:8080/metrics -O - | grep CVE-2022-4450
"registry.k8s.io/external-dns/external-dns:v0.12.0"
"ghcr.io/aquasecurity/trivy-operator:dev"
trivy_vulnerability_id{class="",container_name="external-dns",fixed_version="1.1.1t-r0",image_digest="",image_registry="registry.k8s.io",image_repository="external-dns/external-dns",image_tag="v0.12.0",installed_version="1.1.1n-r0",name="replicaset-external-dns-6cb567959b-external-dns",namespace="default",package_type="",pkg_path="",resource="libcrypto1.1",resource_kind="ReplicaSet",resource_name="external-dns-6cb567959b",severity="High",vuln_id="CVE-2022-4450",vuln_score="7.5",vuln_title="double free after calling PEM_read_bio_ex"} 1
trivy_vulnerability_id{class="",container_name="external-dns",fixed_version="1.1.1t-r0",image_digest="",image_registry="registry.k8s.io",image_repository="external-dns/external-dns",image_tag="v0.12.0",installed_version="1.1.1n-r0",name="replicaset-external-dns-6cb567959b-external-dns",namespace="default",package_type="",pkg_path="",resource="libssl1.1",resource_kind="ReplicaSet",resource_name="external-dns-6cb567959b",severity="High",vuln_id="CVE-2022-4450",vuln_score="7.5",vuln_title="double free after calling PEM_read_bio_ex"} 1
```



## Related issues
- Close #1035

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
