### PR TITLE
feat: Added AWS_REGION env for ECR images in the ClientServer mode

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -401,6 +401,14 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 			})
 		}
 
+		region := CheckAwsEcrPrivateRegistry(container.Image)
+		if region != "" {
+			env = append(env, corev1.EnvVar{
+				Name:  "AWS_REGION",
+				Value: region,
+			})
+		}
+
 		if auth, ok := containersCredentials[container.Name]; ok && secret != nil {
 			if checkGcpCrOrPivateRegistry(container.Image) && auth.Username == "_json_key" {
 				registryServiceAccountAuthKey := fmt.Sprintf("%s.password", container.Name)


### PR DESCRIPTION
## Description
Scan pods can't pull images from ECR when AWS_REGION variable not set.
Added AWS_REGION environment variable for Amazon Elastic Container Registry images in the ClientServer mode

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
