### PR TITLE
fix: failed to eval rego misconfig policy

### DIFF
--- a/pkg/policy/loader.go
+++ b/pkg/policy/loader.go
@@ -108,7 +108,7 @@ func LoadPoliciesData(policyPath []string) ([]string, error) {
 	policiesList := []string{}
 	fileList := []string{}
 	err := filepath.Walk(policyPath[0], func(path string, f os.FileInfo, err error) error {
-		if strings.Contains(path, "/kubernetes/") { // load only k8s policies
+		if strings.Contains(path, "policies/kubernetes/") { // load only k8s policies
 			fileList = append(fileList, path)
 		}
 		return nil


### PR DESCRIPTION
## Description
failed to eval rego misconfig policy

## Related issues
- Close #2123

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
