### PR TITLE
fix: access to private regional gcr

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -207,7 +207,7 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 				Value: "true",
 			})
 		}
-		gcrImage := checkGcpCrOrPivateRegistry(c.Image)
+		gcrImage := CheckGcpCrOrPrivateRegistry(c.Image)
 		if _, ok := containersCredentials[c.Name]; ok && secret != nil {
 			registryUsernameKey := fmt.Sprintf("%s.username", c.Name)
 			registryPasswordKey := fmt.Sprintf("%s.password", c.Name)
@@ -433,7 +433,7 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 		}
 
 		if auth, ok := containersCredentials[container.Name]; ok && secret != nil {
-			if checkGcpCrOrPivateRegistry(container.Image) && auth.Username == "_json_key" {
+			if CheckGcpCrOrPrivateRegistry(container.Image) && auth.Username == "_json_key" {
 				registryServiceAccountAuthKey := fmt.Sprintf("%s.password", container.Name)
 				createEnvandVolumeForGcr(&env, &volumeMounts, &volumes, &registryServiceAccountAuthKey, &secret.Name)
 			} else {
@@ -760,7 +760,7 @@ func createEnvandVolumeForGcr(env *[]corev1.EnvVar, volumeMounts *[]corev1.Volum
 	*volumeMounts = append(*volumeMounts, googlecredMount)
 }
 
-func checkGcpCrOrPivateRegistry(imageUrl string) bool {
+func CheckGcpCrOrPrivateRegistry(imageUrl string) bool {
 	imageRegex := regexp.MustCompile(GCPCR_Image_Regex)
 	return imageRegex.MatchString(imageUrl)
 }

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -761,7 +761,7 @@ func createEnvandVolumeForGcr(env *[]corev1.EnvVar, volumeMounts *[]corev1.Volum
 }
 
 func checkGcpCrOrPivateRegistry(imageUrl string) bool {
-	imageRegex := regexp.MustCompile(GCPCR_Inage_Regex)
+	imageRegex := regexp.MustCompile(GCPCR_Image_Regex)
 	return imageRegex.MatchString(imageUrl)
 }
 

--- a/pkg/plugins/trivy/image_test.go
+++ b/pkg/plugins/trivy/image_test.go
@@ -12,6 +12,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestCheckGcpCrOrPrivateRegistry(t *testing.T) {
+	assert.True(t, trivy.CheckGcpCrOrPrivateRegistry("gcr.io/company/application"))
+	assert.True(t, trivy.CheckGcpCrOrPrivateRegistry("us.gcr.io/company/application"))
+	assert.True(t, trivy.CheckGcpCrOrPrivateRegistry("eu.gcr.io/company/application"))
+	assert.True(t, trivy.CheckGcpCrOrPrivateRegistry("asia.gcr.io/company/application"))
+	assert.True(t, trivy.CheckGcpCrOrPrivateRegistry("us-central1-docker.pkg.dev/company/application"))
+}
+
 func TestGetMirroredImage(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	GCPCR_Inage_Regex  = `^(gcr\.io.*|^([a-zA-Z0-9-]+)-*-*.docker.pkg.dev.*)`
+	GCPCR_Image_Regex  = `^(us\.|eu\.|asia\.)?gcr\.io.*|^([a-zA-Z0-9-]+)-*-*.docker\.pkg\.dev.*`
 	AWSECR_Image_Regex = "^\\d+\\.dkr\\.ecr\\.(\\w+-\\w+-\\d+)\\.amazonaws\\.com\\/"
 	// SkipDirsAnnotation annotation  example: trivy-operator.aquasecurity.github.io/skip-dirs: "/tmp,/home"
 	SkipDirsAnnotation = "trivy-operator.aquasecurity.github.io/skip-dirs"


### PR DESCRIPTION
## Description
The PR fixes regex for gcr images and should fix the issue https://github.com/aquasecurity/trivy-operator/issues/1868.

## Test
Tested by the following code:
```go
package main

import (
	"fmt"
	"regexp"
)

const (
	GCPCR_Image_Regex = `^(us\.|eu\.|asia\.)?gcr\.io.*|^([a-zA-Z0-9-]+)-*-*.docker\.pkg\.dev.*`
	//GCPCR_Image_Regex = `^(gcr\.io.*|^([a-zA-Z0-9-]+)-*-*.docker.pkg.dev.*)`
)

func main() {
	imageRegex := regexp.MustCompile(GCPCR_Image_Regex)

	global := imageRegex.MatchString("gcr.io/company/application")
	fmt.Println("global", global)

	us := imageRegex.MatchString("us.gcr.io/company/application")
	fmt.Println("us", us)

	eu := imageRegex.MatchString("eu.gcr.io/company/application")
	fmt.Println("eu", eu)

	asia := imageRegex.MatchString("asia.gcr.io/company/application")
	fmt.Println("asia ", asia)

	docker := imageRegex.MatchString("us-central1-docker.pkg.dev/company/application")
	fmt.Println("docker", docker)
}
```

Output with current regex:
```
global true
us false
eu false
asia  false
docker true
```

Output with fixed regex:
```
global true
us true
eu true
asia  true
docker true
```

## Related issues and PRs
- Close #1868
- https://github.com/aquasecurity/trivy-operator/issues/1095
- https://github.com/aquasecurity/trivy-operator/issues/1298
- https://github.com/aquasecurity/trivy-operator/pull/1404

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
