### PR TITLE
chore: reformat chart templates

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "trivy-operator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,23 +12,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 as a full name.
 */}}
 {{- define "trivy-operator.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "trivy-operator.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -57,17 +57,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use.
 */}}
 {{- define "trivy-operator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "trivy-operator.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- if .Values.serviceAccount.create }}
+    {{- default (include "trivy-operator.fullname" .) .Values.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use.
 */}}
 {{- define "trivy-operator.namespace" -}}
-{{- default .Release.Namespace .Values.operator.namespace }}
+  {{- default .Release.Namespace .Values.operator.namespace }}
 {{- end }}
-

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -1,11 +1,9 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: trivy-operator
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 data:
   {{- with .Values.trivyOperator.scanJobTolerations }}
   scanJob.tolerations: {{ . | toJson | quote }}
@@ -58,22 +56,22 @@ data:
   {{- if .Values.operator.clusterComplianceEnabled }}
   compliance.failEntriesLimit: {{ required ".Values.compliance.failEntriesLimit is required" .Values.compliance.failEntriesLimit | quote }}
   {{- end }}
-  {{- if .Values.trivyOperator.reportResourceLabels }}
-  report.resourceLabels: {{ .Values.trivyOperator.reportResourceLabels | quote }}
-  metrics.resourceLabelsPrefix: {{ .Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
+  {{- with .Values.trivyOperator.reportResourceLabels }}
+  report.resourceLabels: {{ . | quote }}
+  metrics.resourceLabelsPrefix: {{ $.Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
   {{- end }}
-  {{- if .Values.trivyOperator.reportRecordFailedChecksOnly }}
-  report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
+  {{- with .Values.trivyOperator.reportRecordFailedChecksOnly }}
+  report.recordFailedChecksOnly: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivyOperator.skipResourceByLabels }}
-  skipResourceByLabels: {{ .Values.trivyOperator.skipResourceByLabels | quote }}
+  {{- with .Values.trivyOperator.skipResourceByLabels }}
+  skipResourceByLabels: {{ . | quote }}
   {{- end }}
   {{- if .Values.operator.builtInTrivyServer }}
   trivy.serverURL: {{ printf "http://%s.%s:%s" .Values.trivy.serverServiceName (include "trivy-operator.namespace" .) "4954"  | quote }}
   {{- end }}
   node.collector.imageRef: "{{ .Values.nodeCollector.registry }}/{{ .Values.nodeCollector.repository }}:{{ .Values.nodeCollector.tag }}"
-  {{- if .Values.nodeCollector.imagePullSecret }}
-  node.collector.imagePullSecret: "{{ .Values.nodeCollector.imagePullSecret }}"
+  {{- with .Values.nodeCollector.imagePullSecret }}
+  node.collector.imagePullSecret: "{{ . }}"
   {{- end }}
 ---
 apiVersion: v1
@@ -81,8 +79,7 @@ kind: Secret
 metadata:
   name: trivy-operator
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 {{- if eq .Values.trivyOperator.vulnerabilityReportsPlugin "Trivy" }}
 {{- if .Values.trivy.createConfig }}
 ---
@@ -91,29 +88,28 @@ kind: ConfigMap
 metadata:
   name: trivy-operator-trivy-config
   namespace: {{ include "trivy-operator.namespace" $ }}
-  labels:
-    {{- include "trivy-operator.labels" $ | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" $ | nindent 4 }}
 data:
   trivy.repository: "{{ required ".Values.trivy.image.registry is required" .Values.trivy.image.registry }}/{{ required ".Values.trivy.image.repository is required" .Values.trivy.image.repository }}"
   trivy.tag: {{ required ".Values.trivy.image.tag is required" .Values.trivy.image.tag | quote }}
-  {{- if .Values.trivy.image.imagePullSecret }}
-  trivy.imagePullSecret: {{ .Values.trivy.image.imagePullSecret | quote }}
+  {{- with .Values.trivy.image.imagePullSecret }}
+  trivy.imagePullSecret: {{ . | quote }}
   {{- end }}
   trivy.additionalVulnerabilityReportFields: {{ .Values.trivy.additionalVulnerabilityReportFields | quote}}
-  {{- if .Values.trivy.httpProxy }}
-  trivy.httpProxy: {{ .Values.trivy.httpProxy | quote }}
+  {{- with .Values.trivy.httpProxy }}
+  trivy.httpProxy: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.httpsProxy }}
-  trivy.httpsProxy: {{ .Values.trivy.httpsProxy | quote }}
+  {{- with .Values.trivy.httpsProxy }}
+  trivy.httpsProxy: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.serverInsecure }}
-  trivy.serverInsecure: {{ .Values.trivy.serverInsecure | quote }}
+  {{- with .Values.trivy.serverInsecure }}
+  trivy.serverInsecure: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.sslCertDir }}
-  trivy.sslCertDir: {{ .Values.trivy.sslCertDir | quote }}
+  {{- with .Values.trivy.sslCertDir }}
+  trivy.sslCertDir: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.noProxy }}
-  trivy.noProxy: {{ .Values.trivy.noProxy | quote }}
+  {{- with .Values.trivy.noProxy }}
+  trivy.noProxy: {{ . | quote }}
   {{- end }}
   {{- range $key, $registry := .Values.trivy.nonSslRegistries }}
   trivy.nonSslRegistry.{{ $key }}: {{ $registry | quote }}
