### PR TITLE
docs: updated managed registries on Azure with Workload Identities

### DIFF
--- a/docs/docs/vulnerability-scanning/managed-registries.md
+++ b/docs/docs/vulnerability-scanning/managed-registries.md
@@ -29,26 +29,37 @@ The official steps for setting up Workload Identity on AKS can be found [here](h
 - Managed clusters or self-managed clusters installed, [see docs](https://azure.github.io/azure-workload-identity/docs/installation/self-managed-clusters.html)
 - Mutating admission webhook installed, [see docs](https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html)
 
-- update trivy-operator service accout to include workload identity annotation and lables (update clientID and tenantID), Example:
-
+- update trivy-operator service account to include workload identity annotation.
+Example (replace `<client-id>` with the one of the [identity created during the setup](https://azure.github.io/azure-workload-identity/docs/quick-start.html#4-create-an-aad-application-or-user-assigned-managed-identity-and-grant-permissions-to-access-the-secret))
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: trivy-operator
   namespace: trivy-system
-  labels:
-    app.kubernetes.io/name: trivy-operator
-    app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.18.1"
-    app.kubernetes.io/managed-by: kubectl
-    azure.workload.identity/use: "true"
   annotations:
-    azure.workload.identity/client-id: "client-id"
-    azure.workload.identity/tenant-id: "tenant-id"
+    azure.workload.identity/client-id: "<client-id>"
 ```
 
-- Add the following label to podTemplateLabels in helm settings : `scanJob.podTemplateLabels=azure.workload.identity/use=true`
+- Add the following label to podTemplateLabels in helm values.
+Example using `values.yaml`:
+```yaml
+serviceAccount:
+  name: <service-account-name>
+  create: false # Optional
+trivyOperator:
+  scanJobPodTemplateLabels: azure.workload.identity/use=true
+```
+We can deploy the operator inside our cluster with referencing our new `values.yaml` manifest to override the default values: (replace `<service-account-name>` with the name of the service account you created [during the setup](https://azure.github.io/azure-workload-identity/docs/quick-start.html#5-create-a-kubernetes-service-account))
+
+```sh
+helm upgrade --install trivy-operator aqua/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version {{ var.chart_version }}
+  --values ./values.yaml
+```
+
 
 ## Google Container Registry (GCR)
 


### PR DESCRIPTION
Updated the documentation about accessing ACR with workload identities

## Description

Recently I had to add the trivy operator to our cluster on AKS, so I've updated the relevant documentation for Microsoft Entra workload identities.

## Related issues
None since it's a trivial contribution

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
