### PR TITLE
feat: added configurable appProtocol to metrics service

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -88,8 +88,9 @@ Keeps security report resources updated
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | securityContext security context |
-| service | object | `{"annotations":{},"headless":true,"metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
+| service | object | `{"annotations":{},"headless":true,"metricsAppProtocol":"TCP","metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
 | service.annotations | object | `{}` | annotations added to the operator's service |
+| service.metricsAppProtocol | string | `"TCP"` | appProtocol of the monitoring service |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |

--- a/deploy/helm/templates/monitor/service.yaml
+++ b/deploy/helm/templates/monitor/service.yaml
@@ -16,4 +16,5 @@ spec:
       port: {{ .Values.service.metricsPort }}
       targetPort: metrics
       protocol: TCP
+      appProtocol: {{ .Values.service.metricsAppProtocol }}
   selector: {{- include "trivy-operator.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -181,6 +181,8 @@ service:
   metricsPort: 80
   # -- annotations added to the operator's service
   annotations: {}
+  # -- appProtocol of the monitoring service
+  metricsAppProtocol: TCP
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -3110,6 +3110,7 @@ spec:
       port: 80
       targetPort: metrics
       protocol: TCP
+      appProtocol: TCP
   selector:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator


### PR DESCRIPTION
## Description

I'm not sure about the default value `TCP`. I think thats the Kubernetes default but not sure if trivy has something specific.

## Related issues
- Close #1866

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
