### PR TITLE
feat: ssl-cert dir support on init containers and built-in server

### DIFF
--- a/deploy/helm/templates/trivy-server/statefulset.yaml
+++ b/deploy/helm/templates/trivy-server/statefulset.yaml
@@ -115,6 +115,11 @@ spec:
             - mountPath: /home/scanner/.cache
               name: data
               readOnly: false
+          {{- with .Values.trivy.sslCertDir | quote }}
+            - mountPath: {{ . }}
+              name: ssl-cert-dir
+              readOnly: true
+          {{- end }}
           {{- with .Values.trivy.server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -124,6 +129,11 @@ spec:
         {{- if not .Values.trivy.storageClassEnabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.trivy.sslCertDir | quote }}
+        - name: ssl-cert-dir
+          hostPath:
+            path: {{ . }}
         {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description
ssl-cert dir support on init containers and built-in server

## Related issues
- Close #1676

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
