### PR TITLE
chore: declare missing properties in values.yaml

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -27,6 +27,7 @@ Keeps security report resources updated
 | managedBy | string | `"Helm"` | managedBy is similar to .Release.Service but allows to overwrite the value |
 | nameOverride | string | `""` | nameOverride override operator name |
 | nodeCollector.excludeNodes | string | `nil` | excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev) |
+| nodeCollector.imagePullSecret | string | `nil` | imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace |
 | nodeCollector.registry | string | `"ghcr.io"` | registry of the node-collector image |
 | nodeCollector.repository | string | `"aquasecurity/node-collector"` | repository of the node-collector image |
 | nodeCollector.tag | string | `"0.0.6"` | tag version of the node-collector image |
@@ -57,6 +58,7 @@ Keeps security report resources updated
 | operator.privateRegistryScanSecretsNames | object | `{}` | privateRegistryScanSecretsNames is map of namespace:secrets, secrets are comma seperated which can be used to authenticate in private registries in case if there no imagePullSecrets provided example : {"mynamespace":"mySecrets,anotherSecret"} |
 | operator.rbacAssessmentScannerEnabled | bool | `true` | rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner |
 | operator.replicas | int | `1` | replicas the number of replicas of the operator's pod |
+| operator.revisionHistoryLimit | string | `nil` | number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10) |
 | operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation |
 | operator.scanJobTTL | string | `""` | scanJobTTL the set automatic cleanup time after the job is completed |
 | operator.scanJobTimeout | string | `"5m"` | scanJobTimeout the length of time to wait before giving up on a scan job |
