### PR TITLE
feat: use serverServiceName as container name

### DIFF
--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -73,7 +73,7 @@ spec:
       - name:  {{ . }}
       {{- end }}
       containers:
-        - name: {{ .Values.trivy.serverServiceName }}
+        - name: trivy-server
           image: "{{ .Values.trivy.image.registry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
           imagePullPolicy: "IfNotPresent"
           {{- with .Values.trivy.server.securityContext }}

--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -73,7 +73,7 @@ spec:
       - name:  {{ . }}
       {{- end }}
       containers:
-        - name: main
+        - name: {{ .Values.trivy.serverServiceName }}
           image: "{{ .Values.trivy.image.registry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
           imagePullPolicy: "IfNotPresent"
           {{- with .Values.trivy.server.securityContext }}


### PR DESCRIPTION
## Description

To improve the monitoring of containers in our environment. It would be helpful if the trivy-server container had a clearer name. The current name `main` can be confusing.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
