### PR TITLE
feat: Enable passing values for operator through custom ConfigMap and/or Secrets

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -75,6 +75,8 @@ Keeps security report resources updated
 | operator.scannerReportTTL | string | `"24h"` | scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled |
 | operator.serverAdditionalAnnotations | object | `{}` | serverAdditionalAnnotations the flag to set additional annotations for the trivy server pod |
 | operator.trivyServerHealthCheckCacheExpiration | string | `"10h"` | trivyServerHealthCheckCacheExpiration The flag to set the interval for trivy server health cache before it invalidate |
+| operator.valuesFromConfigMap | string | `""` | vaulesFromConfigMap name of a ConfigMap to apply OPERATOR_* environment variables. Will override Helm values. |
+| operator.valuesFromSecret | string | `""` | valuesFromSecret name of a Secret to apply OPERATOR_* environment variables. Will override Helm AND ConfigMap values. |
 | operator.vulnerabilityScannerEnabled | bool | `true` | the flag to enable vulnerability scanner |
 | operator.vulnerabilityScannerScanOnlyCurrentRevisions | bool | `true` | vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment. |
 | operator.webhookBroadcastTimeout | string | `"30s"` | webhookBroadcastTimeout the flag to set timeout for webhook requests if webhookBroadcastURL is enabled |

