### PR TITLE
fix(chart): only create servicemonitor if API supports it

### DIFF
--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.serviceMonitor.enabled true }}
+{{- if and (eq .Values.serviceMonitor.enabled true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -147,7 +147,8 @@ service:
   metricsPort: 80
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
-# you must have Prometheus already installed and running
+# you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will
+# have no effect.
 serviceMonitor:
   # -- enabled determines whether a serviceMonitor should be deployed
   enabled: false


### PR DESCRIPTION
## Description

Adds a capabilities check to the `ServiceMonitor` template to make sure that the K8s cluster does have the prometheus monitoring stack installed. If not, deploy will silently ignore the resource even if enabled.

## Related issues
None.

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
