### PR TITLE
fix: the use of embedded checks, fallback for air-gapped env.

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -178,7 +178,7 @@ Keeps security report resources updated
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks  |
-| trivy.useEmbeddedRegoPolicies | string | `"false"` | useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments when setting useBuiltinRegoPolicies to true the `useBuiltinRegoPolicies` should be set to false |
+| trivy.useEmbeddedRegoPolicies | string | `"false"` | To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments. When useEmbeddedRegoPolicies is set to true, useBuiltinRegoPolicies should be set to false. |
 | trivy.vulnType | string | `nil` | vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os) |
 | trivyOperator.additionalReportLabels | string | `""` | additionalReportLabels comma-separated representation of the labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the reports with the labels `foo: bar` and `env: stage` |
 | trivyOperator.configAuditReportsPlugin | string | `"Trivy"` | configAuditReportsPlugin the name of the plugin that generates config audit reports. |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -177,7 +177,8 @@ Keeps security report resources updated
 | trivy.storageSize | string | `"5Gi"` | storageSize is the size of the trivy server PVC |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
-| trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default  |
+| trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks  |
+| trivy.useEmbeddedRegoPolicies | string | `"false"` | useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments  |
 | trivy.vulnType | string | `nil` | vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os) |
 | trivyOperator.additionalReportLabels | string | `""` | additionalReportLabels comma-separated representation of the labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the reports with the labels `foo: bar` and `env: stage` |
 | trivyOperator.configAuditReportsPlugin | string | `"Trivy"` | configAuditReportsPlugin the name of the plugin that generates config audit reports. |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -178,7 +178,7 @@ Keeps security report resources updated
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks  |
-| trivy.useEmbeddedRegoPolicies | string | `"false"` | useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments  |
+| trivy.useEmbeddedRegoPolicies | string | `"false"` | useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments when setting useBuiltinRegoPolicies to true the `useBuiltinRegoPolicies` should be set to false |
 | trivy.vulnType | string | `nil` | vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os) |
 | trivyOperator.additionalReportLabels | string | `""` | additionalReportLabels comma-separated representation of the labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the reports with the labels `foo: bar` and `env: stage` |
 | trivyOperator.configAuditReportsPlugin | string | `"Trivy"` | configAuditReportsPlugin the name of the plugin that generates config audit reports. |

--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -67,6 +67,9 @@ data:
   {{- with .Values.trivy.useBuiltinRegoPolicies }}
   trivy.useBuiltinRegoPolicies: {{ . | quote }}
   {{- end }}
+  {{- with .Values.trivy.useEmbeddedRegoPolicies }}
+  trivy.useEmbeddedRegoPolicies: {{ . | quote }}
+  {{- end }}
   {{- with .Values.trivy.offlineScan }}
   trivy.offlineScan: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -527,7 +527,7 @@ trivy:
   useBuiltinRegoPolicies: "true"
 
   # -- useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments
-  #
+  # when setting useBuiltinRegoPolicies to true the `useBuiltinRegoPolicies` should be set to false
   useEmbeddedRegoPolicies: "false"
 
   # -- The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -526,8 +526,8 @@ trivy:
   #
   useBuiltinRegoPolicies: "true"
 
-  # -- useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments
-  # when setting useBuiltinRegoPolicies to true the `useBuiltinRegoPolicies` should be set to false
+  # -- To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments.
+  # When useEmbeddedRegoPolicies is set to true, useBuiltinRegoPolicies should be set to false.
   useEmbeddedRegoPolicies: "false"
 
   # -- The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -522,9 +522,13 @@ trivy:
   #
   dbRepositoryInsecure: "false"
 
-  # -- The Flag to enable the usage of builtin rego policies by default
+  # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks
   #
   useBuiltinRegoPolicies: "true"
+
+  # -- useEmbeddedRegoPolicies The Flag to enable the usage of embedded rego policies, this should be used as fallback for air-gapped environments
+  #
+  useEmbeddedRegoPolicies: "false"
 
   # -- The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner
   #

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -3040,6 +3040,7 @@ data:
   trivy.sbomSources: ""
   trivy.dbRepositoryInsecure: "false"
   trivy.useBuiltinRegoPolicies: "true"
+  trivy.useEmbeddedRegoPolicies: "false"
   trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"
   trivy.timeout: "5m0s"
   trivy.mode: "Standalone"

--- a/pkg/configauditreport/plugin.go
+++ b/pkg/configauditreport/plugin.go
@@ -19,6 +19,8 @@ type ConfigAuditConfig interface {
 
 	// GetUseBuiltinRegoPolicies return trivy config which associated to configauditreport plugin
 	GetUseBuiltinRegoPolicies() bool
+	// GetUseEmbeddedRegoPolicies return trivy embedded rego policies (mainly for air-gapped environment)
+	GetUseEmbeddedRegoPolicies() bool
 	// GetSupportedConfigAuditKinds list of supported kinds to be scanned by the config audit scanner
 	GetSupportedConfigAuditKinds() []string
 

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -56,6 +56,7 @@ const (
 	keyTrivyDBRepositoryInsecure = "trivy.dbRepositoryInsecure"
 
 	keyTrivyUseBuiltinRegoPolicies    = "trivy.useBuiltinRegoPolicies"
+	keyTrivyUseEmbeddedRegoPolicies   = "trivy.useEmbeddedRegoPolicies"
 	keyTrivySupportedConfigAuditKinds = "trivy.supportedConfigAuditKinds"
 
 	keyTrivyServerURL              = "trivy.serverURL"
@@ -275,6 +276,17 @@ func (c Config) GetUseBuiltinRegoPolicies() bool {
 	boolVal, err := strconv.ParseBool(val)
 	if err != nil {
 		return true
+	}
+	return boolVal
+}
+func (c Config) GetUseEmbeddedRegoPolicies() bool {
+	val, ok := c.Data[keyTrivyUseEmbeddedRegoPolicies]
+	if !ok {
+		return false
+	}
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
 	}
 	return boolVal
 }

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1070,7 +1070,8 @@ func (a resultSort) Less(i, j int) bool { return a[i].Metadata.ID < a[j].Metadat
 func (a resultSort) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 type testConfig struct {
-	builtInPolicies bool
+	builtInPolicies  bool
+	embeddedPolicies bool
 }
 
 func newTestConfig(builtInPolicies bool) testConfig {
@@ -1080,6 +1081,11 @@ func newTestConfig(builtInPolicies bool) testConfig {
 // GetUseBuiltinRegoPolicies return trivy config which associated to configauditreport plugin
 func (tc testConfig) GetUseBuiltinRegoPolicies() bool {
 	return tc.builtInPolicies
+}
+
+// GetUseBuiltinRegoPolicies return trivy config which associated to configauditreport plugin
+func (tc testConfig) GetUseEmbeddedRegoPolicies() bool {
+	return tc.embeddedPolicies
 }
 
 // GetSupportedConfigAuditKinds list of supported kinds to be scanned by the config audit scanner


### PR DESCRIPTION
## Description
The use of embedded checks, fallback for air-gapped env.

## Related issues
- Close #2078

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
