### PR TITLE
fix:  operator.scanSecretTTL not being respect

### DIFF
--- a/deploy/helm/templates/configmaps/trivy-operator-config.yaml
+++ b/deploy/helm/templates/configmaps/trivy-operator-config.yaml
@@ -22,6 +22,7 @@ data:
   OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
   OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
   OPERATOR_SCANNER_REPORT_TTL: {{ .Values.operator.scannerReportTTL | quote }}
+  OPERATOR_SCANNER_SECRET_TTL: {{ .Values.operator.scanSecretTTL | quote }}
   OPERATOR_CACHE_REPORT_TTL: {{ .Values.operator.cacheReportTTL | quote }}
   CONTROLLER_CACHE_SYNC_TIMEOUT: {{ .Values.operator.controllerCacheSyncTimeout | quote }}
   OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: {{ .Values.operator.configAuditScannerEnabled | quote }}


### PR DESCRIPTION
## Description
respect operator.scanSecretTTL
## Related issues
- Close #2208 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
