### PR TITLE
fix: missing reports on via cluster sbom cache

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -41,6 +41,7 @@ Keeps security report resources updated
 | operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
 | operator.cacheReportTTL | string | `"120h"` | cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled |
 | operator.clusterComplianceEnabled | bool | `true` | clusterComplianceEnabled the flag to enable cluster compliance scanner |
+| operator.clusterSbomCacheEnabled | bool | `true` | the flag to enable cluster sbom cache generation |
 | operator.configAuditScannerEnabled | bool | `true` | configAuditScannerEnabled the flag to enable configuration audit scanner |
 | operator.configAuditScannerScanOnlyCurrentRevisions | bool | `true` | configAuditScannerScanOnlyCurrentRevisions the flag to only create config audit scans on the current revision of a deployment. |
 | operator.controllerCacheSyncTimeout | string | `"5m"` | controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m). |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name | quote }}
-          image: "chenkeinan/trivy-operator:miss"
+          image: "{{ include "global.imageRegistry" . | default .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name | quote }}
-          image: "{{ include "global.imageRegistry" . | default .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "chenkeinan/trivy-operator:miss"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
             - name: OPERATOR_SBOM_GENERATION_ENABLED
               value: {{ .Values.operator.sbomGenerationEnabled | quote }}
+            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
+              value: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
             - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
               value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
             - name: OPERATOR_SCANNER_REPORT_TTL

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -69,6 +69,8 @@ operator:
   vulnerabilityScannerEnabled: true
   # -- the flag to enable sbom generation
   sbomGenerationEnabled: true
+  # -- the flag to enable cluster sbom cache generation
+  clusterSbomCacheEnabled: true
   # -- scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
   scannerReportTTL: "24h"
   # -- cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2857,7 +2857,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "trivy-operator"
-          image: "chenkeinan/trivy-operator:miss"
+          image: "ghcr.io/aquasecurity/trivy-operator:0.17.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: OPERATOR_NAMESPACE

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2857,7 +2857,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "trivy-operator"
-          image: "ghcr.io/aquasecurity/trivy-operator:0.17.1"
+          image: "chenkeinan/trivy-operator:miss"
           imagePullPolicy: IfNotPresent
           env:
             - name: OPERATOR_NAMESPACE
@@ -2897,6 +2897,8 @@ spec:
             - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
               value: "true"
             - name: OPERATOR_SBOM_GENERATION_ENABLED
