### PR TITLE
docs: Grafana Dashboard - Add headless parameter to values.yaml

### DIFF
--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -82,6 +82,8 @@ serviceMonitor:
   enabled: true
 trivy:
   ignoreUnfixed: true
+service:
+  headless: false    
 ```
 
 In the changes above, we tell the Trivy Helm Chart to first, enable the ServiceMonitor and then to ignore all vulnerabilities that do not have a fix available yet. The ServiceMonitor is required to allow Prometheus to discover the Trivy Operator Service and scrape its metrics.
@@ -141,8 +143,6 @@ kubectl port-forward service/prom-grafana -n monitoring 3000:80
 In a new terminal, we are going to port-forward to the Trivy Operator service to access the metrics provided by the operator.
 
 Note that this operation is optional and just used to demonstrate where you can find the metrics to then query them in a better way through Prometheus and Grafana.
-
-Run the following command to remove the headless setting  `clusterIP: None` by editing `trivy-operator` service:
 
 ```
 kubectl edit service trivy-operator -n trivy-system

--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -83,6 +83,7 @@ serviceMonitor:
 trivy:
   ignoreUnfixed: true
 service:
+  # disabled ensures that the pod gets a ClusterIP.
   headless: false    
 ```
 

--- a/docs/tutorials/grafana-dashboard.md
+++ b/docs/tutorials/grafana-dashboard.md
@@ -145,10 +145,6 @@ In a new terminal, we are going to port-forward to the Trivy Operator service to
 
 Note that this operation is optional and just used to demonstrate where you can find the metrics to then query them in a better way through Prometheus and Grafana.
 
-```
-kubectl edit service trivy-operator -n trivy-system
-```
-
 Run the following command to port-forward the Trivy Operator Service:
 
 ```


### PR DESCRIPTION
## Description

This enhancement simplifies the deployment process and ensures that the headless setting is correctly applied from the start when setting up a Dashboard in Grafana .

The trivy-operator Helm chart provides a headless parameter.

```
service:
  headless: false    
```

Running the command below to remove the ClusterIP might not work as expected. 

```
kubectl edit service trivy-operator -n trivy-system
```

The workaround for this was to run the following three commands:

```
kubectl get service trivy-operator -o yaml > trivy-operator.yaml
kubectl delete service trivy-operator 
kubectl apply -f trivy-operator.yaml
```
Updated the documentation to reflect this change and removed any references to the previous method

## Related issues

Trivial Fix - Docs Only

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
