### PR TITLE
fix: trivy db repository credential set

### DIFF
--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -233,8 +233,8 @@ func (c Config) GetSkipJavaDBUpdate() bool {
 }
 
 func (c Config) TrivyDBRepositoryCredentialsSet() bool {
-	_, userOk := c.Data[keyTrivyDBRepositoryUsername]
-	_, passOk := c.Data[keyTrivyDBRepositoryPassword]
+	_, userOk := c.SecretData[keyTrivyDBRepositoryUsername]
+	_, passOk := c.SecretData[keyTrivyDBRepositoryPassword]
 	return userOk && passOk
 }
 


### PR DESCRIPTION
## Description

Regarding the issue in #2063, I checked the code and realized that environment value (TRIVY_USER/TRIVY_PASSWORD) is not set at initContainer step.

So I looked at the related code, and it seemed to be caused by the DB Registry User/Password information set in k8s secret being set to refer to ConfigMap data.

```
func (c Config) TrivyDBRepositoryCredentialsSet() bool {
	_, userOk := c.Data[keyTrivyDBRepositoryUsername]
	_, passOk := c.Data[keyTrivyDBRepositoryPassword]
	return userOk && passOk
}
```

I tried putting the trivy db private registry credentials in the configmap and it worked fine, but I think it should be referencing secret as originally intended, please confirm

## Related issues
- Close #2063 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