+              value: "true"
+            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
               value: "true"
             - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
               value: "true"

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	HealthProbeBindAddress                       string         `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
 	VulnerabilityScannerEnabled                  bool           `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`
 	SbomGenerationEnable                         bool           `env:"OPERATOR_SBOM_GENERATION_ENABLED" envDefault:"true"`
+	ClusterSbomCacheEnable                       bool           `env:"OPERATOR_CLUSTER_SBOM_CACHE_ENABLED" envDefault:"true"`
 	VulnerabilityScannerScanOnlyCurrentRevisions bool           `env:"OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS" envDefault:"true"`
 	ScannerReportTTL                             *time.Duration `env:"OPERATOR_SCANNER_REPORT_TTL" envDefault:"24h"`
 	CacheReportTTL                               *time.Duration `env:"OPERATOR_CACHE_REPORT_TTL" envDefault:"120h"`

--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -51,7 +51,7 @@ func (r *TTLReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Config.InfraAssessmentScannerEnabled {
 		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.InfraAssessmentReport{}})
 	}
-	if r.Config.SbomGenerationEnable {
+	if r.Config.ClusterSbomCacheEnable {
 		ttlResources = append(ttlResources, kube.Resource{ForObject: &v1alpha1.ClusterSbomReport{}})
 	}
 	installModePredicate, err := predicate.InstallModePredicate(r.Config)

--- a/pkg/vulnerabilityreport/controller/helper.go
+++ b/pkg/vulnerabilityreport/controller/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/sbomreport"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
+	"github.com/go-logr/logr"
 )
 
 const (
@@ -64,24 +65,25 @@ func compareReports(actual map[string]bool, images kube.ContainerImages) bool {
 	return reflect.DeepEqual(actual, expected)
 }
 
-func getGlobalSbomReports(ctx context.Context, sbomReadWriter sbomreport.ReadWriter, images kube.ContainerImages) (map[string]v1alpha1.SbomReportData, error) {
+func getGlobalSbomReports(ctx context.Context, sbomReadWriter sbomreport.ReadWriter, images kube.ContainerImages, log logr.Logger) map[string]v1alpha1.SbomReportData {
 	sbomReportDataMap := make(map[string]v1alpha1.SbomReportData, 0)
 	for name, ref := range images {
 		list, err := sbomReadWriter.FindReportByImageRef(ctx, ref)
 		if err != nil {
-			return nil, err
+			log.V(1).Info("cached sbom not found for image ref - running standard scan-job", "image-ref", ref)
+			return map[string]v1alpha1.SbomReportData{}
 		}
-
 		if len(list) > 0 {
 			for _, data := range list {
 				if isSbomExceededSecretSizeLimit(data.Report.Bom, secretSizeLimit) {
-					return map[string]v1alpha1.SbomReportData{}, nil
+					log.V(1).Info("cached sbom size exceeded secret size limit for image ref - running standard scan-job", "image-ref", ref)
+					return map[string]v1alpha1.SbomReportData{}
 				}
 				sbomReportDataMap[name] = data.Report
 			}
 		}
 	}
-	return sbomReportDataMap, nil
+	return sbomReportDataMap
 }
 
 func isSbomExceededSecretSizeLimit(bom v1alpha1.BOM, maxSecretSize int) bool {

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -196,6 +196,8 @@ func (r *ScanJobController) processCompleteScanJob(ctx context.Context, job *bat
 		if err != nil {
 			return err
 		}
+	}
+	if r.Config.ClusterSbomCacheEnable {
 		err = r.SbomReadWriter.WriteCluster(ctx, sbomClusterReports)
 		if err != nil {
 			return err
@@ -314,9 +316,10 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 		if err != nil {
 			return VulnerabilityReports{}, nil, nil, err
 		}
-		sbomReports.sbomClusterReports = []v1alpha1.ClusterSbomReport{clusterReport}
+		if r.Config.ClusterSbomCacheEnable {
+			sbomReports.sbomClusterReports = []v1alpha1.ClusterSbomReport{clusterReport}
+		}
 		sbomReports.sbomNamespaceReports = []v1alpha1.SbomReport{sbomReport}
-
 	}
 	return vulnerabilityReports, secretReports, sbomReports, nil
 }

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -126,11 +126,11 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 	return func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 		log := r.Logger.WithValues("kind", workloadKind, "name", req.NamespacedName)
 		workloadRef := kube.ObjectRefFromKindAndObjectKey(workloadKind, req.NamespacedName)
-		log.V(1).Info("Getting workload from cache")
+		log.V(1).Info("Getting workload from cache", "workload", workloadRef.Name)
 		workloadObj, err := r.ObjectFromObjectRef(ctx, workloadRef)
 		if err != nil {
 			if k8sapierror.IsNotFound(err) {
-				log.V(1).Info("Ignoring cached workload that must have been deleted")
+				log.V(1).Info("Ignoring cached workload that must have been deleted", "workload", workloadRef.Name)
 				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("getting %s from cache: %w", workloadKind, err)
@@ -150,8 +150,6 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		containerImages := kube.GetContainerImagesFromPodSpec(podSpec, r.GetSkipInitContainers())
 		hash := kube.ComputeHash(podSpec)
 
-		log = log.WithValues("podSpecHash", hash)
-
 		hasVulnReports := true
 		if r.Config.VulnerabilityScannerEnabled {
 			hasVulnReports, err = hasVulnerabilityReports(ctx, r.VulnerabilityReadWriter, workloadRef, hash, containerImages)
@@ -168,7 +166,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		}
 
 		if hasVulnReports && hasExposedSecretReports {
-			log.V(1).Info("VulnerabilityReports or Secret Reports already exist")
+			log.V(1).Info("VulnerabilityReports or Secret Reports already exist for the workload", "workload", workloadRef.Name)
 			return ctrl.Result{}, nil
 		}
 		var reportsData map[string]v1alpha1.SbomReportData
@@ -193,19 +191,17 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 				return ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, nil
 			}
 		}
-		if r.Config.SbomGenerationEnable {
-			reportsData, err = getGlobalSbomReports(ctx, r.SbomReadWriter, containerImages)
-			if err != nil {
-				reportsData = map[string]v1alpha1.SbomReportData{}
-			}
+		if r.Config.ClusterSbomCacheEnable {
+			reportsData = getGlobalSbomReports(ctx, r.SbomReadWriter, containerImages, log)
 			if len(reportsData) > 0 {
 				err = r.reuseSbomReport(ctx, workloadObj, reportsData)
 				if err != nil {
+					log.V(1).Info("unable to reuse report for image containers from cached sbom  - running standard scan-job", "image containers", containerImages)
 					reportsData = map[string]v1alpha1.SbomReportData{}
 				}
 			}
 		}
-		log.V(1).Info("Submitting a scan for the workload")
+		log.V(1).Info("Submitting a scan for the workload", "workload", workloadRef.Name)
 		// sync all potential workload for scanning
 		r.SubmitScanJobChan <- ScanJobRequest{Workload: workloadObj, Context: ctx, ClusterSbomReport: reportsData}
 		// collect scan job processing results

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -196,12 +196,12 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		if r.Config.SbomGenerationEnable {
 			reportsData, err = getGlobalSbomReports(ctx, r.SbomReadWriter, containerImages)
 			if err != nil {
-				return ctrl.Result{}, err
+				reportsData = map[string]v1alpha1.SbomReportData{}
 			}
 			if len(reportsData) > 0 {
-				err = r.reuseReport(ctx, workloadObj, reportsData)
+				err = r.reuseSbomReport(ctx, workloadObj, reportsData)
 				if err != nil {
-					return ctrl.Result{}, err
+					reportsData = map[string]v1alpha1.SbomReportData{}
 				}
 			}
 		}
@@ -372,7 +372,7 @@ func (r *WorkloadController) SubmitScanJob(ctx context.Context, owner client.Obj
 	return nil
 }
 
-func (r *WorkloadController) reuseReport(ctx context.Context, owner client.Object, sbomReportDataMap map[string]v1alpha1.SbomReportData) error {
+func (r *WorkloadController) reuseSbomReport(ctx context.Context, owner client.Object, sbomReportDataMap map[string]v1alpha1.SbomReportData) error {
 	hash, err := kube.ComputeSpecHash(owner)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
missing reports on via cluster sbom cache

## Related issues
- Close #1697

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