@@ -129,38 +125,38 @@ data:
   trivy.dbRepository: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
   trivy.javaDbRepository: "{{ .Values.trivy.javaDbRegistry }}/{{ .Values.trivy.javaDbRepository }}"
   trivy.command: {{ .Values.trivy.command | quote }}
-  {{- if .Values.trivy.skipDirs }}
-  trivy.skipDirs: {{ .Values.trivy.skipDirs | quote }}
+  {{- with .Values.trivy.skipDirs }}
+  trivy.skipDirs: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.vulnType }}
-  trivy.vulnType: {{ .Values.trivy.vulnType | quote }}
+  {{- with .Values.trivy.vulnType }}
+  trivy.vulnType: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.dbRepositoryInsecure }}
-  trivy.dbRepositoryInsecure: {{ .Values.trivy.dbRepositoryInsecure | quote }}
+  {{- with .Values.trivy.dbRepositoryInsecure }}
+  trivy.dbRepositoryInsecure: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.useBuiltinRegoPolicies }}
-  trivy.useBuiltinRegoPolicies: {{ .Values.trivy.useBuiltinRegoPolicies | quote }}
+  {{- with .Values.trivy.useBuiltinRegoPolicies }}
+  trivy.useBuiltinRegoPolicies: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.offlineScan }}
-  trivy.offlineScan: {{ .Values.trivy.offlineScan | quote }}
+  {{- with .Values.trivy.offlineScan }}
+  trivy.offlineScan: {{ . | quote }}
   {{- end }}
   trivy.supportedConfigAuditKinds: {{ .Values.trivy.supportedConfigAuditKinds | quote }}
-  {{- if .Values.trivy.ignoreUnfixed }}
-  trivy.ignoreUnfixed: {{ .Values.trivy.ignoreUnfixed | quote }}
+  {{- with .Values.trivy.ignoreUnfixed }}
+  trivy.ignoreUnfixed: {{ . | quote }}
   {{- end }}
-  {{- if .Values.trivy.timeout }}
-  trivy.timeout: {{ .Values.trivy.timeout | quote }}
+  {{- with .Values.trivy.timeout }}
+  trivy.timeout: {{ . | quote }}
   {{- end }}
   {{- with .Values.trivy.ignoreFile }}
   trivy.ignoreFile: |
-{{- . | trim | nindent 4 }}
+    {{- . | trim | nindent 4 }}
   {{- end }}
-{{- range $k, $v := .Values.trivy }}
+  {{- range $k, $v := .Values.trivy }}
   {{- if hasPrefix "ignorePolicy" $k }}
   trivy.{{- $k }}: |
-{{- $v | trim | nindent 4 }}
+    {{- $v | trim | nindent 4 }}
   {{- end }}
-{{- end }}
+  {{- end }}
   {{- if .Values.operator.builtInTrivyServer }}
   trivy.serverURL: {{ printf "http://%s.%s:%s" .Values.trivy.serverServiceName (include "trivy-operator.namespace" .) "4954"  | quote }}
   trivy.mode: "ClientServer"
