### PR TITLE
feat: use TRIVY_SKIP_DB_UPDATE env variable

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -192,7 +192,7 @@ data:
   TRIVY_LISTEN: "0.0.0.0:4954"
   TRIVY_CACHE_DIR: "/home/scanner/.cache/trivy"
   TRIVY_DEBUG: {{ .Values.trivy.debug | quote }}
-  TRIVY_SKIP_UPDATE: "false"
+  TRIVY_SKIP_DB_UPDATE: "false"
   TRIVY_DB_REPOSITORY: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

While starting the builtInTrivyServer the following log message is being displayed:

```
'TRIVY_SKIP_UPDATE' is deprecated. Use 'TRIVY_SKIP_DB_UPDATE' instead.
```

This PR will update the configured environment variable.


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.