### PR TITLE
feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "trivy-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.operator.replicas }}
+  {{- if .Values.operator.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -31,6 +31,9 @@ operator:
   # -- replicas the number of replicas of the operator's pod
   replicas: 1
 
+  # -- number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10)
+  # revisionHistoryLimit: 1
+
   # -- additional labels for the operator pod
   podLabels: {}
 


### PR DESCRIPTION
## Description
You may want to clean up old replicasets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy).

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
