### PR TITLE
fix: helm sets wrong value for OPERATOR_SBOM_GENERATION_ENABLED

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
               value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
             - name: OPERATOR_SBOM_GENERATION_ENABLED
-              value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
+              value: {{ .Values.operator.sbomGenerationEnabled | quote }}
             - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
               value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
             - name: OPERATOR_SCANNER_REPORT_TTL


### PR DESCRIPTION
## Description

Addresses issue where setting helm value `operator.sbomGenerationEnabled=false` does not disable SBOM generation.

## Related issues
- Close #1381

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
