### PR TITLE
fix: remove controller manager timeout

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -371,10 +371,8 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 		}
 	}
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, *operatorConfig.ControllerCacheSyncTimeout)
-	defer cancel()
 	setupLog.Info("Starting controllers manager")
-	if err := mgr.Start(ctxWithTimeout); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("starting controllers manager: %w", err)
 	}
 


### PR DESCRIPTION
## Description
Remove controller manager timeout
## Related issues
- Close #1979

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
