### PR TITLE
docs: add SBOM Report for webhook integrations

### DIFF
--- a/docs/tutorials/integrations/webhook.md
+++ b/docs/tutorials/integrations/webhook.md
@@ -23,3 +23,4 @@ The Webhook integration support the following reports types:
 - `clusterConfigAuditReport`
 - `clusterInfraAssessmentReport`
 - `clusterComplianceReport`
+- `sbomReport`


### PR DESCRIPTION
## Description

Webhook integration already supports SBOM Report.

https://github.com/aquasecurity/trivy-operator/blob/0496b2c75988ef93c47e849a973a2809dadc08bf/pkg/webhook/webhookreporter.go#L56


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
