### PR TITLE
feat(manifests): add metrics component for static installation

### DIFF
--- a/deploy/static/components/metrics/kustomization.yaml
+++ b/deploy/static/components/metrics/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - metrics.yaml

--- a/deploy/static/components/metrics/metrics.yaml
+++ b/deploy/static/components/metrics/metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trivy-operator
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+spec:
+  namespaceSelector:
+    any: false
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+      app.kubernetes.io/instance: trivy-operator
+  endpoints:
+    - honorLabels: true
+      port: metrics
+      scheme: http


### PR DESCRIPTION
## Description

In order to provide "feature parity" with the chart, a component is proposed to expose the ServiceMonitor manifest. It can be consumed by anyone using a remote component or by downloading it and using it locally like the original chart.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

About the checklist, let me know what you would like for this, and I'll adjust the PR accordingly. 