### PR TITLE
fix: typo in policy download

### DIFF
--- a/pkg/policy/loader.go
+++ b/pkg/policy/loader.go
@@ -80,11 +80,11 @@ func (pl *policyLoader) LoadPolicies() ([]string, error) {
 
 	policyPath, err := pl.getBuiltInPolicies(context.Background())
 	if err != nil {
-		return []string{}, fmt.Errorf("failed to donwload policies: %w", err)
+		return []string{}, fmt.Errorf("failed to download policies: %w", err)
 	}
 	policiesData, err := LoadPoliciesData(policyPath)
 	if err != nil {
-		return []string{}, fmt.Errorf("failed to donwload policies: %w", err)
+		return []string{}, fmt.Errorf("failed to download policies: %w", err)
 	}
 	_ = pl.cache.SetWithExpire(bundlePolicies, policiesData, *pl.expiration)
 	return policiesData, nil


### PR DESCRIPTION
## Description
I fixed an incorrect message displayed when downloading policy data fails.

## Related issues

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
