### PR TITLE
feat: Implement global chart values for image.registry

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -19,6 +19,7 @@ Keeps security report resources updated
 | compliance.reportType | string | `"summary"` | reportType this flag control the type of report generated (summary or all) |
 | excludeNamespaces | string | `""` | excludeNamespaces is a comma separated list of namespaces (or glob patterns) to be excluded from scanning. Only applicable in the all namespaces install mode, i.e. when the targetNamespaces values is a blank string. |
 | fullnameOverride | string | `""` | fullnameOverride override operator full name |
+| global.image.registry | string | `""` | global populates the same value for each instance of image.registry |
 | image.pullPolicy | string | `"IfNotPresent"` | pullPolicy set the operator pullPolicy |
 | image.pullSecrets | list | `[]` | pullSecrets set the operator pullSecrets |
 | image.registry | string | `"ghcr.io"` |  |

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -70,3 +70,12 @@ Create the name of the service account to use.
 {{- define "trivy-operator.namespace" -}}
   {{- default .Release.Namespace .Values.operator.namespace }}
 {{- end }}
+
+{{/*
+Define the image registry to use if global values are set.
+*/}}
+{{- define "global.imageRegistry" -}}
+{{- if ((.Values.global).image).registry -}}
+  {{- .Values.global.image.registry }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -70,7 +70,7 @@ data:
   {{- if .Values.operator.builtInTrivyServer }}
   trivy.serverURL: {{ printf "http://%s.%s:%s" .Values.trivy.serverServiceName (include "trivy-operator.namespace" .) "4954"  | quote }}
   {{- end }}
-  node.collector.imageRef: "{{ .Values.nodeCollector.registry }}/{{ .Values.nodeCollector.repository }}:{{ .Values.nodeCollector.tag }}"
+  node.collector.imageRef: "{{ include "global.imageRegistry" . | default .Values.nodeCollector.registry }}/{{ .Values.nodeCollector.repository }}:{{ .Values.nodeCollector.tag }}"
   {{- with .Values.nodeCollector.imagePullSecret }}
   node.collector.imagePullSecret: "{{ . }}"
   {{- end }}

--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ include "trivy-operator.namespace" $ }}
   labels: {{- include "trivy-operator.labels" $ | nindent 4 }}
 data:
-  trivy.repository: "{{ required ".Values.trivy.image.registry is required" .Values.trivy.image.registry }}/{{ required ".Values.trivy.image.repository is required" .Values.trivy.image.repository }}"
+  trivy.repository: "{{ required ".Values.trivy.image.registry is required" ( include "global.imageRegistry" . | default .Values.trivy.image.registry ) }}/{{ required ".Values.trivy.image.repository is required" .Values.trivy.image.repository }}"
   trivy.tag: {{ required ".Values.trivy.image.tag is required" .Values.trivy.image.tag | quote }}
   {{- with .Values.trivy.image.imagePullSecret }}
   trivy.imagePullSecret: {{ . | quote }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name | quote }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "global.imageRegistry" . | default .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/deploy/helm/templates/trivy-server/statefulset.yaml
+++ b/deploy/helm/templates/trivy-server/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
         - name: trivy-server
-          image: "{{ .Values.trivy.image.registry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
+          image: "{{ include "global.imageRegistry" . | default .Values.trivy.image.registry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
           imagePullPolicy: "IfNotPresent"
           {{- with .Values.trivy.server.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,12 @@
 # Default values for the trivy-operator Helm chart, these are used to render
 # the templates into valid k8s Resources.
 
+# -- global values provide a centralized configuration for 'image.registry', reducing the potential for errors.
+# If left blank, the chart will default to the individually set 'image.registry' values
+global:
+  image:
+    registry: ""
+
 # -- managedBy is similar to .Release.Service but allows to overwrite the value
 managedBy: Helm
 


### PR DESCRIPTION
## Description

This PR provides a single global value to set the `image.registry` values used multiple times inside the chart. This makes it easier to change the `image.registry` across all values without inconsistencies. 

Also, global values are accessible by parent and sub-charts, which makes it easier to handle in multi-chart environments.

These change only affects Helm deployments, it does not modify any Trivy Operator components.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