@@ -170,29 +166,23 @@ data:
   trivy.serverURL: {{ required ".Values.trivy.serverURL is required" .Values.trivy.serverURL | quote }}
   {{- end }}
   {{- end }}
-  {{- with .Values.trivy.resources }}
-    {{- with .requests }}
-      {{- if .cpu }}
-  trivy.resources.requests.cpu: {{ .cpu | quote }}
-      {{- end }}
-      {{- if hasKey . "memory" }}
-  trivy.resources.requests.memory: {{ .memory | quote }}
-      {{- end }}
-      {{- if hasKey . "ephemeralStorage" }}
-  trivy.resources.requests.ephemeral-storage: {{ .ephemeralStorage | quote }}
-      {{- end }}
-    {{- end }}
-    {{- with .limits }}
-      {{- if .cpu }}
-  trivy.resources.limits.cpu: {{ .cpu | quote }}
-      {{- end }}
-      {{- if .memory }}
-  trivy.resources.limits.memory: {{ .memory | quote }}
-      {{- end }}
-      {{- if hasKey . "ephemeralStorage" }}
-  trivy.resources.limits.ephemeral-storage: {{  .ephemeralStorage | quote }}
-      {{- end }}
-    {{- end }}
+  {{- with dig "resources" "requests" "cpu" "" .Values.trivy }}
+  trivy.resources.requests.cpu: {{ . | quote }}
+  {{- end }}
+  {{- with dig "resources" "requests" "memory" "" .Values.trivy }}
+  trivy.resources.requests.memory: {{ . | quote }}
+  {{- end }}
+  {{- with dig "resources" "requests" "ephemeralStorage" "" .Values.trivy }}
+  trivy.resources.requests.ephemeral-storage: {{ . | quote }}
+  {{- end }}
+  {{- with dig "resources" "limits" "cpu" "" .Values.trivy }}
+  trivy.resources.limits.cpu: {{ . | quote }}
+  {{- end }}
+  {{- with dig "resources" "limits" "memory" "" .Values.trivy }}
+  trivy.resources.limits.memory: {{ . | quote }}
+  {{- end }}
+  {{- with dig "resources" "limits" "ephemeralStorage" "" .Values.trivy }}
+  trivy.resources.limits.ephemeral-storage: {{ . | quote }}
   {{- end }}
   {{- if .Values.operator.builtInTrivyServer }}
   TRIVY_LISTEN: "0.0.0.0:4954"
