### PR TITLE
feat: retrieve sbom specified sources from oci registries

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -132,6 +132,7 @@ Keeps security report resources updated
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
+| trivy.sbomSources | string | `""` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -132,7 +132,7 @@ Keeps security report resources updated
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
-| trivy.sbomSources | string | `""` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
+| trivy.sbomSources | string | `nil` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -132,7 +132,7 @@ Keeps security report resources updated
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
-| trivy.sbomSources | string | `nil` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
+| trivy.sbomSources | string | `""` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |

--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -51,6 +51,7 @@ data:
   trivy.dbRepository: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
   trivy.javaDbRepository: "{{ .Values.trivy.javaDbRegistry }}/{{ .Values.trivy.javaDbRepository }}"
   trivy.command: {{ .Values.trivy.command | quote }}
+  trivy.sbomSources: {{ .Values.trivy.sbomSources }}
   {{- with .Values.trivy.skipFiles }}
   trivy.skipFiles: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -51,7 +51,7 @@ data:
   trivy.dbRepository: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
   trivy.javaDbRepository: "{{ .Values.trivy.javaDbRegistry }}/{{ .Values.trivy.javaDbRepository }}"
   trivy.command: {{ .Values.trivy.command | quote }}
-  trivy.sbomSources: {{ .Values.trivy.sbomSources }}
+  trivy.sbomSources: {{ .Values.trivy.sbomSources | quote }}
   {{- with .Values.trivy.skipFiles }}
   trivy.skipFiles: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -293,6 +293,9 @@ trivy:
   # on the active mode other settings might be applicable or required.
   mode: Standalone
 
+  # -- sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor)
+  sbomSources: ""
+
   # -- includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false)
   # note: this flag is only applicable when trivy.command is set to filesystem
   includeDevDeps: false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -294,7 +294,7 @@ trivy:
   mode: Standalone
 
   # -- sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor)
-  sbomSources: ""
+  sbomSources: ~
 
   # -- includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false)
   # note: this flag is only applicable when trivy.command is set to filesystem

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -294,7 +294,7 @@ trivy:
   mode: Standalone
 
   # -- sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor)
-  sbomSources: ~
+  sbomSources: ""
 
   # -- includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false)
   # note: this flag is only applicable when trivy.command is set to filesystem

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2793,6 +2793,7 @@ data:
   trivy.dbRepository: "ghcr.io/aquasecurity/trivy-db"
   trivy.javaDbRepository: "ghcr.io/aquasecurity/trivy-java-db"
   trivy.command: "image"
+  trivy.sbomSources: 
   trivy.dbRepositoryInsecure: "false"
   trivy.useBuiltinRegoPolicies: "true"
   trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2793,7 +2793,7 @@ data:
   trivy.dbRepository: "ghcr.io/aquasecurity/trivy-db"
   trivy.javaDbRepository: "ghcr.io/aquasecurity/trivy-java-db"
   trivy.command: "image"
-  trivy.sbomSources: 
+  trivy.sbomSources: ""
   trivy.dbRepositoryInsecure: "false"
   trivy.useBuiltinRegoPolicies: "true"
   trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -28,6 +28,7 @@ const (
 	keyTrivyMode                                = "trivy.mode"
 	keyTrivyAdditionalVulnerabilityReportFields = "trivy.additionalVulnerabilityReportFields"
 	keyTrivyCommand                             = "trivy.command"
+	keyTrivySbomSources                         = "trivy.sbomSources"
 	KeyTrivySeverity                            = "trivy.severity"
 	keyTrivySlow                                = "trivy.slow"
 	keyTrivyVulnType                            = "trivy.vulnType"
@@ -209,6 +210,14 @@ func (c Config) GetIncludeDevDeps() bool {
 		return false
 	}
 	return boolVal
+}
+
+func (c Config) GetSbomSources() string {
+	val, ok := c.Data[keyTrivySbomSources]
+	if !ok {
+		return ""
+	}
+	return val
 }
 
 func (c Config) GetSkipJavaDBUpdate() bool {

--- a/pkg/plugins/trivy/config_test.go
+++ b/pkg/plugins/trivy/config_test.go
@@ -931,7 +931,7 @@ func TestPlugin_GetSbomSources(t *testing.T) {
 			want:       "",
 		},
 		{
-			name: "GetSbomSources not set",
+			name: "GetSbomSources with oci and rekor",
 			configData: map[string]string{
 				"trivy.sbomSources": "oci,rekor",
 			},

--- a/pkg/plugins/trivy/config_test.go
+++ b/pkg/plugins/trivy/config_test.go
@@ -918,3 +918,35 @@ func TestPlugin_GetIncludeDevDeps(t *testing.T) {
 		})
 	}
 }
+
+func TestPlugin_GetSbomSources(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configData map[string]string
+		want       string
+	}{
+		{
+			name:       "GetSbomSources not set",
+			configData: map[string]string{},
+			want:       "",
+		},
+		{
+			name: "GetSbomSources not set",
+			configData: map[string]string{
+				"trivy.sbomSources": "oci,rekor",
+			},
+			want: "oci,rekor",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := Config{
+				trivyoperator.PluginConfig{
+					Data: tc.configData,
+				},
+			}
+			got := config.GetSbomSources()
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -522,11 +522,14 @@ func GetFSScanningArgs(ctx trivyoperator.PluginContext, command Command, mode Mo
 	if mode == ClientServer {
 		args = append(args, "--server", trivyServerURL)
 	}
+
 	slow := Slow(c)
 	if len(slow) > 0 {
 		args = append(args, slow)
 	}
-
+	if sbomSources := c.GetSbomSources(); len(sbomSources) > 0 {
+		args = append(args, []string{"--sbom-sources", sbomSources}...)
+	}
 	if c.GetIncludeDevDeps() && command == Filesystem {
 		args = append(args, "--include-dev-deps")
 	}


### PR DESCRIPTION
## Description
Retrieve sbom specified sources from oci registries

## Related issues
- Close #1624

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
