### PR TITLE
ability to opt-out persistent volume claim for trivy-server

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -136,6 +136,7 @@ Keeps security report resources updated
 | trivy.skipJavaDBUpdate | bool | `false` | skipJavaDBUpdate is the flag to enable skip Java index databases update for Trivy client. |
 | trivy.slow | bool | `true` | slow this flag is to use less CPU/memory for scanning though it takes more time than normal scanning. It fits small-footprint |
 | trivy.sslCertDir | string | `nil` | sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs |
+| trivy.storageClassEnabled | string | `true` | storageClassEnabled controls whether to use a storage class for trivy server or emptydir (one may want to use ephemeral storage) |
 | trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -136,8 +136,8 @@ Keeps security report resources updated
 | trivy.skipJavaDBUpdate | bool | `false` | skipJavaDBUpdate is the flag to enable skip Java index databases update for Trivy client. |
 | trivy.slow | bool | `true` | slow this flag is to use less CPU/memory for scanning though it takes more time than normal scanning. It fits small-footprint |
 | trivy.sslCertDir | string | `nil` | sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs |
-| trivy.storageClassEnabled | string | `true` | storageClassEnabled controls whether to use a storage class for trivy server or emptydir (one may want to use ephemeral storage) |
-| trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC |
+| trivy.storageClassEnabled | bool | `true` | whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage) |
+| trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default  |

--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -35,6 +35,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: trivy-server
       app.kubernetes.io/instance: trivy-server
+  {{- if .Values.trivy.storageClassEnabled }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -47,6 +48,7 @@ spec:
         accessModes:
           - ReadWriteOnce
         storageClassName: {{ .Values.trivy.storageClassName }}
+  {{- end }}        
   template:
     metadata:
       annotations:
@@ -133,6 +135,10 @@ spec:
       volumes:
         - name: tmp-data
           emptyDir: {}
+        {{- if not .Values.trivy.storageClassEnabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -266,7 +266,10 @@ trivy:
   # on the active mode other settings might be applicable or required.
   mode: Standalone
 
-  # -- storageClassName is the name of the storage class to be used for trivy server PVC
+  # -- whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage)
+  storageClassEnabled: true
+  
+  # -- storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class
   storageClassName: ""
 
   # -- podLabels is the extra pod labels to be used for trivy server

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -268,7 +268,7 @@ trivy:
 
   # -- whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage)
   storageClassEnabled: true
-  
+
   # -- storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class
   storageClassName: ""
 


### PR DESCRIPTION
## Description

Added a new config value under `trivy.storageClassEnabled`.
In it's very simplistic implementation:
- value is `true`: Helm chart is rendered with `kind: PersistentVolumeClaim` as `data` volume.  
- value is `false`: Will *not* render `kind: PersistentVolumeClaim`, but configure a volume `data` as `emptyDir` instead.

> This setting is left `true` by default, avoiding any existing compatibility issues.

## Related issues
- Close #1456

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
