### PR TITLE
feat: Helm, allow to define service type for metrics Service

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -95,9 +95,13 @@ Keeps security report resources updated
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | securityContext security context |
-| service | object | `{"annotations":{},"headless":true,"metricsAppProtocol":"TCP","metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
+| service | object | `{"annotations":{},"headless":true,"metricsAppProtocol":"TCP","metricsPort":80,"nodePort":null,"type":"ClusterIP"}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
 | service.annotations | object | `{}` | annotations added to the operator's service |
+| service.headless | bool | `true` | if true, the Service doesn't allocate any IP |
 | service.metricsAppProtocol | string | `"TCP"` | appProtocol of the monitoring service |
+| service.metricsPort | int | `80` | port exposed by the Service |
+| service.nodePort | string | `nil` | the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one. |
+| service.type | string | `"ClusterIP"` | the Service type |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |

--- a/deploy/helm/templates/monitor/service.yaml
+++ b/deploy/helm/templates/monitor/service.yaml
@@ -8,13 +8,17 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.service.headless }}
+  {{- if and (.Values.service.headless) (eq .Values.service.type "ClusterIP") }}
   clusterIP: None
-  {{ end }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
       targetPort: metrics
+      {{- if not (empty .Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       appProtocol: {{ .Values.service.metricsAppProtocol }}
   selector: {{- include "trivy-operator.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -183,12 +183,18 @@ image:
 # -- service only expose a metrics endpoint for prometheus to scrape,
 # trivy-operator does not have a user interface.
 service:
+  # -- if true, the Service doesn't allocate any IP
   headless: true
+  # -- port exposed by the Service
   metricsPort: 80
   # -- annotations added to the operator's service
   annotations: {}
   # -- appProtocol of the monitoring service
   metricsAppProtocol: TCP
+  # -- the Service type
+  type: ClusterIP
+  # -- the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one.
+  nodePort:
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -3111,9 +3111,7 @@ metadata:
     app.kubernetes.io/version: "0.19.0"
     app.kubernetes.io/managed-by: kubectl
 spec:
-  
   clusterIP: None
-  
   ports:
     - name: metrics
       port: 80
@@ -3123,6 +3121,7 @@ spec:
   selector:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
+  type: ClusterIP
 ---
 # Source: trivy-operator/templates/rbac/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description

My use case is to scrape the metrics from a prometheus outside the Kubernetes cluster, thus I use a Service of kind NodePort for this.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
