### PR TITLE
docs: add section on importing the Grafana dashboard using the Grafana Helm Chart

### DIFF
--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -186,7 +186,7 @@ sum(trivy_image_exposedsecrets)
 ### Set up Grafana Dashboard for Trivy Operator Metrics
 
 Lastly, we want to visualise the security issues within our cluster in a Grafana Dashboard.
-You can either do that manually in Grafana, or using the Helm chart. 
+You can either do that manually in Grafana, or using the Grafana Helm chart. 
 
 The link to the dashboard in Grafana is [the following.](https://grafana.com/grafana/dashboards/17813)
 
@@ -208,7 +208,7 @@ Here, we will paste the ID of the Aqua Trivy Dashboard: `17813`
 Once pasted, you should see the following dashboard as part of your Dashboard list: `Trivy Operator Dashboard`
 
 
-#### Using the Helm Chart
+#### Using the Grafana Helm Chart
 
 The Grafana Helm chart supports importing the dashboard. To import the dashbaord using the ID, the Helm chart requires both a dashboard provider, as well as the dashboard itself as shown in the snippet below.
 In the [Grafana Helm chart documentation](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards), you find examples of importing a dashboard with the dashboard ID. 

--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -186,8 +186,13 @@ sum(trivy_image_exposedsecrets)
 ### Set up Grafana Dashboard for Trivy Operator Metrics
 
 Lastly, we want to visualise the security issues within our cluster in a Grafana Dashboard.
+You can either do that manually in Grafana, or through the Helm Chart. 
 
-For this, navigate to the Grafana URL http://localhost:3000.
+The link to the dashboard in Grafana is [the following.](https://grafana.com/grafana/dashboards/17813)
+
+#### Manually in Grafana
+
+Navigate to the Grafana URL http://localhost:3000.
 
 Username: admin  
 Password: prom-operator
@@ -200,8 +205,36 @@ Once you see all the default Dashboards, click `New`, then `Import`.
 
 Here, we will paste the ID of the Aqua Trivy Dashboard: `17813`
 
-The link to the dashboard in Grafana is [the following.](https://grafana.com/grafana/dashboards/17813)
+Once pasted, you should see the following dashboard as part of your Dashboard list: `Trivy Operator Dashboard`
 
-Once pasted, you should see the following Dashboard as part of your Dashboard list: `Trivy Operator Dashboard`
+
+#### Using the Helm Chart
+
+The Grafana Helm chart supports importing the dashboard. To import the dashbaord using the ID, the Helm chart requires both a dashboard provider, as well as the dashboard itself as shown in the snippet below.
+In the [Grafana Helm chart documentation](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards), you find examples of importing a dashboard with the dashboard ID. 
+
+```yaml
+grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+      - name: '' 
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: false
+        options:
+          path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default: 
+      trivy-operator-dashboard:
+        gnetId: 17813
+        revision: 2
+        datasource: Prometheus
+```
+
+When the Helm Chart has been applied, you should see the dashboard as part of your Dashboard list. It is named `Trivy Operator Dashboard`.
 
 ![Trivy Operator Dashbaord in Grafana Screenshot](../images/trivy-grafana.png)

--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -186,7 +186,7 @@ sum(trivy_image_exposedsecrets)
 ### Set up Grafana Dashboard for Trivy Operator Metrics
 
 Lastly, we want to visualise the security issues within our cluster in a Grafana Dashboard.
-You can either do that manually in Grafana, or through the Helm Chart. 
+You can either do that manually in Grafana, or using the Helm chart. 
 
 The link to the dashboard in Grafana is [the following.](https://grafana.com/grafana/dashboards/17813)
 
@@ -235,6 +235,6 @@ grafana:
         datasource: Prometheus
 ```
 
-When the Helm Chart has been applied, you should see the dashboard as part of your Dashboard list. It is named `Trivy Operator Dashboard`.
+When the Helm chart has been applied, you should see the dashboard as part of your Dashboard list. It is named `Trivy Operator Dashboard`.
 
 ![Trivy Operator Dashbaord in Grafana Screenshot](../images/trivy-grafana.png)


### PR DESCRIPTION
## Description
Adding section on how to import the dashboard using the Grafana Helm Chart. I think this is helpful as many use the Grafana Helm chart to set it up. 

From the Grafana spec:
https://github.com/grafana/helm-charts/blob/grafana-8.0.2/charts/grafana/values.yaml#L708-L759

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works. 
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
