### PR TITLE
feat: Provide credentials in imagePullSecret without global access

### DIFF
--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -252,19 +252,34 @@ func (r *WorkloadController) SubmitScanJob(ctx context.Context, owner client.Obj
 		"name", owner.GetName(), "namespace", owner.GetNamespace())
 	var err error
 	credentials := make(map[string]docker.Auth, 0)
+
+	privateRegistrySecrets, err := r.Config.GetPrivateRegistryScanSecretsNames()
+	if err != nil {
+		return err
+	}
+
+	pConfig, err := r.PluginContext.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	multiSecretSupport := trivy.MultiSecretSupport(trivy.Config{PluginConfig: pConfig})
+
 	if r.AccessGlobalSecretsAndServiceAccount && len(reusedReports) == 0 {
-		privateRegistrySecrets, err := r.Config.GetPrivateRegistryScanSecretsNames()
+		// Global access is enabled - therefore imagePullSecrets from the podSpec can be used
+		credentials, err = r.CredentialsByServer(ctx, owner, privateRegistrySecrets, multiSecretSupport, true)
 		if err != nil {
 			return err
 		}
-		pConfig, err := r.PluginContext.GetConfig()
-		if err != nil {
-			return err
-		}
-		multiSecretSupport := trivy.MultiSecretSupport(trivy.Config{PluginConfig: pConfig})
-		credentials, err = r.CredentialsByServer(ctx, owner, privateRegistrySecrets, multiSecretSupport)
-		if err != nil {
-			return err
+	} else {
+		// Global access is disabled - check if privateRegistrySecrets references an imagePullSecret in the operator namespace
+		imagePullSecretName, ok := privateRegistrySecrets[r.Config.Namespace]
+		if ok {
+			// privateRegistrySecrets references an imagePullSecret in the operator namespace - use this for pulling private images
+			credentials, err = r.CredentialsByServer(ctx, owner, map[string]string{r.Config.Namespace: imagePullSecretName}, multiSecretSupport, false)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
When running a cluster that contains images from a private registry one needs to configure authentication. This is done by using kubernetes ImagePullSecrets. By default the trivy-operator is able to read the secrets attached to a target workload and use them to access the container registry.

While this is necessary when working with different registries inside the cluster, this comes with one security downside: the operator needs access to all secrets inside the cluster.

If all images are being pulled from a single private registry then one ImagePullSecret can be used for all of them. The easiest one to use is inside the operator namespace (because the operator has access to secrets in its own namespace).

This change does not impact any deployments running with default settings (global access enabled). But in case one disables that access this allows to instead read a single ImagePullSecret and use it for all images.

## Related issues
- Close #2158 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
