### PR TITLE
chore: reformat missed chart templates

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -165,8 +165,8 @@ data:
   trivy.mode: {{ .Values.trivy.mode | quote }}
   {{- if eq .Values.trivy.mode "ClientServer" }}
   trivy.serverURL: {{ required ".Values.trivy.serverURL is required" .Values.trivy.serverURL | quote }}
-  {{- if .Values.trivy.clientServerSkipUpdate }}
-  trivy.clientServerSkipUpdate: {{ .Values.trivy.clientServerSkipUpdate | quote }}
+  {{- with .Values.trivy.clientServerSkipUpdate }}
+  trivy.clientServerSkipUpdate: {{ . | quote }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -4,14 +4,13 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ .Values.serviceMonitor.namespace | default (include "trivy-operator.namespace" . ) }}
-  {{- if .Values.serviceMonitor.annotations }}
-  annotations:
-    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
-    {{- if .Values.serviceMonitor.labels }}
-      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.serviceMonitor.namespace }}
@@ -24,13 +23,11 @@ spec:
   endpoints:
   - honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     port: metrics
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
     {{- end }}
     scheme: http
-    {{- if .Values.serviceMonitor.endpointAdditionalProperties }}
     {{- with .Values.serviceMonitor.endpointAdditionalProperties }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
The PR reformats chart templates missed in the PR https://github.com/aquasecurity/trivy-operator/pull/1439 and fixes formatting introduced in the PR https://github.com/aquasecurity/trivy-operator/pull/1452.
The PR does not change any functionality of the chart.

## Related issues
- https://github.com/aquasecurity/trivy-operator/pull/1439
- https://github.com/aquasecurity/trivy-operator/pull/1452

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
