### PR TITLE
docs: add information on running Helm Chart in client server mode

### DIFF
--- a/docs/docs/vulnerability-scanning/trivy.md
+++ b/docs/docs/vulnerability-scanning/trivy.md
@@ -33,7 +33,25 @@ EOF
 
 ## ClientServer
 
-You can connect Trivy to an external Trivy server by changing the default `trivy.mode` from
+Running Trivy in Client Server mode is more efficient as every scan will access the same Trivy vulnerability database from the server.
+
+There are two options to run the Trivy Operator in Client Server mode as detailed below.
+
+**1. Server Managed by the Trivy Operator**
+
+The Trivy Operator has an option [in the values.yaml file](https://github.com/aquasecurity/trivy-operator/blob/8b906fdf4d4c4ac425db6065e6d577af4e00c284/deploy/helm/values.yaml#L107) of the Helm chart to specify the Trivy Operator to run in Client Server mode:
+```
+operator:
+  builtInTrivyServer: false
+```
+
+Setting this option to `true` will enable the Client Server mode, managed by the Trivy Operator. No further configuration is required. The Trivy Operator will spin up two pods in the respective namsepace:
+1. trivy-operator: Responsible for running scans
+2. trivy-server-0: Provides the Trivy vulnerability database to the trivy-operator
+
+**2. External Server Managed by the user**
+
+Users can connect Trivy to an external Trivy server by changing the default `trivy.mode` from
 [`Standalone`][trivy-standalone] to [`ClientServer`][trivy-clientserver] and specifying `trivy.serverURL`.
 
 ```bash

--- a/docs/docs/vulnerability-scanning/trivy.md
+++ b/docs/docs/vulnerability-scanning/trivy.md
@@ -46,8 +46,9 @@ operator:
 ```
 
 Setting this option to `true` will enable the Client Server mode, managed by the Trivy Operator. No further configuration is required. The Trivy Operator will spin up two pods in the respective namsepace:
-1. trivy-operator: Responsible for running scans
-2. trivy-server-0: Provides the Trivy vulnerability database to the trivy-operator
+
+1. `trivy-operator`: Responsible for running scans
+2. `trivy-server-0`: Provides the Trivy vulnerability database to the trivy-operator
 
 **2. External Server Managed by the user**
 


### PR DESCRIPTION
Update client/server mode documentations