### PR TITLE
feat: make headless service configurable

### DIFF
--- a/deploy/helm/templates/monitor/service.yaml
+++ b/deploy/helm/templates/monitor/service.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{ if .Values.service.headless }}
   clusterIP: None
+  {{ end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -153,6 +153,7 @@ image:
 # -- service only expose a metrics endpoint for prometheus to scrape,
 # trivy-operator does not have a user interface.
 service:
+  headless: true
   metricsPort: 80
   # -- annotations added to the operator's service
   annotations: {}


### PR DESCRIPTION
## Description
Add headless monitor service configurable

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

For a better usability of the helm chart it may be useful to make the headless service configurable. This is just relevant if you want to export the metrics and scrape them with prometheus.
With this configuration flag, it is not necessary anymore to adjust the service deployment by hand.