### PR TITLE
docs: Improve documentation for ClusterVulnerabilityReports

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -40,7 +40,7 @@ Keeps security report resources updated
 | operator.batchDeleteDelay | string | `"10s"` | batchDeleteDelay the duration to wait before deleting another batch of config audit reports. |
 | operator.batchDeleteLimit | int | `10` | batchDeleteLimit the maximum number of config audit reports deleted by the operator when the plugin's config has changed. |
 | operator.builtInServerRegistryInsecure | bool | `false` | builtInServerRegistryInsecure is the flag to enable insecure connection from the built-in Trivy server to the registry. |
-| operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
+| operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enables the usage of built-in trivy server in cluster. It also overrides the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
 | operator.cacheReportTTL | string | `"120h"` | cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled |
 | operator.clusterComplianceEnabled | bool | `true` | clusterComplianceEnabled the flag to enable cluster compliance scanner |
 | operator.clusterSbomCacheEnabled | bool | `false` | the flag to enable cluster sbom cache generation |
@@ -67,7 +67,7 @@ Keeps security report resources updated
 | operator.rbacAssessmentScannerEnabled | bool | `true` | rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner |
 | operator.replicas | int | `1` | replicas the number of replicas of the operator's pod |
 | operator.revisionHistoryLimit | string | `nil` | number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10) |
-| operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation |
+| operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation, required for enabling ClusterVulnerabilityReports |
 | operator.scanJobTTL | string | `""` | scanJobTTL the set automatic cleanup time after the job is completed |
 | operator.scanJobTimeout | string | `"5m"` | scanJobTimeout the length of time to wait before giving up on a scan job |
 | operator.scanJobsConcurrentLimit | int | `10` | scanJobsConcurrentLimit the maximum number of scan jobs create by the operator |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -73,7 +73,7 @@ operator:
 
   # -- the flag to enable vulnerability scanner
   vulnerabilityScannerEnabled: true
-  # -- the flag to enable sbom generation
+  # -- the flag to enable sbom generation, required for enabling ClusterVulnerabilityReports
   sbomGenerationEnabled: true
   # -- the flag to enable cluster sbom cache generation
   clusterSbomCacheEnabled: false
@@ -99,7 +99,7 @@ operator:
   batchDeleteDelay: 10s
   # -- accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts to allow `vulnerability scan job` to pull images from private registries
   accessGlobalSecretsAndServiceAccount: true
-  # -- builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values
+  # -- builtInTrivyServer The flag enables the usage of built-in trivy server in cluster. It also overrides the following trivy params with built-in values
   # trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975
   builtInTrivyServer: false
   # -- builtInServerRegistryInsecure is the flag to enable insecure connection from the built-in Trivy server to the registry.

--- a/docs/docs/crds/clustervulnerability-report.md
+++ b/docs/docs/crds/clustervulnerability-report.md
@@ -3,6 +3,7 @@
 An instance of the ClusterVulnerabilityReport represents the latest vulnerabilities found in kubernetes cluster control-plane and node components.
 It consists of a list of control-plane and node components vulnerabilities with a summary of
 vulnerabilities grouped by severity.
+ClusterVulnerabilityReports are based on [CVEs](https://github.com/aquasecurity/vuln-list-k8s/tree/main/upstream) from the K8s vulnerability advisory.
 
 The following listing shows a sample ClusterVulnerabilityReport associated with the kind cluster v1.21.1
 


### PR DESCRIPTION
## Description

From the documentation and the description of helm values it's not obvious that SBOM generation is required to enable ClusterVulnerabilityReports. @chen-keinan told me about that in discussion #1898. I proposed an adjustment of the documentation for this part.

## Related issues/discussions
- resolves #1898

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
