### PR TITLE
feat: add extra labels for operator and server controllers in Helm chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -49,6 +49,7 @@ Keeps security report resources updated
 | operator.controllerCacheSyncTimeout | string | `"5m"` | controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m). |
 | operator.exposedSecretScannerEnabled | bool | `true` | exposedSecretScannerEnabled the flag to enable exposed secret scanner |
 | operator.infraAssessmentScannerEnabled | bool | `true` | infraAssessmentScannerEnabled the flag to enable infra assessment scanner |
+| operator.labels | object | `{}` | additional labels for the operator deployment |
 | operator.leaderElectionId | string | `"trivyoperator-lock"` | leaderElectionId determines the name of the resource that leader election will use for holding the leader lock. |
 | operator.logDevMode | bool | `false` | logDevMode the flag to enable development mode (more human-readable output, extra stack traces and logging information, etc) |
 | operator.mergeRbacFindingWithConfigAudit | bool | `false` | mergeRbacFindingWithConfigAudit the flag to enable merging rbac finding with config-audit report |
@@ -129,11 +130,12 @@ Keeps security report resources updated
 | trivy.insecureRegistries | object | `{}` | The registry to which insecure connections are allowed. There can be multiple registries with different keys. |
 | trivy.javaDbRegistry | string | `"ghcr.io"` | javaDbRegistry is the registry for the Java vulnerability database. |
 | trivy.javaDbRepository | string | `"aquasecurity/trivy-java-db"` |  |
+| trivy.labels | object | `{}` | labels is the extra labels to be used for trivy server statefulset |
 | trivy.mode | string | `"Standalone"` | mode is the Trivy client mode. Either Standalone or ClientServer. Depending on the active mode other settings might be applicable or required. |
 | trivy.noProxy | string | `nil` | noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings. |
 | trivy.nonSslRegistries | object | `{}` | Registries without SSL. There can be multiple registries with different keys. |
 | trivy.offlineScan | bool | `false` | offlineScan is the flag to enable the offline scan functionality in Trivy This will prevent outgoing HTTP requests, e.g. to search.maven.org |
-| trivy.podLabels | string | `nil` | podLabels is the extra pod labels to be used for trivy server |
+| trivy.podLabels | object | `{}` | podLabels is the extra pod labels to be used for trivy server |
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -3,7 +3,11 @@ kind: Deployment
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+  labels: 
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    {{- with .Values.operator.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.operator.replicas }}
   {{- with .Values.operator.revisionHistoryLimit }}

--- a/deploy/helm/templates/trivy-server/statefulset.yaml
+++ b/deploy/helm/templates/trivy-server/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-server
     app.kubernetes.io/instance: trivy-server
+    {{- with .Values.trivy.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podManagementPolicy: "Parallel"
   serviceName: {{ .Values.trivy.serverServiceName }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -40,6 +40,9 @@ operator:
   # -- number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10)
   revisionHistoryLimit: ~
 
+  # -- additional labels for the operator deployment
+  labels: {}
+
   # -- additional labels for the operator pod
   podLabels: {}
 
@@ -320,8 +323,11 @@ trivy:
   # -- storageSize is the size of the trivy server PVC
   storageSize: "5Gi"
 
+  # -- labels is the extra labels to be used for trivy server statefulset
+  labels: {}
+
   # -- podLabels is the extra pod labels to be used for trivy server
-  podLabels:
+  podLabels: {}
 
   # -- priorityClassName is the name of the priority class used for trivy server
   priorityClassName: ""


### PR DESCRIPTION
## Description

Sometimes we may face situations where we need to be able to identify a deployment owner inside a cluster, this is easily done with labels, but the current trivy-operator chart does not allow to set custom labels to the controllers, only the pods'.

This PR introduces new `operator.labels` and `trivy.labels` values that will let users add custom labels to the operator and trivy-server controllers.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
