### PR TITLE
fix: load trivy-policies by config

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -207,9 +207,12 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 			return fmt.Errorf("unable to setup scan job  reconciler: %w", err)
 		}
 	}
-	policyLoader, err := buildPolicyLoader(trivyOperatorConfig)
-	if err != nil {
-		return fmt.Errorf("unable to constract policy loader: %w", err)
+	var policyLoader policy.Loader
+	if operatorConfig.ConfigAuditScannerEnabled {
+		policyLoader, err = buildPolicyLoader(trivyOperatorConfig)
+		if err != nil {
+			return fmt.Errorf("unable to constract policy loader: %w", err)
+		}
 	}
 
 	if operatorConfig.ScannerReportTTL != nil {


### PR DESCRIPTION
## Description
fix: load trivy-policies by config

## Related issues
- Related #1897

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
