### PR TITLE
fix: service monitor cause operator to crash

### DIFF
--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -1004,25 +1004,27 @@ func (c *ResourcesMetricsCollector) collectClusterComplianceInfoReports(ctx cont
 		if c.Config.MetricsClusterComplianceInfo {
 			labelValues[0] = r.Spec.Complaince.Title
 			labelValues[1] = r.Spec.Complaince.Description
-			for _, summary := range r.Status.SummaryReport.SummaryControls {
-				if summary.TotalFail == nil {
-					continue
-				}
-				status := PassStatus
-				metricCounter := 1
-				if *summary.TotalFail > 0 {
-					status = FailStatus
-					metricCounter = *summary.TotalFail
-				}
-				labelValues[2] = summary.ID
-				labelValues[3] = summary.Name
-				labelValues[4] = NewStatusLabel(Status(status)).Label
-				labelValues[5] = summary.Severity
+			if r.Status.SummaryReport != nil {
+				for _, summary := range r.Status.SummaryReport.SummaryControls {
+					if summary.TotalFail == nil {
+						continue
+					}
+					status := PassStatus
+					metricCounter := 1
+					if *summary.TotalFail > 0 {
+						status = FailStatus
+						metricCounter = *summary.TotalFail
+					}
+					labelValues[2] = summary.ID
+					labelValues[3] = summary.Name
+					labelValues[4] = NewStatusLabel(Status(status)).Label
+					labelValues[5] = summary.Severity
 
-				for i, label := range c.GetReportResourceLabels() {
-					labelValues[i+6] = r.Labels[label]
+					for i, label := range c.GetReportResourceLabels() {
+						labelValues[i+6] = r.Labels[label]
+					}
+					metrics <- prometheus.MustNewConstMetric(c.complianceInfoDesc, prometheus.GaugeValue, float64(metricCounter), labelValues...)
 				}
-				metrics <- prometheus.MustNewConstMetric(c.complianceInfoDesc, prometheus.GaugeValue, float64(metricCounter), labelValues...)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
fix: service monitor cause operator to crash

## Related issues
- Close #1682

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
