### PR TITLE
fix: check gcr service account

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -210,7 +210,7 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 			registryPasswordKey := fmt.Sprintf("%s.password", c.Name)
 			secretName := secret.Name
 			if CheckGcpCrOrPrivateRegistry(c.Image) &&
-				trivyoperator.GetDefaultConfig().GetScanJobUseGCRServiceAccount() {
+				ctx.GetTrivyOperatorConfig().GetScanJobUseGCRServiceAccount() {
 				createEnvandVolumeForGcr(&env, &volumeMounts, &volumes, &registryPasswordKey, &secretName)
 			} else {
 				env = append(env, corev1.EnvVar{

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -68,7 +68,7 @@ const (
 	KeyNodeCollectorVolumeMounts         = "nodeCollector.volumeMounts"
 	KeyScanJobCustomVolumesMount         = "scanJob.customVolumesMount"
 	KeyScanJobCustomVolumes              = "scanJob.customVolumes"
-	KeyScanJobUseGCRServiceAccount       = "scanJob.UseGCRServiceAccount"
+	KeyScanJobUseGCRServiceAccount       = "scanJob.useGCRServiceAccount"
 
 	keyScanJobNodeSelector = "scanJob.nodeSelector"
 	keyScanJobAnnotations  = "scanJob.annotations"


### PR DESCRIPTION
Fix the checks for the gcr service account/

## Description
This address the pull requested #2108 merged.

- Fixed the typo in const `KeyScanJobUseGCRServiceAccount`.
- Use the DataConfig from the context instead of getting the default which does not contain our value

## Related issues
- Close #2108
