### PR TITLE
fix: handle non sha256 digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/CycloneDX/cyclonedx-go v0.8.0
 	github.com/aquasecurity/trivy v0.50.1
-	github.com/aquasecurity/trivy-kubernetes v0.6.5
+	github.com/aquasecurity/trivy-kubernetes v0.6.6-0.20240401115615-a80da9767444
 	github.com/bluele/gcache v0.0.2
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/aquasecurity/trivy-db v0.0.0-20231020043206-3770774790ce h1:53T1cV67m
 github.com/aquasecurity/trivy-db v0.0.0-20231020043206-3770774790ce/go.mod h1:cj9/QmD9N3OZnKQMp+/DvdV+ym3HyIkd4e+F0ZM3ZGs=
 github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48 h1:JVgBIuIYbwG+ekC5lUHUpGJboPYiCcxiz06RCtz8neI=
 github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48/go.mod h1:Ldya37FLi0e/5Cjq2T5Bty7cFkzUDwTcPeQua+2M8i8=
-github.com/aquasecurity/trivy-kubernetes v0.6.5 h1:pI8C/IuTIdQBS3HzdBoWUGfDpSRAUALuYGOCLLuAMQE=
-github.com/aquasecurity/trivy-kubernetes v0.6.5/go.mod h1:rMvXfOG6anW/9F4vhv4gN9NPkS6ixurfXtYujUPrSvo=
+github.com/aquasecurity/trivy-kubernetes v0.6.6-0.20240401115615-a80da9767444 h1:GLH96nkoTokFW/0lxxJKKqhgbBphettiZ060XUDN+us=
+github.com/aquasecurity/trivy-kubernetes v0.6.6-0.20240401115615-a80da9767444/go.mod h1:rMvXfOG6anW/9F4vhv4gN9NPkS6ixurfXtYujUPrSvo=
 github.com/aquasecurity/trivy-policies v0.10.0 h1:QONOsIFi6+WyB+7NGMBQeCgMFcRg6RV9dTBBpeOFDxU=
 github.com/aquasecurity/trivy-policies v0.10.0/go.mod h1:7WU0GTUqtQxqQ+FV3JAy7lskQQZU6lp7Mz1i8GEapFw=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=


### PR DESCRIPTION
## Description
Handle non sha256 digest

## Related issues
- Close #1920

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).

