### PR TITLE
chore: bump github.com/hashicorp/go-getter-v1.7.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -372,3 +372,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.7.5

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.4 h1:3yQjWuxICvSpYwqSayAdKRFcvBl1y/vogCxczWSmix0=
-github.com/hashicorp/go-getter v1.7.4/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/hashicorp/go-getter v1.7.5 h1:dT58k9hQ/vbxNMwoI5+xFYAJuv6152UNvdHokfI5wE4=
+github.com/hashicorp/go-getter v1.7.5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.6 h1:TwRYfx2z2C4cLbXmT8I5PgP/xmuqASDyiVuGYfs9GZM=


### PR DESCRIPTION
```
ghcr.io/aquasecurity/trivy-operator:5d266cfb4c9b643446c2262160c5d5f04b95f651-amd64 (alpine 3.19.1)
==================================================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/trivy-operator (gobinary)
=======================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────┐
│            Library             │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                          Title                           │
├────────────────────────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ github.com/hashicorp/go-getter │ CVE-2024-6257 │ HIGH     │ fixed  │ v1.7.4            │ 1.7.5         │ hashicorp/go-getter: Arbitrary command execution through │
│                                │               │          │        │                   │               │ local git config file                                    │
│                                │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6257                │
└────────────────────────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────┘
```