### PR TITLE
chore: platform and type - no metadata values

### DIFF
--- a/deploy/helm/templates/specs/k8s-cis-1.23.yaml
+++ b/deploy/helm/templates/specs/k8s-cis-1.23.yaml
@@ -3,8 +3,6 @@ apiVersion: aquasecurity.github.io/v1alpha1
 kind: ClusterComplianceReport
 metadata:
   name: k8s-cis-1.23
-  platform: k8s
-  type: cis
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator


### PR DESCRIPTION
remove
platform: k8s
type: cis
from metadata
fixes #2178