### PR TITLE
feat: ingress resource on config-scan support

### DIFF
--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -84,6 +84,7 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Determine which Kubernetes workloads the controller will reconcile and add them to resources
 	targetWorkloads := r.Config.GetTargetWorkloads()
+	targetWorkloads = append(targetWorkloads, strings.ToLower(string(kube.KindIngress)))
 	for _, tw := range targetWorkloads {
 		var resource kube.Resource
 		if err = resource.GetWorkloadResource(tw, &v1alpha1.ConfigAuditReport{}, r.ObjectResolver); err != nil {

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -729,6 +729,8 @@ func (r *Resource) GetWorkloadResource(kind string, object client.Object, resolv
 		*r = Resource{Kind: KindCronJob, ForObject: resolver.GetSupportedObjectByKind(KindCronJob, &batchv1.CronJob{}), OwnsObject: object}
 	case "job":
 		*r = Resource{Kind: KindJob, ForObject: &batchv1.Job{}, OwnsObject: object}
+	case "ingress":
+		*r = Resource{Kind: KindIngress, ForObject: &networkingv1.Ingress{}, OwnsObject: object}
 	default:
 		return fmt.Errorf("workload of kind %s is not supported", kind)
 	}


### PR DESCRIPTION
## Description
ingress resource on config-scan support

## Related issues
- Close #1703

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
