### PR TITLE
feat: Add additional values for ServiceMonitor in helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # trivy-operator
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
 
 Keeps security report resources updated
 
@@ -83,7 +83,9 @@ Keeps security report resources updated
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |
+| serviceMonitor.annotations | object | `{}` | Additional annotations for the serviceMonitor |
 | serviceMonitor.enabled | bool | `false` | enabled determines whether a serviceMonitor should be deployed |
+| serviceMonitor.endpointAdditionalProperties | object | `{}` | EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc. |
 | serviceMonitor.honorLabels | bool | `true` | HonorLabels chooses the metric’s labels on collisions with target labels |
 | serviceMonitor.interval | string | `nil` | Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used. |
 | serviceMonitor.labels | object | `{}` | Additional labels for the serviceMonitor |

--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ .Values.serviceMonitor.namespace | default (include "trivy-operator.namespace" . ) }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
@@ -24,4 +28,9 @@ spec:
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}
     scheme: http
+    {{- if .Values.serviceMonitor.endpointAdditionalProperties }}
+    {{- with .Values.serviceMonitor.endpointAdditionalProperties }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -161,10 +161,14 @@ serviceMonitor:
   namespace: ~
   # -- Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used.
   interval: ~
+  # -- Additional annotations for the serviceMonitor
+  annotations: {}
   # -- Additional labels for the serviceMonitor
   labels: {}
   # -- HonorLabels chooses the metric’s labels on collisions with target labels
   honorLabels: true
+  # -- EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
+  endpointAdditionalProperties: {}
 
 trivyOperator:
   # -- vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy`


### PR DESCRIPTION
## Description

- Allows setting `annotations` to the ServiceMonitor resource. Useful for things like https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types
- Allows setting `endpointAdditionalProperties` such as `relabeling`, `metricRelabelings` etc.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
