### PR TITLE
feat(helm): only deploy ClusterComplianceReports if enabled

### DIFF
--- a/deploy/helm/templates/specs/cis-1.23.yaml
+++ b/deploy/helm/templates/specs/cis-1.23.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.clusterComplianceEnabled }}
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:
@@ -821,3 +822,4 @@ spec:
         checks:
           - id: AVD-KSV-0110
         severity: MEDIUM
+{{- end }}

--- a/deploy/helm/templates/specs/nsa-1.0.yaml
+++ b/deploy/helm/templates/specs/nsa-1.0.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.clusterComplianceEnabled }}
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:
@@ -180,3 +181,4 @@ spec:
         checks:
           - id: AVD-KCV-0020
         severity: 'MEDIUM'
+{{- end }}

--- a/deploy/helm/templates/specs/pss-baseline.yaml
+++ b/deploy/helm/templates/specs/pss-baseline.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.clusterComplianceEnabled }}
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:
@@ -98,3 +99,4 @@ spec:
         checks:
           - id: avd-ksv-0026
         severity: 'MEDIUM'
+{{- end }}

--- a/deploy/helm/templates/specs/pss-restricted.yaml
+++ b/deploy/helm/templates/specs/pss-restricted.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.clusterComplianceEnabled }}
 apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:
@@ -138,3 +139,4 @@ spec:
         checks:
           - id: avd-ksv-0106
         severity: 'LOW'
+{{- end }}


### PR DESCRIPTION
## Description

Only deploy ClusterComplianceReports (using Helm) if they are enabled.

## Related issues

- As discussed in #1078

## Checklist

- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
