### PR TITLE
feat: Also publish chart to OCI registry

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - deploy/helm/Chart.yaml
 env:
+  CR_PACKAGE_PATH: .cr-release-packages
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm
@@ -17,17 +18,20 @@ jobs:
   release:
     # this job will only run if the PR has been merged
     if: github.event.client_payload.action == 'chart-release' || github.event.client_payload.action == 'chart-and-app-release'
+    permissions:
+      contents: write  # for peter-evans/repository-dispatch to create a repository dispatch event
+      packages: write  # to push OCI chart package to GitHub Registry
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v1.1
+        uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390 # v4.1.0
         with:
-          version: v3.5.0
+          version: v3.14.2
       - name: Set up python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.7
       - name: Setup Chart Linting
@@ -37,7 +41,7 @@ jobs:
         uses: helm/kind-action@v1.9.0 # v1.5.0
         with:
           version: ${{ env.KIND_VERSION }}
-          image: ${{ env.KIND_IMAGE }}
+          node_image: ${{ env.KIND_IMAGE }}
       - name: Run chart-testing
         run: ct lint-and-install --validate-maintainers=false --charts deploy/helm
       - name: Install chart-releaser
@@ -48,11 +52,13 @@ jobs:
       - name: Package helm chart
         run: |
           ./cr package ${{ env.CHART_DIR }}
+
+        # Classic helm repository with GitHub pages
       - name: Upload helm chart
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
         continue-on-error: true
         run: |
-          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }} -p .cr-release-packages
+          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }}
       - name: Index helm chart
         run: |
           ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml
@@ -67,6 +73,24 @@ jobs:
           destination_branch: "gh-pages"
           user_email: aqua-bot@users.noreply.github.com
           user_name: "aqua-bot"
+
+        # OCI registry as helm repository (helm 3.8+)
+      - name: Login to GHCR
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in ${{ env.CR_PACKAGE_PATH }}/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${{ env.GH_OWNER }}/${{ env.HELM_REP }}
+          done
 
       - name: Get latest tag
         id: latest_tag

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ guide to see how vulnerability and configuration audit reports are generated aut
 
 ### Quick Start
 