--- a/deploy/helm/templates/configmaps/trivy-operator-config.yaml
+++ b/deploy/helm/templates/configmaps/trivy-operator-config.yaml
@@ -1,0 +1,50 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trivy-operator-config
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  OPERATOR_LOG_DEV_MODE: {{ .Values.operator.logDevMode | quote }}
+  OPERATOR_SCAN_JOB_TTL: {{ .Values.operator.scanJobTTL | quote }}
+  OPERATOR_SCAN_JOB_TIMEOUT: {{ .Values.operator.scanJobTimeout | quote }}
+  OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
+  OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: {{ .Values.operator.scanNodeCollectorLimit | quote }}
+  OPERATOR_SCAN_JOB_RETRY_AFTER: {{ .Values.operator.scanJobsRetryDelay | quote }}
+  OPERATOR_BATCH_DELETE_LIMIT: {{ .Values.operator.batchDeleteLimit | quote }}
+  OPERATOR_BATCH_DELETE_DELAY: {{ .Values.operator.batchDeleteDelay | quote }}
+  OPERATOR_METRICS_BIND_ADDRESS: ":8080"
+  OPERATOR_METRICS_FINDINGS_ENABLED: {{ .Values.operator.metricsFindingsEnabled | quote }}
+  OPERATOR_METRICS_VULN_ID_ENABLED: {{ .Values.operator.metricsVulnIdEnabled | quote }}
+  OPERATOR_HEALTH_PROBE_BIND_ADDRESS: ":9090"
+  OPERATOR_VULNERABILITY_SCANNER_ENABLED: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
+  OPERATOR_SBOM_GENERATION_ENABLED: {{ .Values.operator.sbomGenerationEnabled | quote }}
+  OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
+  OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
+  OPERATOR_SCANNER_REPORT_TTL: {{ .Values.operator.scannerReportTTL | quote }}
+  OPERATOR_CACHE_REPORT_TTL: {{ .Values.operator.cacheReportTTL | quote }}
+  CONTROLLER_CACHE_SYNC_TIMEOUT: {{ .Values.operator.controllerCacheSyncTimeout | quote }}
+  OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: {{ .Values.operator.configAuditScannerEnabled | quote }}
+  OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED: {{ .Values.operator.rbacAssessmentScannerEnabled | quote }}
+  OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED: {{ .Values.operator.infraAssessmentScannerEnabled | quote }}
+  OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
+  OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
+  OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED: {{ .Values.operator.metricsExposedSecretInfo | quote }}
+  OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED: {{ .Values.operator.metricsConfigAuditInfo | quote }}
+  OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED: {{ .Values.operator.metricsRbacAssessmentInfo | quote }}
+  OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED: {{ .Values.operator.metricsInfraAssessmentInfo | quote }}
+  OPERATOR_METRICS_IMAGE_INFO_ENABLED: {{ .Values.operator.metricsImageInfo | quote }}
+  OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED: {{ .Values.operator.metricsClusterComplianceInfo | quote }}
+  OPERATOR_WEBHOOK_BROADCAST_URL: {{ .Values.operator.webhookBroadcastURL | quote }}
+  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: {{ .Values.operator.webhookBroadcastTimeout | quote }}
+  OPERATOR_SEND_DELETED_REPORTS: {{ .Values.operator.webhookSendDeletedReports | quote }}
+  OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
+  OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS: {{ .Values.operator.accessGlobalSecretsAndServiceAccount | quote }}
+  OPERATOR_BUILT_IN_TRIVY_SERVER: {{ .Values.operator.builtInTrivyServer | quote }}
+  TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION: {{ .Values.operator.trivyServerHealthCheckCacheExpiration | quote }}
+  OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT: {{ .Values.operator.mergeRbacFindingWithConfigAudit | quote }}
+  OPERATOR_CLUSTER_COMPLIANCE_ENABLED: {{ .Values.operator.clusterComplianceEnabled | quote }}
+{{- if gt (int .Values.operator.replicas) 1 }}
+  OPERATOR_LEADER_ELECTION_ENABLED: "true"
+  OPERATOR_LEADER_ELECTION_ID: {{ .Values.operator.leaderElectionId | quote }}
+{{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -43,89 +43,16 @@ spec:
               value: {{ tpl .Values.targetWorkloads . | quote }}
             - name: OPERATOR_SERVICE_ACCOUNT
               value: {{ include "trivy-operator.serviceAccountName" . | quote }}
-            - name: OPERATOR_LOG_DEV_MODE
-              value: {{ .Values.operator.logDevMode | quote }}
-            - name: OPERATOR_SCAN_JOB_TTL
-              value: {{ .Values.operator.scanJobTTL | quote }}
-            - name: OPERATOR_SCAN_JOB_TIMEOUT
-              value: {{ .Values.operator.scanJobTimeout | quote }}
-            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
-              value: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
-            - name: OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT
-              value: {{ .Values.operator.scanNodeCollectorLimit | quote }}
-            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
-              value: {{ .Values.operator.scanJobsRetryDelay | quote }}
-            - name: OPERATOR_BATCH_DELETE_LIMIT
-              value: {{ .Values.operator.batchDeleteLimit | quote }}
-            - name: OPERATOR_BATCH_DELETE_DELAY
-              value: {{ .Values.operator.batchDeleteDelay | quote }}
-            - name: OPERATOR_METRICS_BIND_ADDRESS
-              value: ":8080"
-            - name: OPERATOR_METRICS_FINDINGS_ENABLED
-              value: {{ .Values.operator.metricsFindingsEnabled | quote }}
-            - name: OPERATOR_METRICS_VULN_ID_ENABLED
-              value: {{ .Values.operator.metricsVulnIdEnabled | quote }}
-            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
-              value: ":9090"
-            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
-              value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
-            - name: OPERATOR_SBOM_GENERATION_ENABLED
-              value: {{ .Values.operator.sbomGenerationEnabled | quote }}
-            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
-              value: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
-            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
-            - name: OPERATOR_SCANNER_REPORT_TTL
-              value: {{ .Values.operator.scannerReportTTL | quote }}
-            - name: OPERATOR_CACHE_REPORT_TTL
-              value: {{ .Values.operator.cacheReportTTL | quote }}
-            - name: CONTROLLER_CACHE_SYNC_TIMEOUT
-              value: {{ .Values.operator.controllerCacheSyncTimeout | quote }}
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
-              value: {{ .Values.operator.configAuditScannerEnabled | quote }}
-            - name: OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED
-              value: {{ .Values.operator.rbacAssessmentScannerEnabled | quote }}
-            - name: OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED
-              value: {{ .Values.operator.infraAssessmentScannerEnabled | quote }}
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
-            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
-              value: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
-            - name: OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED
-              value: {{ .Values.operator.metricsExposedSecretInfo | quote }}
-            - name: OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED
-              value: {{ .Values.operator.metricsConfigAuditInfo | quote }}
-            - name: OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED
-              value: {{ .Values.operator.metricsRbacAssessmentInfo | quote }}
-            - name: OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED
-              value: {{ .Values.operator.metricsInfraAssessmentInfo | quote }}
-            - name: OPERATOR_METRICS_IMAGE_INFO_ENABLED
-              value: {{ .Values.operator.metricsImageInfo | quote }}  
-            - name: OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED
-              value: {{ .Values.operator.metricsClusterComplianceInfo | quote }}  
-            - name: OPERATOR_WEBHOOK_BROADCAST_URL
-              value: {{ .Values.operator.webhookBroadcastURL | quote }}
-            - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
-              value: {{ .Values.operator.webhookBroadcastTimeout | quote }}
-            - name: OPERATOR_SEND_DELETED_REPORTS
-              value: {{ .Values.operator.webhookSendDeletedReports | quote }}
-            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
-              value: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
-            - name: OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS
-              value: {{ .Values.operator.accessGlobalSecretsAndServiceAccount | quote }}
-            - name: OPERATOR_BUILT_IN_TRIVY_SERVER
-              value: {{ .Values.operator.builtInTrivyServer | quote }}
-            - name: TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION
-              value: {{ .Values.operator.trivyServerHealthCheckCacheExpiration | quote }}
-            - name: OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT
-              value: {{ .Values.operator.mergeRbacFindingWithConfigAudit | quote }}
-            - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
-              value: {{ .Values.operator.clusterComplianceEnabled | quote }}
-            {{- if gt (int .Values.operator.replicas) 1 }}
-            - name: OPERATOR_LEADER_ELECTION_ENABLED
-              value: "true"
-            - name: OPERATOR_LEADER_ELECTION_ID
-              value: {{ .Values.operator.leaderElectionId | quote }}
+          envFrom:
+            - configMapRef:
+                name: trivy-operator-config
+            {{- if .Values.operator.valuesFromConfigMap }}
+            - configMapRef:
+                name: {{ .Values.operator.valuesFromConfigMap }}
+            {{- end }}
+            {{- if .Values.operator.valuesFromSecret }}
+            - secretRef:
+                name: {{ .Values.operator.valuesFromSecret }}
             {{- end }}
           ports:
             - name: metrics

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -157,6 +157,12 @@ operator:
   # -- mergeRbacFindingWithConfigAudit the flag to enable merging rbac finding with config-audit report
   mergeRbacFindingWithConfigAudit: false
 
+  # -- vaulesFromConfigMap name of a ConfigMap to apply OPERATOR_* environment variables. Will override Helm values.
+  valuesFromConfigMap: ""
+
+  # -- valuesFromSecret name of a Secret to apply OPERATOR_* environment variables. Will override Helm AND ConfigMap values.
+  valuesFromSecret: ""
+
 image:
   registry: "ghcr.io"
   repository: "aquasecurity/trivy-operator"

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2777,6 +2777,58 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 data:
 ---
+# Source: trivy-operator/templates/configmaps/trivy-operator-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trivy-operator-config
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.18.5"
+    app.kubernetes.io/managed-by: kubectl
+data:
+  OPERATOR_LOG_DEV_MODE: "false"
+  OPERATOR_SCAN_JOB_TTL: ""
+  OPERATOR_SCAN_JOB_TIMEOUT: "5m"
+  OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"
+  OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: "1"
+  OPERATOR_SCAN_JOB_RETRY_AFTER: "30s"
+  OPERATOR_BATCH_DELETE_LIMIT: "10"
+  OPERATOR_BATCH_DELETE_DELAY: "10s"
+  OPERATOR_METRICS_BIND_ADDRESS: ":8080"
+  OPERATOR_METRICS_FINDINGS_ENABLED: "true"
+  OPERATOR_METRICS_VULN_ID_ENABLED: "false"
+  OPERATOR_HEALTH_PROBE_BIND_ADDRESS: ":9090"
+  OPERATOR_VULNERABILITY_SCANNER_ENABLED: "true"
+  OPERATOR_SBOM_GENERATION_ENABLED: "true"
+  OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: "false"
+  OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: "true"
+  OPERATOR_SCANNER_REPORT_TTL: "24h"
+  OPERATOR_CACHE_REPORT_TTL: "120h"
+  CONTROLLER_CACHE_SYNC_TIMEOUT: "5m"
+  OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: "true"
+  OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED: "true"
+  OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED: "true"
+  OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: "true"
+  OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED: "true"
+  OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED: "false"
+  OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_IMAGE_INFO_ENABLED: "false"
+  OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED: "false"
+  OPERATOR_WEBHOOK_BROADCAST_URL: ""
+  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: "30s"
+  OPERATOR_SEND_DELETED_REPORTS: "false"
+  OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES: "{}"
+  OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS: "true"
+  OPERATOR_BUILT_IN_TRIVY_SERVER: "false"
+  TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION: "10h"
+  OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT: "false"
+  OPERATOR_CLUSTER_COMPLIANCE_ENABLED: "true"
+---
 # Source: trivy-operator/templates/configmaps/trivy.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -2880,84 +2932,9 @@ spec:
               value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
             - name: OPERATOR_SERVICE_ACCOUNT
               value: "trivy-operator"
-            - name: OPERATOR_LOG_DEV_MODE
-              value: "false"
-            - name: OPERATOR_SCAN_JOB_TTL
-              value: ""
-            - name: OPERATOR_SCAN_JOB_TIMEOUT
-              value: "5m"
-            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
-              value: "10"
-            - name: OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT
-              value: "1"
-            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
-              value: "30s"
-            - name: OPERATOR_BATCH_DELETE_LIMIT
-              value: "10"
-            - name: OPERATOR_BATCH_DELETE_DELAY
-              value: "10s"
-            - name: OPERATOR_METRICS_BIND_ADDRESS
-              value: ":8080"
-            - name: OPERATOR_METRICS_FINDINGS_ENABLED
-              value: "true"
-            - name: OPERATOR_METRICS_VULN_ID_ENABLED
-              value: "false"
-            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
-              value: ":9090"
-            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
-              value: "true"
-            - name: OPERATOR_SBOM_GENERATION_ENABLED
-              value: "true"
-            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
-              value: "false"
-            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: "true"
-            - name: OPERATOR_SCANNER_REPORT_TTL
-              value: "24h"
-            - name: OPERATOR_CACHE_REPORT_TTL
-              value: "120h"
-            - name: CONTROLLER_CACHE_SYNC_TIMEOUT
-              value: "5m"
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
-              value: "true"
-            - name: OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED
-              value: "true"
-            - name: OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED
-              value: "true"
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: "true"
-            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
-              value: "true"
-            - name: OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED
-              value: "false"
-            - name: OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED
-              value: "false"
-            - name: OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED
-              value: "false"
-            - name: OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED
-              value: "false"
-            - name: OPERATOR_METRICS_IMAGE_INFO_ENABLED
-              value: "false"  
-            - name: OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED
-              value: "false"  
-            - name: OPERATOR_WEBHOOK_BROADCAST_URL
-              value: ""
-            - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
-              value: "30s"
-            - name: OPERATOR_SEND_DELETED_REPORTS
-              value: "false"
-            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
-              value: "{}"
-            - name: OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS
-              value: "true"
-            - name: OPERATOR_BUILT_IN_TRIVY_SERVER
-              value: "false"
-            - name: TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION
-              value: "10h"
-            - name: OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT
-              value: "false"
-            - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
-              value: "true"
+          envFrom:
+            - configMapRef:
+                name: trivy-operator-config
           ports:
             - name: metrics
               containerPort: 8080
@@ -3010,6 +2987,25 @@ spec:
   selector:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
+---
+# Source: trivy-operator/templates/rbac/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trivy-operator
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.18.5"
+    app.kubernetes.io/managed-by: kubectl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-operator
+    namespace: trivy-system
 ---
 # Source: trivy-operator/templates/rbac/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3380,11 +3376,12 @@ rules:
   verbs:
     - get
 ---
-# Source: trivy-operator/templates/rbac/clusterrolebinding.yaml
+# Source: trivy-operator/templates/rbac/leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: trivy-operator
+  name: trivy-operator-leader-election
+  namespace: trivy-system
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
@@ -3392,8 +3389,8 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: trivy-operator
+  kind: Role
+  name: trivy-operator-leader-election
 subjects:
   - kind: ServiceAccount
     name: trivy-operator
@@ -3427,11 +3424,11 @@ rules:
     verbs:
       - create
 ---
-# Source: trivy-operator/templates/rbac/leader-election-rolebinding.yaml
+# Source: trivy-operator/templates/rbac/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: trivy-operator-leader-election
+  name: trivy-operator
   namespace: trivy-system
   labels:
     app.kubernetes.io/name: trivy-operator
@@ -3441,7 +3438,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: trivy-operator-leader-election
+  name: trivy-operator
 subjects:
   - kind: ServiceAccount
     name: trivy-operator
@@ -3476,26 +3473,6 @@ rules:
       - create
       - get
       - delete
----
-# Source: trivy-operator/templates/rbac/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: trivy-operator
-  namespace: trivy-system
-  labels:
-    app.kubernetes.io/name: trivy-operator
-    app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.18.5"
-    app.kubernetes.io/managed-by: kubectl
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: trivy-operator
-subjects:
-  - kind: ServiceAccount
-    name: trivy-operator
-    namespace: trivy-system
 ---
 # Source: trivy-operator/templates/rbac/view-configauditreports-clusterrole.yaml
 # permissions for end users to view configauditreports

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2988,25 +2988,6 @@ spec:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
 ---
-# Source: trivy-operator/templates/rbac/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: trivy-operator
-  labels:
-    app.kubernetes.io/name: trivy-operator
-    app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.18.5"
-    app.kubernetes.io/managed-by: kubectl
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: trivy-operator
-subjects:
-  - kind: ServiceAccount
-    name: trivy-operator
-    namespace: trivy-system
----
 # Source: trivy-operator/templates/rbac/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -3376,12 +3357,11 @@ rules:
   verbs:
     - get
 ---
-# Source: trivy-operator/templates/rbac/leader-election-rolebinding.yaml
+# Source: trivy-operator/templates/rbac/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: trivy-operator-leader-election
-  namespace: trivy-system
+  name: trivy-operator
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
@@ -3389,8 +3369,8 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: trivy-operator-leader-election
+  kind: ClusterRole
+  name: trivy-operator
 subjects:
   - kind: ServiceAccount
     name: trivy-operator
@@ -3424,11 +3404,11 @@ rules:
     verbs:
       - create
 ---
-# Source: trivy-operator/templates/rbac/rolebinding.yaml
+# Source: trivy-operator/templates/rbac/leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: trivy-operator
+  name: trivy-operator-leader-election
   namespace: trivy-system
   labels:
     app.kubernetes.io/name: trivy-operator
@@ -3438,7 +3418,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: trivy-operator
+  name: trivy-operator-leader-election
 subjects:
   - kind: ServiceAccount
     name: trivy-operator
@@ -3473,6 +3453,26 @@ rules:
       - create
       - get
       - delete
+---
+# Source: trivy-operator/templates/rbac/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trivy-operator
+  namespace: trivy-system
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: "0.18.5"
+    app.kubernetes.io/managed-by: kubectl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-operator
+    namespace: trivy-system
 ---
 # Source: trivy-operator/templates/rbac/view-configauditreports-clusterrole.yaml
 # permissions for end users to view configauditreports

--- a/docs/getting-started/installation/configuration.md
+++ b/docs/getting-started/installation/configuration.md
@@ -50,6 +50,15 @@ The values of the `OPERATOR_NAMESPACE` and `OPERATOR_TARGET_NAMESPACES` determin
 | MultiNamespace| `operators`| `foo,bar,baz`| The operator can be configured to watch for events in more than one namespace.                                 |
 | AllNamespaces| `operators`| (blank string)| The operator can be configured to watch for events in all namespaces.|
 
+## Configuration from custom ConfigMap and/or Secret
+
+When deployed with the Helm Chart, the environment variables for the Operator Configuration are applied from the `trivy-operator-config` ConfigMap. It is possible to provide a custom ConfigMap and/or Secret to override these values.
+This is especially useful or even required, when configuration cannot be set through the Helm values, for example when some of the data is retrieved from external sources like Vault or other secret management systems in Cloud Provider environments.
+To apply values from a custom ConfigMap and/or Secret, the according Helm values need to be set:
+
+- `operator.valuesFromConfigMap`: The name of the ConfigMap to apply the values from. Will override the values `trivy-operator-config` ConfigMap.
+- `operator.valuesFromSecret`: The name of the Secret to apply the values from. Will override values from the `trivy-operator-config` AND `operator.valuesFromConfigMap` (if defined) ConfigMap.
+
 ## Example - configure namespaces to scan
 
 To change the target namespace from all namespaces to the `default` namespace edit the `trivy-operator` Deployment and change the value of the `OPERATOR_TARGET_NAMESPACES` environment variable from the blank string (`""`) to the `default` value.


### PR DESCRIPTION
## Description

This feature / change enables providing Configuration for the Trivy-Operator from custom ConfigMap and/or Secret using the Helm Chart, which is a common / widely used pattern.

So far, all configuration have been passed using the `env` field in the [deployment](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/templates/deployment.yaml#L46-L129).
Since this method has the [highest precedence](https://renehernandez.io/notes/env-vars-precedence-k8s-pod/), it was not possible to provide additional values.
To overcome this, all `.Values.operator.*` Helm values have been moved into their own ConfigMap called `trivy-operator-config` and then referred to it with `envFrom`.

This allowes to provide additional ConfigMaps/Secrets and override previous values.
The behaviour is defined in the [Container v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#container-v1-core) Spec of Kubernetes for the `envFrom` field:

> _[..] When a key exists in multiple sources, **the value associated with the last source will take precedence**. [..]_

The next Step was to add two additional Helm values, `.Values.operator.valuesFromSecret` and `.Values.operator.valuesFromConfigMap`. 
If defined, the deployment will apply values from the defined ConfigMap/Secret, while considering the following precedeence:

- `valuesFromConfigMap` will override `trivy-operator-config`
- `valuesFromSecret` will override `trivy-operator-config` AND `valuesFromConfigMap`

## How was it tested

I first deployed the Helm Chart with only the default values and then grabbed the env Variables of the `trivy-operator`, saving the output to a file:

```shell
kubectl -n trivy-system exec deployments/trivy-operator -- printenv \
  | grep OPERATOR \
  | sort \
  > envs_default.yaml
```

Then I moved all the `OPERATOR_*` values to the `trivy-operator-config` ConfigMap and again grabbed all the env Variables into a file `envs_cm.yaml`.

Now I compared the two files with `diff envs_default.yaml envs_cm.yaml`.
I used this approach for further use cases:

#### No breaking changes

Define Helm values 
```helm
operator:
  infraAssessmentScannerEnabled: false
  configAuditScannerEnabled: false
  webhookBroadcastTimeout: 33s
```

and expect them to be correctly applied, having the same behaviour as before:
```shell
OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED=false
OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED=false
OPERATOR_WEBHOOK_BROADCAST_TIMEOUT=33s
```

#### Custom ConfigMap overrides Helm values

Same Helm values as above + setting `valuesFromConfigMap` to `custom-operator-config`.
Deploy a custom ConfigMap  with content:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: custom-operator-config
  namespace: trivy-system
data:
  OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: "true"
  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: "22s"
```

check env Variables in the Pod:
```shell
OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED=false
OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED=true
OPERATOR_WEBHOOK_BROADCAST_TIMEOUT=22s
```

#### Custom Secret overrides Helm values AND custom ConfigMap

Same Helm values and ConfigMap as above + setting `valuesFromSecret` to `custom-operator-config`
Deploy a custom Secret with content:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: custom-operator-config
  namespace: trivy-system
type: Opaque
data:
  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: MTFz // '11s' encoded with base64
```

check env Variables in the Pod:
```shell
OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED=false
OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED=true
OPERATOR_WEBHOOK_BROADCAST_TIMEOUT=11s
```


## Related issues
- Close #1737

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
