### PR TITLE
fix: report ttl respect scanner flags

### DIFF
--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -35,11 +35,18 @@ type TTLReportReconciler struct {
 
 func (r *TTLReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// watch reports for ttl
-	ttlResources := []kube.Resource{
-		{ForObject: &v1alpha1.VulnerabilityReport{}},
-		{ForObject: &v1alpha1.ConfigAuditReport{}},
-		{ForObject: &v1alpha1.ExposedSecretReport{}},
-		{ForObject: &v1alpha1.RbacAssessmentReport{}},
+	ttlResources := make([]kube.Resource, 0)
+	if r.Config.RbacAssessmentScannerEnabled {
+		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.RbacAssessmentReport{}})
+	}
+	if r.Config.ConfigAuditScannerEnabled {
+		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.ConfigAuditReport{}})
+	}
+	if r.Config.VulnerabilityScannerEnabled {
+		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.VulnerabilityReport{}})
+	}
+	if r.Config.ExposedSecretScannerEnabled {
+		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.ExposedSecretReport{}})
 	}
 	if r.Config.InfraAssessmentScannerEnabled {
 		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.InfraAssessmentReport{}})


### PR DESCRIPTION
## Description
the purpose of this change is for the TTL reconcile to respect scanners(vulns, exposed-secret and etc) enabled flags 

## Checklist
- [x ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant 