### PR TITLE
chore: make operator policies-config optional

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -133,6 +133,7 @@ Keeps security report resources updated
 | trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
 | trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
+| trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies, this should be used when the user wants to use their own rego policies  |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |
 | trivy.httpProxy | string | `nil` | httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub. |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -133,7 +133,7 @@ Keeps security report resources updated
 | trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
 | trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
-| trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies, this should be used when the user wants to use their own rego policies  |
+| trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies  |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |
 | trivy.httpProxy | string | `nil` | httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub. |

--- a/deploy/helm/templates/configmaps/policies.yaml
+++ b/deploy/helm/templates/configmaps/policies.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.trivy.externalRegoPoliciesEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
     {{- include "trivy-operator.labels" . | nindent 4 }}
 data:
   {{- .Values.trivyOperator.policiesConfig | nindent 2 }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -538,7 +538,7 @@ trivy:
   # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks
   #
   useBuiltinRegoPolicies: "true"
-  # -- The Flag to enable the usage of external rego policies, this should be used when the user wants to use their own rego policies
+  # -- The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies
   #
   externalRegoPoliciesEnabled: false
   # -- To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -538,7 +538,9 @@ trivy:
   # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks
   #
   useBuiltinRegoPolicies: "true"
-
+  # -- The Flag to enable the usage of external rego policies, this should be used when the user wants to use their own rego policies
+  #
+  externalRegoPoliciesEnabled: false
   # -- To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments.
   # When useEmbeddedRegoPolicies is set to true, useBuiltinRegoPolicies should be set to false.
   useEmbeddedRegoPolicies: "false"

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2948,19 +2948,6 @@ data:
 
   node.collector.nodeSelector: "true"
 ---
-# Source: trivy-operator/templates/configmaps/policies.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trivy-operator-policies-config
-  namespace: trivy-system
-  labels:
-    app.kubernetes.io/name: trivy-operator
-    app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.21.3"
-    app.kubernetes.io/managed-by: kubectl
-data:
----
 # Source: trivy-operator/templates/configmaps/trivy-operator-config.yaml
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
## Description
make operator policies-config optional

## Related issues
- Close #2098

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