@@ -76,24 +78,32 @@ Keeps security report resources updated
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | securityContext security context |
-| service | object | `{"metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
+| service | object | `{"annotations":{},"metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
+| service.annotations | object | `{}` | annotations added to the operator's service |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |
 | serviceMonitor.enabled | bool | `false` | enabled determines whether a serviceMonitor should be deployed |
-| serviceMonitor.interval | string | `""` | The namespace where Prometheus expects to find service monitors namespace: "" |
+| serviceMonitor.honorLabels | bool | `true` | HonorLabels chooses the metric’s labels on collisions with target labels |
+| serviceMonitor.interval | string | `nil` | Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used. |
 | serviceMonitor.labels | object | `{}` | Additional labels for the serviceMonitor |
+| serviceMonitor.namespace | string | `nil` | The namespace where Prometheus expects to find service monitors |
 | targetNamespaces | string | `""` | targetNamespace defines where you want trivy-operator to operate. By default, it's a blank string to select all namespaces, but you can specify another namespace, or a comma separated list of namespaces. |
 | targetWorkloads | string | `"pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"` | targetWorkloads is a comma seperated list of Kubernetes workload resources to be included in the vulnerability and config-audit scans if left blank, all workload resources will be scanned |
 | tolerations | list | `[]` | tolerations set the operator tolerations |
 | trivy.additionalVulnerabilityReportFields | string | `""` | additionalVulnerabilityReportFields is a comma separated list of additional fields which can be added to the VulnerabilityReport. Supported parameters: Description, Links, CVSS, Target, Class, PackagePath and PackageType |
 | trivy.command | string | `"image"` | command. One of `image`, `filesystem` or `rootfs` scanning, depending on the target type required for the scan. For 'filesystem' and `rootfs` scanning, ensure that the `trivyOperator.scanJobPodTemplateContainerSecurityContext` is configured to run as the root user (runAsUser = 0). |
 | trivy.createConfig | bool | `true` | createConfig indicates whether to create config objects |
-| trivy.dbRegistry | string | `"ghcr.io"` | serverCustomHeaders: "foo=bar" |
+| trivy.dbRegistry | string | `"ghcr.io"` |  |
 | trivy.dbRepository | string | `"aquasecurity/trivy-db"` |  |
 | trivy.dbRepositoryInsecure | string | `"false"` | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
+| trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |
+| trivy.httpProxy | string | `nil` | httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub. |
+| trivy.httpsProxy | string | `nil` | httpsProxy is the HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub. |
+| trivy.ignoreFile | string | `nil` | ignoreFile can be used to tell Trivy to ignore vulnerabilities by ID (one per line) |
 | trivy.ignoreUnfixed | bool | `false` | ignoreUnfixed is the flag to show only fixed vulnerabilities in vulnerabilities reported by Trivy. Set to true to enable it.  |
+| trivy.image.imagePullSecret | string | `nil` | imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace |
 | trivy.image.registry | string | `"ghcr.io"` | registry of the Trivy image |
 | trivy.image.repository | string | `"aquasecurity/trivy"` | repository of the Trivy image |
 | trivy.image.tag | string | `"0.43.1"` | tag version of the Trivy image |
@@ -101,6 +111,7 @@ Keeps security report resources updated
 | trivy.javaDbRegistry | string | `"ghcr.io"` | javaDbRegistry is the registry for the Java vulnerability database. |
 | trivy.javaDbRepository | string | `"aquasecurity/trivy-java-db"` |  |
 | trivy.mode | string | `"Standalone"` | mode is the Trivy client mode. Either Standalone or ClientServer. Depending on the active mode other settings might be applicable or required. |
+| trivy.noProxy | string | `nil` | noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings. |
 | trivy.nonSslRegistries | object | `{}` | Registries without SSL. There can be multiple registries with different keys. |
 | trivy.offlineScan | bool | `false` | offlineScan is the flag to enable the offline scan functionality in Trivy This will prevent outgoing HTTP requests, e.g. to search.maven.org |
 | trivy.podLabels | string | `nil` | podLabels is the extra pod labels to be used for trivy server |
@@ -110,17 +121,22 @@ Keeps security report resources updated
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |
 | trivy.server.securityContext | object | `{"privileged":false,"readOnlyRootFilesystem":true}` | securityContext set trivy-server securityContext |
+| trivy.serverCustomHeaders | string | `nil` | serverCustomHeaders is a comma separated list of custom HTTP headers sent by Trivy client to Trivy server. Only applicable in ClientServer mode. |
+| trivy.serverInsecure | bool | `false` | serverInsecure is the flag to enable insecure connection to the Trivy server. |
 | trivy.serverPassword | string | `""` | serverPassword this param is the server user to be used to download db from private registry |
 | trivy.serverServiceName | string | `"trivy-service"` | serverServiceName this param is the server service name to be used in cluster |
+| trivy.serverToken | string | `nil` | serverToken is the token to authenticate Trivy client with Trivy server. Only applicable in ClientServer mode. |
 | trivy.serverTokenHeader | string | `"Trivy-Token"` | serverTokenHeader is the name of the HTTP header used to send the authentication token to Trivy server. Only application in ClientServer mode when trivy.serverToken is specified. |
 | trivy.serverUser | string | `""` | serverUser this param is the server user to be used to download db from private registry |
 | trivy.severity | string | `"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"` | severity is a comma separated list of severity levels reported by Trivy. |
 | trivy.skipDirs | string | `nil` | a comma separated list of directories for Trivy to skip |
 | trivy.slow | bool | `true` | slow this flag is to use less CPU/memory for scanning though it takes more time than normal scanning. It fits small-footprint |
+| trivy.sslCertDir | string | `nil` | sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs |
 | trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default  |
+| trivy.vulnType | string | `nil` | vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os) |
 | trivyOperator.additionalReportLabels | string | `""` | additionalReportLabels comma-separated representation of the labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the reports with the labels `foo: bar` and `env: stage` |
 | trivyOperator.configAuditReportsPlugin | string | `"Trivy"` | configAuditReportsPlugin the name of the plugin that generates config audit reports. |
 | trivyOperator.metricsResourceLabelsPrefix | string | `"k8s_label_"` | metricsResourceLabelsPrefix Prefix that will be prepended to the labels names indicated in `reportResourceLabels` when including them in the Prometheus metrics |
@@ -137,3 +153,5 @@ Keeps security report resources updated
 | trivyOperator.scanJobTolerations | list | `[]` | scanJobTolerations tolerations to be applied to the scanner pods and node-collector so that they can run on nodes with matching taints |
 | trivyOperator.skipResourceByLabels | string | `""` | skipResourceByLabels comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels |
 | trivyOperator.vulnerabilityReportsPlugin | string | `"Trivy"` | vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy` |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |

--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -19,7 +19,7 @@ spec:
     matchLabels:
       {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
   endpoints:
-  - honorLabels: {{ .Values.serviceMonitor.honorLabels | default true }}
+  - honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     port: metrics
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -32,7 +32,7 @@ operator:
   replicas: 1
 
   # -- number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10)
-  # revisionHistoryLimit: 1
+  revisionHistoryLimit: ~
 
   # -- additional labels for the operator pod
   podLabels: {}
@@ -148,6 +148,8 @@ image:
 # trivy-operator does not have a user interface.
 service:
   metricsPort: 80
+  # -- annotations added to the operator's service
+  annotations: {}
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will
@@ -156,11 +158,13 @@ serviceMonitor:
   # -- enabled determines whether a serviceMonitor should be deployed
   enabled: false
   # -- The namespace where Prometheus expects to find service monitors
-  # namespace: ""
-  interval: ""
+  namespace: ~
+  # -- Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used.
+  interval: ~
   # -- Additional labels for the serviceMonitor
   labels: {}
-  # honorLabels: true
+  # -- HonorLabels chooses the metric’s labels on collisions with target labels
+  honorLabels: true
 
 trivyOperator:
   # -- vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy`
