### PR TITLE
fix: handle trivy insecure database in ClientServer mode

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -456,7 +456,12 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 				Value: "true",
 			})
 		}
-
+		if config.GetDBRepositoryInsecure() {
+			env = append(env, corev1.EnvVar{
+				Name:  "TRIVY_INSECURE",
+				Value: "true",
+			})
+		}
 		requirements, err := config.GetResourceRequirements()
 		if err != nil {
 			return corev1.PodSpec{}, nil, err


### PR DESCRIPTION
## Description

This will allow  `trivy.dbRepositoryInsecure: "true"` setting to work also in ClienServer mode. Useful for javaDbRepository which is (AFAIK) not stored on Server

## Related issues
- Close #1590

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
