### PR TITLE
feat: add dbRepositoryUsername and dbRepositoryPassword for dbReposit…

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -103,9 +103,9 @@ Keeps security report resources updated
 | trivy.createConfig | bool | `true` | createConfig indicates whether to create config objects |
 | trivy.dbRegistry | string | `"ghcr.io"` |  |
 | trivy.dbRepository | string | `"aquasecurity/trivy-db"` |  |
-| trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication |
-| trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication |
 | trivy.dbRepositoryInsecure | string | `"false"` | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)  |
+| trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
+| trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -103,6 +103,8 @@ Keeps security report resources updated
 | trivy.createConfig | bool | `true` | createConfig indicates whether to create config objects |
 | trivy.dbRegistry | string | `"ghcr.io"` |  |
 | trivy.dbRepository | string | `"aquasecurity/trivy-db"` |  |
+| trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication |
+| trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication |
 | trivy.dbRepositoryInsecure | string | `"false"` | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |

--- a/deploy/helm/templates/secrets/trivy.yaml
+++ b/deploy/helm/templates/secrets/trivy.yaml
@@ -10,6 +10,12 @@ data:
   {{- with .Values.trivy.githubToken }}
   trivy.githubToken: {{ . | b64enc | quote }}
   {{- end }}
+  {{- with .Values.trivy.dbRepositoryUsername }}
+  trivy.dbRepositoryUsername: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.trivy.dbRepositoryPassword }}
+  trivy.dbRepositoryPassword: {{ . | b64enc | quote }}
+  {{- end }}
   {{- if or (eq .Values.trivy.mode "ClientServer") .Values.operator.builtInTrivyServer }}
   {{- with .Values.trivy.serverToken }}
   trivy.serverToken: {{ . | b64enc | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -429,6 +429,8 @@ trivy:
 
   dbRegistry: "ghcr.io"
   dbRepository: "aquasecurity/trivy-db"
+  dbRepositoryUsername: ~
+  dbRepositoryPassword: ~
 
   # -- javaDbRegistry is the registry for the Java vulnerability database.
   javaDbRegistry: "ghcr.io"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -429,7 +429,13 @@ trivy:
 
   dbRegistry: "ghcr.io"
   dbRepository: "aquasecurity/trivy-db"
+
+  # -- The username for dbRepository authentication
+  #
   dbRepositoryUsername: ~
+
+  # -- The password for dbRepository authentication
+  #
   dbRepositoryPassword: ~
 
   # -- javaDbRegistry is the registry for the Java vulnerability database.

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -48,6 +48,8 @@ const (
 	keyTrivySkipFiles            = "trivy.skipFiles"
 	keyTrivySkipDirs             = "trivy.skipDirs"
 	keyTrivyDBRepository         = "trivy.dbRepository"
+	keyTrivyDBRepositoryUsername = "trivy.dbRepositoryUsername"
+	keyTrivyDBRepositoryPassword = "trivy.dbRepositoryPassword"
 	keyTrivyJavaDBRepository     = "trivy.javaDbRepository"
 	keyTrivyDBRepositoryInsecure = "trivy.dbRepositoryInsecure"
 

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -49,7 +49,7 @@ const (
 	keyTrivySkipDirs             = "trivy.skipDirs"
 	keyTrivyDBRepository         = "trivy.dbRepository"
 	keyTrivyDBRepositoryUsername = "trivy.dbRepositoryUsername"
-	keyTrivyDBRepositoryPassword = "trivy.dbRepositoryPassword"
+	keyTrivyDBRepositoryPassword = "trivy.dbRepositoryPassword" // #nosec G101
 	keyTrivyJavaDBRepository     = "trivy.javaDbRepository"
 	keyTrivyDBRepositoryInsecure = "trivy.dbRepositoryInsecure"
 

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -210,6 +210,12 @@ func (c Config) GetSkipJavaDBUpdate() bool {
 	return boolVal
 }
 
+func (c Config) TrivyDBRepositoryCredentialsSet() bool {
+	_, userOk := c.Data[keyTrivyDBRepositoryUsername]
+	_, passOk := c.Data[keyTrivyDBRepositoryPassword]
+	return userOk && passOk
+}
+
 func (c Config) GetImageScanCacheDir() string {
 	val, ok := c.Data[keyTrivyImageScanCacheDir]
 	if !ok || val == "" {

--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -570,6 +570,8 @@ func initContainerFSEnvVar(trivyConfigName string, config Config) []corev1.EnvVa
 		constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),
 		constructEnvVarSourceFromConfigMap("NO_PROXY", trivyConfigName, keyTrivyNoProxy),
 		constructEnvVarSourceFromSecret("GITHUB_TOKEN", trivyConfigName, keyTrivyGitHubToken),
+		constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
+		constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
 	}
 	if config.GetDBRepositoryInsecure() {
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -570,8 +570,12 @@ func initContainerFSEnvVar(trivyConfigName string, config Config) []corev1.EnvVa
 		constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),
 		constructEnvVarSourceFromConfigMap("NO_PROXY", trivyConfigName, keyTrivyNoProxy),
 		constructEnvVarSourceFromSecret("GITHUB_TOKEN", trivyConfigName, keyTrivyGitHubToken),
-		constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
-		constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
+	}
+	if config.TrivyDBRepositoryCredentialsSet() {
+		envs = append(envs, []corev1.EnvVar{
+			constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
+			constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
+		}...)
 	}
 	if config.GetDBRepositoryInsecure() {
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -536,8 +536,12 @@ func initContainerEnvVar(trivyConfigName string, config Config) []corev1.EnvVar 
 		constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),
 		constructEnvVarSourceFromConfigMap("NO_PROXY", trivyConfigName, keyTrivyNoProxy),
 		constructEnvVarSourceFromSecret("GITHUB_TOKEN", trivyConfigName, keyTrivyGitHubToken),
-		constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
-		constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
+	}
+	if config.TrivyDBRepositoryCredentialsSet() {
+		envs = append(envs, []corev1.EnvVar{
+			constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
+			constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
+		}...)
 	}
 
 	if config.GetDBRepositoryInsecure() {

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -536,6 +536,8 @@ func initContainerEnvVar(trivyConfigName string, config Config) []corev1.EnvVar 
 		constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),
 		constructEnvVarSourceFromConfigMap("NO_PROXY", trivyConfigName, keyTrivyNoProxy),
 		constructEnvVarSourceFromSecret("GITHUB_TOKEN", trivyConfigName, keyTrivyGitHubToken),
+		constructEnvVarSourceFromSecret("TRIVY_USERNAME", trivyConfigName, keyTrivyDBRepositoryUsername),
+		constructEnvVarSourceFromSecret("TRIVY_PASSWORD", trivyConfigName, keyTrivyDBRepositoryPassword),
 	}
 
 	if config.GetDBRepositoryInsecure() {


### PR DESCRIPTION
## Description

Add the configs dbRepositoryUsername and dbRepositoryPassword to allow authentication for the dbRepository.
This configuration sets the environment variables TRIVY_USERNAME and TRIVY_PASSWORD in the scan-vulnerabilityreport-pods.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/README.md) with the relevant information.
