### PR TITLE
fix(helm): trivy server value typo

### DIFF
--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -95,7 +95,7 @@ data:
   {{- else }}
   trivy.mode: {{ .Values.trivy.mode | quote }}
   {{- if eq .Values.trivy.mode "ClientServer" }}
-  trivy.serverURL: {{ required ".Values.trivy.serverUrl is required" .Values.trivy.serverUrl | quote }}
+  trivy.serverURL: {{ required ".Values.trivy.serverURL is required" .Values.trivy.serverURL | quote }}
   {{- with .Values.trivy.clientServerSkipUpdate }}
   trivy.clientServerSkipUpdate: {{ . | quote }}
   {{- end }}


### PR DESCRIPTION
## Description

This PR fixes the typo introduced in commit https://github.com/aquasecurity/trivy-operator/commit/f652926cc222efe7377c44389c38432551f1f356#diff-fcb9b9ad942468c142ea99160a28f7b76079583996e888e9801bce4f0f104784R98 that impacts the usage of Trivy Operator in Client/Server mode.

Like mentioned in the issue though, it looks like the commit that introduced the issue was done by a CI/CD process ?

## Related issues
- Close [1983](https://github.com/aquasecurity/trivy-operator/issues/1983)

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
