### PR TITLE
feat: Automatically build helm chart on PR merge

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -4,11 +4,11 @@
 name: Publish Helm chart
 
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: The branch, tag or SHA to publish, e.g. v0.0.1
-        required: true
+  pull_request_target:
+    types:
+      - closed
+    paths:
+      - 'deploy/helm/Chart.yaml'
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
@@ -17,12 +17,12 @@ env:
   KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 jobs:
   release:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v1.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,9 +57,8 @@
        `public.ecr.aws/aquasecurity/trivy-operator:0.15.1`
    2. Trivy-operator container images published to GitHub Container Registry
        `ghcr.io/aquasecurity/trivy-operator:0.15.1`
-7. Publish the Helm chart by manually triggering the [`.github/workflows/publish-helm-chart.yaml`] workflow
-8. Publish docs on <https://aquasecurity.github.io/trivy-operator/> by manually triggering the [`.github/workflows/publish-docs.yaml`] workflow
-9. Submit trivy-operator Operator to OperatorHub and ArtifactHUB by opening the PR to the <https://github.com/k8s-operatorhub/community-operators> repository.
+7. Publish docs on <https://aquasecurity.github.io/trivy-operator/> by manually triggering the [`.github/workflows/publish-docs.yaml`] workflow
+8. Submit trivy-operator Operator to OperatorHub and ArtifactHUB by opening the PR to the <https://github.com/k8s-operatorhub/community-operators> repository.
 
 [`deploy/helm/Chart.yaml`]: ./deploy/helm/Chart.yaml
 [`deploy/static/namespace.yaml`]: ./deploy/static/namespace.yaml

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # trivy-operator
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
 
 Keeps security report resources updated
 


### PR DESCRIPTION
## Description

Currently the helm chart version is tied to the application version and thus tied to the application release cycle.  
With this PR, a new helm chart gets automatically published if the file `Chart.yaml` has changed on a PR merge.

Can't be tested in a feature branch, for this reason I can't ensure this works as intended.

## Related issues
- Close #701

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