@@ -203,35 +193,34 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
----
 {{- if not .Values.trivy.existingSecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: trivy-operator-trivy-config
   namespace: {{ include "trivy-operator.namespace" $ }}
-  labels:
-    {{- include "trivy-operator.labels" $ | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" $ | nindent 4 }}
 data:
-  {{- if .Values.trivy.githubToken }}
-  trivy.githubToken: {{ .Values.trivy.githubToken | b64enc | quote }}
+  {{- with .Values.trivy.githubToken }}
+  trivy.githubToken: {{ . | b64enc | quote }}
   {{- end }}
   {{- if or (eq .Values.trivy.mode "ClientServer") .Values.operator.builtInTrivyServer }}
-  {{- if .Values.trivy.serverToken }}
-  trivy.serverToken: {{ .Values.trivy.serverToken | b64enc | quote }}
+  {{- with .Values.trivy.serverToken }}
+  trivy.serverToken: {{ . | b64enc | quote }}
   {{- end }}
-  {{- if .Values.trivy.serverCustomHeaders }}
-  trivy.serverCustomHeaders: {{ .Values.trivy.serverCustomHeaders | b64enc | quote }}
+  {{- with .Values.trivy.serverCustomHeaders }}
+  trivy.serverCustomHeaders: {{ . | b64enc | quote }}
   {{- end }}
   {{- end }}
-{{- if .Values.operator.builtInTrivyServer }}
-  {{- if .Values.trivy.githubToken }}
-  GITHUB_TOKEN: {{ .Values.trivy.githubToken | b64enc | quote }}
+  {{- if .Values.operator.builtInTrivyServer }}
+  {{- with .Values.trivy.githubToken }}
+  GITHUB_TOKEN: {{ . | b64enc | quote }}
   {{- end }}
-  {{- if .Values.trivy.serverToken }}
-  TRIVY_TOKEN: {{ .Values.trivy.serverToken | b64enc | quote }}
+  {{- with .Values.trivy.serverToken }}
+  TRIVY_TOKEN: {{ . | b64enc | quote }}
   {{- end }}
   TRIVY_USERNAME: {{ .Values.trivy.serverUser  | b64enc | quote }}
   TRIVY_PASSWORD: {{ .Values.trivy.serverPassword  | b64enc | quote }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -3,28 +3,25 @@ kind: Deployment
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.operator.replicas }}
-  {{- if .Values.operator.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit }}
+  {{- with .Values.operator.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
   {{- end }}
   strategy:
     type: Recreate
   selector:
-    matchLabels:
-      {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
-      annotations:
-        {{- . | toYaml | nindent 8 }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "trivy-operator.selectorLabels" . | nindent 8 }}
-        {{- if .Values.operator.podLabels }}
-        {{- toYaml .Values.operator.podLabels | nindent 8 }}
+        {{- with .Values.operator.podLabels }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "trivy-operator.serviceAccountName" . }}
@@ -143,38 +140,33 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 10
-          resources:
-            {{- .Values.resources | toYaml | nindent 12 }}
+          {{- with .Values.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.securityContext }}
-          securityContext:
-            {{- . | toYaml | nindent 12 }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.volumeMounts }}
-          volumeMounts:
-            {{- . | toYaml | nindent 12 }}
+          volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.image.pullSecrets }}
-      imagePullSecrets:
-        {{- . | toYaml | nindent 8 }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.volumes }}
-      volumes:
-        {{- . | toYaml | nindent 8 }}
+      volumes: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- . | toYaml | nindent 8 }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
-      affinity:
-        {{- . | toYaml | nindent 8 }}
+      affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
-      tolerations:
-        {{- . | toYaml | nindent 8 }}
+      tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}

--- a/deploy/helm/templates/leader-election.yaml
+++ b/deploy/helm/templates/leader-election.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.rbac.create}}
----
+{{- if .Values.rbac.create }}
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "trivy-operator.fullname" . }}-leader-election
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -29,8 +27,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "trivy-operator.fullname" . }}-leader-election
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -39,4 +36,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "trivy-operator.serviceAccountName" . }}
     namespace: {{ include "trivy-operator.namespace" . }}
-{{- end}}
+{{- end }}

--- a/deploy/helm/templates/ns.yaml
+++ b/deploy/helm/templates/ns.yaml
@@ -1,14 +1,11 @@
 {{- if .Values.operator.namespace }}
 {{- if not (lookup "v1" "Namespace" "" .Values.operator.namespace) }}
 {{- if not (eq .Release.Namespace .Values.operator.namespace) }}
-
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.operator.namespace }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
-
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -1,15 +1,12 @@
-{{- if .Values.serviceAccount.create -}}
----
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "trivy-operator.serviceAccountName" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- . | toYaml | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
 
@@ -37,8 +34,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -53,8 +49,7 @@ kind: Role
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -79,8 +74,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -90,7 +84,6 @@ subjects:
     name: {{ include "trivy-operator.serviceAccountName" . }}
     namespace: {{ include "trivy-operator.namespace" . }}
 {{- end }}
-
 ---
 # permissions for end users to view configauditreports
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -3,11 +3,9 @@ kind: Service
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels:
-    {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
-  annotations:
-    {{- . | toYaml | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   clusterIP: None
@@ -16,5 +14,4 @@ spec:
       port: {{ .Values.service.metricsPort }}
       targetPort: metrics
       protocol: TCP
-  selector:
-    {{- include "trivy-operator.selectorLabels" . | nindent 4 }}
+  selector: {{- include "trivy-operator.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
-    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.serviceMonitor.namespace }}
@@ -16,8 +16,7 @@ spec:
     - {{ include "trivy-operator.namespace" . }}
   {{- end }}
   selector:
-    matchLabels:
-      {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
   endpoints:
   - honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     port: metrics

--- a/deploy/helm/templates/specs/cis-1.23.yaml
+++ b/deploy/helm/templates/specs/cis-1.23.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:

--- a/deploy/helm/templates/specs/nsa-1.0.yaml
+++ b/deploy/helm/templates/specs/nsa-1.0.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:

--- a/deploy/helm/templates/specs/pss-baseline.yaml
+++ b/deploy/helm/templates/specs/pss-baseline.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:

--- a/deploy/helm/templates/specs/pss-restricted.yaml
+++ b/deploy/helm/templates/specs/pss-restricted.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:

--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.operator.builtInTrivyServer }}
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,7 +18,6 @@ spec:
       port: 4954
       targetPort: 4954
   sessionAffinity: ClientIP
-
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -60,42 +58,40 @@ spec:
         app.kubernetes.io/name: trivy-server
         app.kubernetes.io/instance: trivy-server
     spec:
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.trivy.priorityClassName }}
+      {{- with .Values.trivy.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "trivy-operator.serviceAccountName" . }}
       automountServiceAccountToken: false
