### PR TITLE
fix: add appropriate info msg for not supported windows images

### DIFF
--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/exposedsecretreport"
@@ -346,7 +347,11 @@ func (r *ScanJobController) completedContainers(ctx context.Context, scanJob *ba
 			completedContainers = append(completedContainers, container)
 			continue
 		}
-		log.Error(nil, "Scan job container", "container", container, "status.reason", status.Reason, "status.message", status.Message)
+		if strings.Contains(status.Message, "no child with platform linux") {
+			log.Info("Scan job container", "container", container, "status.reason", status.Reason, "status.message", "Scanning Windows images is not supported.")
+		} else {
+			log.Error(nil, "Scan job container", "container", container, "status.reason", status.Reason, "status.message", status.Message)
+		}
 	}
 	return completedContainers, nil
 }


### PR DESCRIPTION
## Description
Add appropriate info msg for not supported windows images

## Related issues
- Close #1953

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
