### PR TITLE
fix: set audit config plugin trivy by default

### DIFF
--- a/pkg/operator/envtest/suite_test.go
+++ b/pkg/operator/envtest/suite_test.go
@@ -146,7 +146,7 @@ var _ = BeforeSuite(func() {
 		Commit:  "commit",
 		Date:    "12/12/2020",
 	}
-	pluginca, _, err := plugins.NewResolver().WithBuildInfo(buildInfo).
+	pluginca, _ := plugins.NewResolver().WithBuildInfo(buildInfo).
 		WithNamespace(config.Namespace).
 		WithServiceAccountName(config.ServiceAccount).
 		WithConfig(trivyOperatorConfig).

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -163,7 +163,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	if err != nil {
 		return err
 	}
-	pluginConfig, pluginContextConfig, err := plugins.NewResolver().WithBuildInfo(buildInfo).
+	pluginConfig, pluginContextConfig := plugins.NewResolver().WithBuildInfo(buildInfo).
 		WithNamespace(operatorNamespace).
 		WithServiceAccountName(operatorConfig.ServiceAccount).
 		WithConfig(trivyOperatorConfig).

--- a/pkg/plugins/factory.go
+++ b/pkg/plugins/factory.go
@@ -76,12 +76,8 @@ func (r *Resolver) GetVulnerabilityPlugin() (vulnerabilityreport.Plugin, trivyop
 }
 
 // GetConfigAuditPlugin is a factory method that instantiates the configauditreport.Plugin.
-func (r *Resolver) GetConfigAuditPlugin() (configauditreport.PluginInMemory, trivyoperator.PluginContext, error) {
-	scanner, err := r.config.GetConfigAuditReportsScanner()
-	if err != nil {
-		return nil, nil, err
-	}
-
+func (r *Resolver) GetConfigAuditPlugin() (configauditreport.PluginInMemory, trivyoperator.PluginContext) {
+	scanner := r.config.GetConfigAuditReportsScanner()
 	pluginContext := trivyoperator.NewPluginContext().
 		WithName(string(scanner)).
 		WithClient(r.client).
@@ -90,5 +86,5 @@ func (r *Resolver) GetConfigAuditPlugin() (configauditreport.PluginInMemory, tri
 		WithTrivyOperatorConfig(r.config).
 		Get()
 
-	return trivy.NewTrivyConfigAuditPlugin(ext.NewSystemClock(), ext.NewGoogleUUIDGenerator(), r.objectResolver), pluginContext, nil
+	return trivy.NewTrivyConfigAuditPlugin(ext.NewSystemClock(), ext.NewGoogleUUIDGenerator(), r.objectResolver), pluginContext
 }

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -154,13 +154,13 @@ func (c ConfigData) VulnerabilityScanJobsInSameNamespace() bool {
 	return c.getBoolKey(KeyVulnerabilityScansInSameNamespace)
 }
 
-func (c ConfigData) GetConfigAuditReportsScanner() (Scanner, error) {
+func (c ConfigData) GetConfigAuditReportsScanner() Scanner {
 	var ok bool
 	var value string
 	if value, ok = c[keyConfigAuditReportsScanner]; !ok {
-		return "", fmt.Errorf("property %s not set", keyConfigAuditReportsScanner)
+		return Scanner("Trivy")
 	}
-	return Scanner(value), nil
+	return Scanner(value)
 }
 
 func (c ConfigData) GetScanJobTolerations() ([]corev1.Toleration, error) {

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -60,7 +60,7 @@ func TestConfigData_GetConfigAuditReportsScanner(t *testing.T) {
 			configData: trivyoperator.ConfigData{
 				"configAuditReports.scanner": "Test",
 			},
-			expectedScanner: v1alpha1.ScannerNameTrivy,
+			expectedScanner: trivyoperator.Scanner("Test"),
 		},
 		{
 			name:            "Scaner is not set",

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -53,28 +53,25 @@ func TestConfigData_GetConfigAuditReportsScanner(t *testing.T) {
 	testCases := []struct {
 		name            string
 		configData      trivyoperator.ConfigData
-		expectedError   string
 		expectedScanner trivyoperator.Scanner
 	}{
 		{
 			name: "Should return Trivy",
 			configData: trivyoperator.ConfigData{
-				"configAuditReports.scanner": "Trivy",
+				"configAuditReports.scanner": "Test",
 			},
 			expectedScanner: v1alpha1.ScannerNameTrivy,
 		},
 		{
-			name:          "Should return error when value is not set",
-			configData:    trivyoperator.ConfigData{},
-			expectedError: "property configAuditReports.scanner not set",
+			name:            "Scaner is not set",
+			configData:      trivyoperator.ConfigData{},
+			expectedScanner: trivyoperator.Scanner(v1alpha1.ScannerNameTrivy),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			scanner := tc.configData.GetConfigAuditReportsScanner()
-			if tc.expectedError != "" {
-				assert.Equal(t, tc.expectedScanner, scanner)
-			}
+			assert.Equal(t, tc.expectedScanner, scanner)
 		})
 	}
 }

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -71,11 +71,8 @@ func TestConfigData_GetConfigAuditReportsScanner(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scanner, err := tc.configData.GetConfigAuditReportsScanner()
+			scanner := tc.configData.GetConfigAuditReportsScanner()
 			if tc.expectedError != "" {
-				require.EqualError(t, err, tc.expectedError)
-			} else {
-				require.NoError(t, err)
 				assert.Equal(t, tc.expectedScanner, scanner)
 			}
 		})


### PR DESCRIPTION
## Description
fix: set audit config plugin trivy by default

## Related issues
- Close #1738

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
