### PR TITLE
add: preserve unknown fields in vulnerabilityreport

### DIFF
--- a/deploy/helm/crds/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/deploy/helm/crds/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -264,6 +264,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2092,6 +2092,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -98,6 +98,7 @@ type Vulnerability struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:pruning:PreserveUnknownFields
 // +kubebuilder:resource:shortName={vuln,vulns}
 // +kubebuilder:printcolumn:name="Repository",type=string,JSONPath=`.report.artifact.repository`,description="The name of image repository"
 // +kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.report.artifact.tag`,description="The name of image tag"


### PR DESCRIPTION
## Description

I built a custom operator (https://github.com/telekom-mms/trivy-dojo-report-operator) that uses the kopf-operator (github.com/nolar/kopf/) framework. This framework can act on kubernetes-resource creation. To detect which resources were already worked on, kopf adds a the last state of the resource as an annotation or status to the resource.I cannot use the annotation-feature, because of this issue: https://github.com/kubernetes-sigs/kubebuilder/issues/2556 (annotations get too long).

So my proposal is to preserve unknown fields in the vulnerabilityreport-crd. This way I can add a status-field which kopf then can use to store the state.


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
