### PR TITLE
fix: Update trivy.yaml to support cve list

### DIFF
--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -77,9 +77,11 @@ data:
   {{- with .Values.trivy.timeout }}
   trivy.timeout: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivy.ignoreFile }}
+  {{- if .Values.trivy.ignoreFile }}
   trivy.ignoreFile: |
-    {{- . | trim | nindent 4 }}
+  {{- range .Values.trivy.ignoreFile }}
+    {{ . | indent 4 }}
+  {{- end }}
   {{- end }}
   {{- range $k, $v := .Values.trivy }}
   {{- if hasPrefix "ignorePolicy" $k }}


### PR DESCRIPTION
cve list might be provided as list:

trivy {
    ignoreFile = ["CVE-1970-0001", "CVE-2023-49568"]
}

result in configmap:
trivy.ignoreFile: |
  CVE-1970-0001
  CVE-2023-49568