-The Trivy Operator can be installed easily through the [Helm Chart](https://aquasecurity.github.io/trivy-operator/latest/getting-started/installation/helm/):
+The Trivy Operator can be installed easily through the [Helm Chart](https://aquasecurity.github.io/trivy-operator/latest/getting-started/installation/helm/).
+The Helm Chart can be downloaded by one of the two options:
+
+#### Option 1: Install from traditional helm chart repository
 
 Add the Aqua chart repository:
 
@@ -64,6 +67,17 @@ Install the Helm Chart:
 
 ```sh
    helm install trivy-operator aqua/trivy-operator \
+     --namespace trivy-system \
+     --create-namespace \
+     --version 0.20.6
+```
+
+#### Option 2: Install from OCI registry (supported in Helm v3.8.0+)
+
+Install the Helm Chart:
+
+```sh
+   helm install trivy-operator oci://ghcr.io/aquasecurity/helm-charts/trivy-operator \
      --namespace trivy-system \
      --create-namespace \
      --version 0.20.6

--- a/docs/getting-started/installation/helm.md
+++ b/docs/getting-started/installation/helm.md
@@ -41,6 +41,15 @@ except `kube-system` and `trivy-system`:
      --version {{ var.chart_version }}
 ```
 
+   Or install the chart from the Aqua chart repository **using the OCI registry**:
+
+```sh
+   helm install trivy-operator oci://ghcr.io/aquasecurity/helm-charts/trivy-operator \
+     --namespace trivy-system \
+     --create-namespace \
+     --version {{ var.chart_version }}
+```
+
    Configuration options can be passed using the `--set` parameter. To list only the fixed vulnerabilities in the cluster, one can use the following command.
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,10 @@ guide to see how vulnerability and configuration audit reports are generated aut
 
 ### Quick Start
 
-The Trivy Operator can be installed easily through the [Helm Chart](./getting-started/installation/helm.md):
+The Trivy Operator can be installed easily through the [Helm Chart](./getting-started/installation/helm.md).
+The Helm Chart can be downloaded by one of the two options:
+
+#### Option 1: Install from traditional helm chart repository
 
 Add the Aqua chart repository:
 
@@ -53,6 +56,17 @@ Install the Helm Chart:
      --namespace trivy-system \
      --create-namespace \
      --version {{ var.chart_version }}
+```
+
+#### Option 2: Install from OCI registry (supported in Helm v3.8.0+)
+
+Install the Helm Chart:
+
+```sh
+   helm install trivy-operator oci://ghcr.io/aquasecurity/helm-charts/trivy-operator \
+     --namespace trivy-system \
+     --create-namespace \
+     --version 0.20.6
 ```
 
 This will install the Trivy Helm Chart into the `trivy-system` namespace and start triggering the scans.

--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -96,6 +96,17 @@ helm install trivy-operator aqua/trivy-operator \
   --values trivy-values.yaml
 ```
 
+Or install the chart **using the OCI registry**:
+
+```sh
+helm install trivy-operator oci://ghcr.io/aquasecurity/helm-charts/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version {{ var.chart_version }} \
+  --values trivy-values.yaml
+```
+
+
 Ensure that you can see the following success message:
 
 ```


### PR DESCRIPTION
## Description

See linked issue:

> The helm chart of trivy-operator is published using the classic approach with a static webserver and an index.yaml (on a separate Repository https://github.com/aquasecurity/helm-charts).
> 
> ```bash
> $ helm repo add aqua https://aquasecurity.github.io/helm-charts/
> $ helm install trivy-operator aqua/trivy-operator \
>      --namespace trivy-system \
>      --create-namespace \
>      --version 0.20.6
> ```
> 
> In helm 3.8+ the OCI method went GA:
> - https://blog.bitnami.com/2023/04/httpsblog.bitnami.com202304bitnami-helm-charts-now-oci.html?m=1
> - https://helm.sh/docs/topics/registries/
> - https://github.com/helm/helm/releases/tag/v3.8.0
> 
> I'd like to see you pushing the packaged helm chart(s) also on ghcr.io, alongside the container images and trivy-db's.
> 
> There is existing code available from multiple Kubernetes projects which could easily adapted:
> - [renovatebot/helm-charts](https://github.com/renovatebot/helm-charts/blob/5457a71d97e5318f3b5c152c332429ddf6a694a7/.github/workflows/release.yaml#L37-L44)
> - [nextcloud/helm](https://github.com/nextcloud/helm/blob/9d560de6668ed393f8a8dfa84f5692352cf62ff3/.github/workflows/release.yaml#L39-L43)
> - [cloudnative-pg/charts](https://github.com/cloudnative-pg/charts/blob/001d78758b864f8ffd42799f6f44760c0ca5a671/.github/workflows/release-publish.yml#L49)
> - [argoproj/argo-helm](https://github.com/argoproj/argo-helm/blob/2f82fb5992fe1e390d1ebdbc4be6d5d6c6549a37/.github/configs/cr.yaml#L12)
> - many more ;)
> 
> After one implemented this, users can easily install trivy-operator via:
> 
> ```bash
> helm install trivy-operator oci://ghcr.io/aquasecurity/charts/trivy-operator --version x.y.z
> ```

## Related issues
- Close #1887

Remove this section if you don't have related PRs.

## Testing

- I created a second branch `feature/chart_oci_publish_FORK_ADAPTION` with little adaption of the paths and run it inside my fork:
  ```diff
  git diff feature/chart_oci_publish..feature/chart_oci_publish_FORK_ADAPTION
  diff --git a/.github/workflows/publish-helm-chart.yaml b/.github/workflows/publish-helm-chart.yaml
  index d627445..7d7f539 100644
  --- a/.github/workflows/publish-helm-chart.yaml
  +++ b/.github/workflows/publish-helm-chart.yaml
  @@ -7,17 +7,19 @@ on:
      types: [publish-chart]
      paths:
        - deploy/helm/Chart.yaml
  +  # Manual trigger is also possible
  +  workflow_dispatch: {}
  env:
    CR_PACKAGE_PATH: .cr-release-packages
  -  HELM_REP: helm-charts
  -  GH_OWNER: aquasecurity
  +  HELM_REP: aquasecurity-helm-charts
  +  GH_OWNER: mkilchhofer
    CHART_DIR: deploy/helm
    KIND_VERSION: v0.17.0
    KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
  jobs:
    release:
      # this job will only run if the PR has been merged
  -    if: github.event.client_payload.action == 'chart-release' || github.event.client_payload.action == 'chart-and-app-release'
  +    # if: github.event.client_payload.action == 'chart-release' || github.event.client_payload.action == 'chart-and-app-release'
      permissions:
        contents: write  # for peter-evans/repository-dispatch to create a repository dispatch event
        packages: write  # to push OCI chart package to GitHub Registry
  @@ -92,16 +94,16 @@ jobs:
              helm push "${pkg}" oci://ghcr.io/${{ env.GH_OWNER }}/${{ env.HELM_REP }}
            done

  -      - name: Get latest tag
  -        id: latest_tag
  -        run: |
  -          latest_tag=$(git describe --tags --abbrev=0)
  -          echo "::set-output name=tag::$latest_tag"
  +      # - name: Get latest tag
  +      #   id: latest_tag
  +      #   run: |
  +      #     latest_tag=$(git describe --tags --abbrev=0)
  +      #     echo "::set-output name=tag::$latest_tag"

  -      - name: Repository Dispatch Publish docs
  -        if: github.event.client_payload.action == 'chart-and-app-release' && !contains(steps.latest_tag.outputs.tag, 'rc')
  -        uses: peter-evans/repository-dispatch@v3
  -        with:
  -          token: ${{ secrets.GITHUB_TOKEN }}
  -          event-type: publish-docs
  -          client-payload: '{"action": "docs-release", "tag": "${{ steps.latest_tag.outputs.tag }}"}'
  +      # - name: Repository Dispatch Publish docs
  +      #   if: github.event.client_payload.action == 'chart-and-app-release' && !contains(steps.latest_tag.outputs.tag, 'rc')
  +      #   uses: peter-evans/repository-dispatch@v3
  +      #   with:
  +      #     token: ${{ secrets.GITHUB_TOKEN }}
  +      #     event-type: publish-docs
  +      #     client-payload: '{"action": "docs-release", "tag": "${{ steps.latest_tag.outputs.tag }}"}'
  ```
- Created a repository to simulate the central helm repository: https://github.com/mkilchhofer/aquasecurity-helm-charts
- Executed the workflow without simulating all repo dispatch events
  See: https://github.com/mkilchhofer/trivy-operator/actions/runs/8130660226/job/22219118024
- Classic chart publish works
  ```bash
  $ helm repo add aqua-fork https://mkilchhofer.github.io/aquasecurity-helm-charts/
  "aqua-fork" has been added to your repositories

  $ helm search repo aqua-fork
  NAME                    	CHART VERSION	APP VERSION	DESCRIPTION
  aqua-fork/trivy-operator	0.20.6       	0.18.5     	Keeps security report resources updated
  ```
- OCI publish also works
  ```bash
  $ helm show chart oci://ghcr.io/mkilchhofer/aquasecurity-helm-charts/trivy-operator
  Pulled: ghcr.io/mkilchhofer/aquasecurity-helm-charts/trivy-operator:0.20.6
  Digest: sha256:abfb2006b259fb160daf5d5b51d90928d37242790a9a89273618d41ec4b50519
  apiVersion: v2
  appVersion: 0.18.5
  description: Keeps security report resources updated
  keywords:
  - aquasecurity
  - trivyoperator
  - trivy
  name: trivy-operator
  sources:
  - https://github.com/aquasecurity/trivy-operator
  type: application
  version: 0.20.6
  ```

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