-      {{- if .Values.trivy.server.podSecurityContext }}
-      securityContext:
-{{ toYaml .Values.trivy.server.podSecurityContext | indent 8 }}
+      {{- with .Values.trivy.server.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.trivy.image.imagePullSecret }}
+      {{- with .Values.trivy.image.imagePullSecret }}
       imagePullSecrets:
-      - name:  {{ .Values.trivy.image.imagePullSecret }}
+      - name:  {{ . }}
       {{- end }}
       containers:
         - name: main
           image: "{{ .Values.trivy.image.registry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
           imagePullPolicy: "IfNotPresent"
-          {{- if .Values.trivy.server.securityContext }}
-          securityContext:
-{{ toYaml .Values.trivy.server.securityContext | indent 12 }}
+          {{- with .Values.trivy.server.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - server
           {{- if or (or .Values.trivy.httpProxy .Values.trivy.httpsProxy) .Values.trivy.noProxy }}
           env:
-            {{- if .Values.trivy.httpProxy }}
+            {{- with .Values.trivy.httpProxy }}
             - name: HTTP_PROXY
-              value: {{ .Values.trivy.httpProxy }}
+              value: {{ . }}
             {{- end }}
-            {{- if .Values.trivy.httpsProxy }}
+            {{- with .Values.trivy.httpsProxy }}
             - name: HTTPS_PROXY
-              value: {{ .Values.trivy.httpsProxy }}
+              value: {{ . }}
             {{- end }}
-            {{- if .Values.trivy.noProxy }}
+            {{- with .Values.trivy.noProxy }}
             - name: NO_PROXY
-              value: {{ .Values.trivy.noProxy }}
+              value: {{ . }}
             {{- end }}
           {{- end }}
           envFrom:
@@ -131,19 +127,16 @@ spec:
             - mountPath: /home/scanner/.cache
               name: data
               readOnly: false
-          {{- with .Values.trivy.server }}
-          resources:
-            {{- .resources | toYaml | nindent 12 }}
+          {{- with .Values.trivy.server.resources }}
+          resources: {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         - name: tmp-data
           emptyDir: {}
       {{- with .Values.tolerations }}
-      tolerations:
-        {{- . | toYaml | nindent 8 }}
+      tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- . | toYaml | nindent 8 }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end}}
+{{- end }}

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2316,8 +2316,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 10
-          resources:
-            {}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2325,10 +2323,8 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-      securityContext:
-        {}
 ---
-# Source: trivy-operator/templates/leader_election.yaml
+# Source: trivy-operator/templates/leader-election.yaml
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2356,7 +2352,7 @@ rules:
     verbs:
       - create
 ---
-# Source: trivy-operator/templates/leader_election.yaml
+# Source: trivy-operator/templates/leader-election.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Description
The PR reformats chart templates to common style with more readable blocks and indents.
ConfigMap `trivy-operator-policies-config` has been deleted, because it does not have any data.

The PR does not change any functionality of the chart.
Similar PRs: https://github.com/apache/airflow/pull/29917 https://github.com/apache/airflow/pull/29941 https://github.com/apache/airflow/pull/30312 https://github.com/minio/minio/pull/16947 https://github.com/apache/superset/pull/23681

## Test
The following command prints same (minor differences) output before and after changes:
```sh
helm template test deploy/helm
```

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
