### PR TITLE
fix: Add scanJobAnnotations to the Job instead of just the Pod

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -192,7 +192,7 @@ Keeps security report resources updated
 | trivyOperator.reportRecordFailedChecksOnly | bool | `true` | reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment) |
 | trivyOperator.reportResourceLabels | string | `""` | reportResourceLabels comma-separated scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app` |
 | trivyOperator.scanJobAffinity | list | `[]` | scanJobAffinity affinity to be applied to the scanner pods and node-collector |
-| trivyOperator.scanJobAnnotations | string | `""` | scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
+| trivyOperator.scanJobAnnotations | string | `""` | scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner jobs and pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner jobs and pods with the annotations `foo: bar` and `env: stage` |
 | trivyOperator.scanJobAutomountServiceAccountToken | bool | `false` | scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job |
 | trivyOperator.scanJobCompressLogs | bool | `true` | scanJobCompressLogs control whether scanjob output should be compressed or plain |
 | trivyOperator.scanJobCustomVolumes | list | `[]` | scanJobCustomVolumes add custom volumes to the scan job |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -271,8 +271,8 @@ trivyOperator:
   # -- scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job
   scanJobAutomountServiceAccountToken: false
 
-  # -- scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner pods to be
-  # annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage`
+  # -- scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner jobs and pods to be
+  # annotated with. Example: `foo=bar,env=stage` will annotate the scanner jobs and pods with the annotations `foo: bar` and `env: stage`
   scanJobAnnotations: ""
 
   # -- scanJobPodTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -220,14 +220,17 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		}
 	}
 
+	jobAnnotations := make(map[string]string, len(s.annotations) + 1)
+	jobAnnotations[trivyoperator.AnnotationContainerImages] = containerImagesAsJSON
+	for k, v := range s.annotations {
+		jobAnnotations[k] = v
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetScanJobName(s.object),
 			Namespace: s.pluginContext.GetNamespace(),
 			Labels:    jobLabels,
-			Annotations: map[string]string{
-				trivyoperator.AnnotationContainerImages: containerImagesAsJSON,
-			},
+			Annotations: jobAnnotations,
 		},
 		Spec: jobSpec,
 	}

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -141,6 +141,84 @@ func TestScanJobBuilder(t *testing.T) {
 		}))
 	})
 
+	t.Run("Should get scan job with annotations", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		job, _, err := vulnerabilityreport.NewScanJobBuilder().
+			WithPlugin(&testPlugin{}).
+			WithPluginContext(trivyoperator.NewPluginContext().
+				WithName("test-plugin").
+				WithNamespace("trivy-operator-ns").
+				WithServiceAccountName("trivy-operator-sa").
+				Get()).
+			WithAnnotations(map[string]string{"test-annotation": "test-value"}).
+			WithTimeout(3 * time.Second).
+			WithObject(&appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-6799fc88d8",
+					Namespace: "prod-ns",
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx:1.16",
+								},
+							},
+						},
+					},
+					Selector: &metav1.LabelSelector{},
+				},
+			}).
+			Get()
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(job).ToNot(gomega.BeNil())
+		g.Expect(job).To(gomega.Equal(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scan-vulnerabilityreport-64d65c457",
+				Namespace: "trivy-operator-ns",
+				Labels: map[string]string{
+					trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
+					trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
+					trivyoperator.LabelResourceKind:               "ReplicaSet",
+					trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
+					trivyoperator.LabelResourceNamespace:          "prod-ns",
+					trivyoperator.LabelResourceSpecHash:           "788f48d57f",
+				},
+				Annotations: map[string]string{
+					"test-annotation": "test-value",
+					trivyoperator.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
+				},
+			},
+			Spec: batchv1.JobSpec{
+				BackoffLimit:          ptr.To[int32](0),
+				Completions:           ptr.To[int32](1),
+				ActiveDeadlineSeconds: ptr.To[int64](3),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
+							trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
+							trivyoperator.LabelResourceKind:               "ReplicaSet",
+							trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
+							trivyoperator.LabelResourceNamespace:          "prod-ns",
+							trivyoperator.LabelResourceSpecHash:           "788f48d57f",
+						},
+						Annotations: map[string]string{
+							"test-annotation": "test-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+		}))
+	})
+
 	t.Run("Should get scan job running in workload namespace", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 		job, _, err := vulnerabilityreport.NewScanJobBuilder().


### PR DESCRIPTION
## Description

The `scanJobAnnotations` were only added to the `Pod`, and not the `Job`, despite the name. Let's add the annotations to both places.

## Related issues

- Close #2109

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
