### PR TITLE
docs: change command value fs to filesystem in private-registries tutorial

### DIFF
--- a/docs/tutorials/private-registries.md
+++ b/docs/tutorials/private-registries.md
@@ -33,7 +33,7 @@ Next, we will change the the `command` and the `trivyOperator.scanJobPodTemplate
 
 ```sh
 trivy:
-    command: fs
+    command: filesystem
     ignoreUnfixed: true
 trivyOperator:
     scanJobPodTemplateContainerSecurityContext:


### PR DESCRIPTION
The tutorial states you need to use `command: fs` while it earlier also states it needs to be filesystem. 

the value `fs` won't work.

## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
