### PR TITLE
feat: allow override of matchLabels of serviceMonitor object

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -121,6 +121,7 @@ Keeps security report resources updated
 | serviceMonitor.interval | string | `nil` | Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used. |
 | serviceMonitor.labels | object | `{}` | Additional labels for the serviceMonitor |
 | serviceMonitor.namespace | string | `nil` | The namespace where Prometheus expects to find service monitors |
+| serviceMonitor.selectorOverride | object | `{}` | To override the default matchLabels |
 | targetNamespaces | string | `""` | targetNamespace defines where you want trivy-operator to operate. By default, it's a blank string to select all namespaces, but you can specify another namespace, or a comma separated list of namespaces. |
 | targetWorkloads | string | `"pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"` | targetWorkloads is a comma seperated list of Kubernetes workload resources to be included in the vulnerability and config-audit scans if left blank, all workload resources will be scanned |
 | tolerations | list | `[]` | tolerations set the operator tolerations |

--- a/deploy/helm/templates/monitor/servicemonitor.yaml
+++ b/deploy/helm/templates/monitor/servicemonitor.yaml
@@ -19,7 +19,9 @@ spec:
     - {{ include "trivy-operator.namespace" . }}
   {{- end }}
   selector:
-    matchLabels: {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- if .Values.serviceMonitor.selectorOverride }}
+    {{- with .Values.serviceMonitor.selectorOverride }} {{- toYaml . | nindent 6 }} {{- end }}
+    {{- else }} {{- include "trivy-operator.selectorLabels" . | nindent 6 }} {{- end }}
   endpoints:
   - honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     port: metrics

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -229,6 +229,8 @@ serviceMonitor:
   honorLabels: true
   # -- EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
   endpointAdditionalProperties: {}
+  # -- selectorOverride allows to override the matchLabel selector
+  selectorOverride: {}
 
 trivyOperator:
   # -- vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy`


### PR DESCRIPTION
## Description

When using ArgoCD to deploy trivy-operator the serviceMonitor matchLabel is incorrect since ArgoCD overrides the label  `app.kubernetes.io/instance` with the value  "argocd app name" and modern helm charts are using the value " release name" instead.

This feature allows overriding the selector if necessary.

## Checklist
- [ x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
