### PR TITLE
feat: make trivy-server replicas configurable

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -122,6 +122,7 @@ Keeps security report resources updated
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
+| trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |
 | trivy.server.securityContext | object | `{"privileged":false,"readOnlyRootFilesystem":true}` | securityContext set trivy-server securityContext |
 | trivy.serverCustomHeaders | string | `nil` | serverCustomHeaders is a comma separated list of custom HTTP headers sent by Trivy client to Trivy server. Only applicable in ClientServer mode. |

--- a/deploy/helm/templates/trivy-server.yaml
+++ b/deploy/helm/templates/trivy-server.yaml
@@ -30,7 +30,7 @@ metadata:
 spec:
   podManagementPolicy: "Parallel"
   serviceName: {{ .Values.trivy.serverServiceName }}
-  replicas: 1
+  replicas: {{ .Values.trivy.server.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: trivy-server

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -455,6 +455,9 @@ trivy:
       privileged: false
       readOnlyRootFilesystem: true
 
+    # -- the number of replicas of the trivy-server
+    replicas: 1
+
 compliance:
   # -- failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report
   failEntriesLimit: 10


### PR DESCRIPTION
## Description

Makes trivy-server replicas configurable.

## Related issues
- Close #1321 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added usage information (if the PR introduces new options)