@@ -249,7 +253,7 @@ trivy:
     tag: 0.43.1
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
-    # imagePullSecret:
+    imagePullSecret: ~
 
   # -- mode is the Trivy client mode. Either Standalone or ClientServer. Depending
   # on the active mode other settings might be applicable or required.
@@ -269,16 +273,13 @@ trivy:
   additionalVulnerabilityReportFields: ""
 
   # -- httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub.
-  #
-  # httpProxy:
+  httpProxy: ~
 
   # -- httpsProxy is the HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub.
-  #
-  # httpsProxy:
+  httpsProxy: ~
 
   # -- noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings.
-  #
-  # noProxy:
+  noProxy: ~
 
   # -- Registries without SSL. There can be multiple registries with different keys.
   nonSslRegistries: {}
@@ -287,7 +288,7 @@ trivy:
   #  internalRegistry: registry.registry.svc:5000
 
   # -- sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs
-  # sslCertDir:
+  sslCertDir: ~
 
   # -- The registry to which insecure connections are allowed. There can be multiple registries with different keys.
   insecureRegistries: {}
@@ -321,7 +322,7 @@ trivy:
   timeout: "5m0s"
 
   # -- ignoreFile can be used to tell Trivy to ignore vulnerabilities by ID (one per line)
-  #
+  ignoreFile: ~
   # ignoreFile: |
   #   CVE-1970-0001
   #   CVE-1970-0002
@@ -338,7 +339,7 @@ trivy:
   #   # applies to all other workloads
 
   # -- vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os)
-  # vulnType:
+  vulnType: ~
 
   # -- resources resource requests and limits
   resources:
@@ -353,20 +354,18 @@ trivy:
 
   # -- githubToken is the GitHub access token used by Trivy to download the vulnerabilities
   # database from GitHub. Only applicable in Standalone mode.
-  #
-  # githubToken: "*****"
+  githubToken: ~
 
   # -- serverURL is the endpoint URL of the Trivy server. Required in ClientServer mode.
   #
   # serverURL: "https://trivy.trivy:4975"
 
   # -- serverInsecure is the flag to enable insecure connection to the Trivy server.
-  #
-  # serverInsecure: true
+  serverInsecure: false
+
   # -- serverToken is the token to authenticate Trivy client with Trivy server. Only
   # applicable in ClientServer mode.
-  #
-  # serverToken: "*****"
+  serverToken: ~
 
   # -- existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
   # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
@@ -381,8 +380,9 @@ trivy:
 
   # -- serverCustomHeaders is a comma separated list of custom HTTP headers sent by
   # Trivy client to Trivy server. Only applicable in ClientServer mode.
-  #
-  # -- serverCustomHeaders: "foo=bar"
+  serverCustomHeaders: ~
+  # serverCustomHeaders: "foo=bar"
+
   dbRegistry: "ghcr.io"
   dbRepository: "aquasecurity/trivy-db"
 
@@ -471,13 +471,13 @@ securityContext:
     drop:
       - ALL
 
-# volumeMounts:
+volumeMounts: []
 # Example:
 #  - mountPath: /tmp
 #    name: tmp-data
 #    readOnly: false
 
-# volumes:
+volumes: []
 # Example:
 #  - name: tmp-data
 #    emptyDir: {}
@@ -515,9 +515,9 @@ nodeCollector:
   repository: aquasecurity/node-collector
   # -- tag version of the node-collector image
   tag: 0.0.6
-  # imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret
+  # -- imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret
   # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
-  # imagePullSecret:
+  imagePullSecret: ~
   # -- excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev)
   excludeNodes:
   # -- node-collector pod volumeMounts definition for collecting config files information


### PR DESCRIPTION
## Description
The PR explicitly declares missing and commented properties used by the chart with empty or default values.
The PR includes minor README changes rendered by helm-docs run.
The PR does not change any functionality of the chart.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
