### PR TITLE
fix: Patch version uplift for Docker + GRPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v25.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.3+incompatible // indirect
+	github.com/docker/docker v26.1.5+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
@@ -272,7 +272,7 @@ require (
 	google.golang.org/genproto v0.0.0-20240311173647-c811ad7063a7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/grpc v1.64.1 // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.7.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/docker/cli v25.0.3+incompatible h1:KLeNs7zws74oFuVhgZQ5ONGZiXUUdgsdy6
 github.com/docker/cli v25.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.3+incompatible h1:lLCzRbrVZrljpVNobJu1J2FHk8V0s4BawoZippkc+xo=
-github.com/docker/docker v26.1.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -1758,8 +1758,8 @@ google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
-google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/grpc v1.64.1 h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=
+google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvyjeP0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
## Description

## Related issues
- Close [2218](https://github.com/aquasecurity/trivy-operator/issues/2218)

**Before:**
10:24:03  |base|m@bl460c-9 trivy-operator ±|main|→ trivy fs .
2024-08-08T10:24:05-05:00	INFO	[vuln] Vulnerability scanning is enabled
2024-08-08T10:24:05-05:00	INFO	[secret] Secret scanning is enabled
2024-08-08T10:24:05-05:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-08-08T10:24:05-05:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-08-08T10:24:11-05:00	INFO	Number of language-specific files	num=1
2024-08-08T10:24:11-05:00	INFO	[gomod] Detecting vulnerabilities...

go.mod (gomod)

Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 1)

┌──────────────────────────┬─────────────────────┬──────────┬────────┬─────────────────────┬─────────────────────────────────┬───────────────────────────────────────────────────────────┐
│         Library          │    Vulnerability    │ Severity │ Status │  Installed Version  │          Fixed Version          │                           Title                           │
├──────────────────────────┼─────────────────────┼──────────┼────────┼─────────────────────┼─────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ github.com/docker/docker │ CVE-2024-41110      │ CRITICAL │ fixed  │ 26.1.3+incompatible │ 23.0.14, 26.1.4, 27.1.0, 25.0.6 │ moby: Authz zero length regression                        │
│                          │                     │          │        │                     │                                 │ https://avd.aquasec.com/nvd/cve-2024-41110                │
├──────────────────────────┼─────────────────────┼──────────┤        ├─────────────────────┼─────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ google.golang.org/grpc   │ GHSA-xr7q-jx4m-x55m │ LOW      │        │ 1.64.0              │ 1.64.1                          │ Private tokens could appear in logs if context containing │
│                          │                     │          │        │                     │                                 │ gRPC metadata is...                                       │
│                          │                     │          │        │                     │                                 │ https://github.com/advisories/GHSA-xr7q-jx4m-x55m         │
└──────────────────────────┴─────────────────────┴──────────┴────────┴─────────────────────┴─────────────────────────────────┴───────────────────────────────────────────────────────────┘


**After :**
10:20:32  |base|m@bl460c-9 trivy-operator ±|hacks4snacks/vulnpatch ✗|→ trivy fs .
2024-08-08T10:21:05-05:00	INFO	[vuln] Vulnerability scanning is enabled
2024-08-08T10:21:05-05:00	INFO	[secret] Secret scanning is enabled
2024-08-08T10:21:05-05:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-08-08T10:21:05-05:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-08-08T10:21:12-05:00	INFO	Number of language-specific files	num=1
2024-08-08T10:21:12-05:00	INFO	[gomod] Detecting vulnerabilities...

**No detections**

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
