### PR TITLE
fix: use correct items list struct for ClusterVulnerabilityReportList

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -208,6 +208,6 @@ type ClusterVulnerabilityReportList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
 
-	// Vulnerability is the spec for a vulnerability record.
-	Items []VulnerabilityReport `json:"items"`
+	// ClusterVulnerability is the spec for a cluster vulnerability record.
+	Items []ClusterVulnerabilityReport `json:"items"`
 }

--- a/pkg/apis/aquasecurity/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/aquasecurity/v1alpha1/zz_generated.deepcopy.go
@@ -431,7 +431,7 @@ func (in *ClusterVulnerabilityReportList) DeepCopyInto(out *ClusterVulnerability
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]VulnerabilityReport, len(*in))
+		*out = make([]ClusterVulnerabilityReport, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
## Description

Currently `ClusterVulnerabilityReportList` Items returns a slice of `VulnerabilityReport` instead of `ClusterVulnerabilityReport`.

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
