### PR TITLE
Add existingsecret to policiesbundle

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -91,6 +91,7 @@ Keeps security report resources updated
 | policiesBundle.registryUser | string | `nil` | registryUser is the user for the registry |
 | policiesBundle.repository | string | `"aquasecurity/trivy-policies"` | repository of the policies bundle |
 | policiesBundle.tag | int | `0` | tag version of the policies bundle |
+| policiesBundle.existingSecret | bool | `false` | Specify wether to use an existing secret |
 | priorityClassName | string | `""` | priorityClassName set the operator priorityClassName |
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |

--- a/deploy/helm/templates/secrets/operator.yaml
+++ b/deploy/helm/templates/secrets/operator.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.policiesBundle.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -12,4 +13,4 @@ data:
   {{- with .Values.policiesBundle.registryPassword }}
   policies.bundle.oci.password: {{ . | b64enc | quote }}
   {{- end }}
-  
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -622,6 +622,11 @@ policiesBundle:
   registryUser: ~
   # -- registryPassword is the password for the registry
   registryPassword: ~
+  # -- existingSecret if a secret containing registry credentials that have been created outside the chart (e.g external-secrets, sops, etc...).
+  # Keys must be at least one of the following: policies.bundle.oci.user, policies.bundle.oci.password
+  # Overrides policiesBundle.registryUser, policiesBundle.registryPassword values.
+  # Note: The secret has to be named "trivy-operator".
+  existingSecret: false
 
 
 nodeCollector:


### PR DESCRIPTION
## Description
Add the possibility to specify an existing secret for the policiesBundle secret.

## Related issues
- Close #1951

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
