### PR TITLE
fix: scanjob.customVolumesMount is not applied to the Built-Job

### DIFF
--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -166,11 +166,11 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		templateSpec.Volumes = append(templateSpec.Volumes, s.customVolumes...)
 	}
 	if len(s.customVolumesMount) > 0 {
-		for _, container := range templateSpec.Containers {
-			container.VolumeMounts = append(container.VolumeMounts, s.customVolumesMount...)
+		for i := range templateSpec.Containers {
+			templateSpec.Containers[i].VolumeMounts = append(templateSpec.Containers[i].VolumeMounts, s.customVolumesMount...)
 		}
-		for _, initContainer := range templateSpec.InitContainers {
-			initContainer.VolumeMounts = append(initContainer.VolumeMounts, s.customVolumesMount...)
+		for i := range templateSpec.InitContainers {
+			templateSpec.InitContainers[i].VolumeMounts = append(templateSpec.InitContainers[i].VolumeMounts, s.customVolumesMount...)
 		}
 	}
 	templateSpec.PriorityClassName = s.podPriorityClassName

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -294,6 +294,97 @@ func TestScanJobBuilder(t *testing.T) {
 			},
 		}))
 	})
+
+	t.Run("Shoud set scan job with custom volume and volume mount", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		job, _, err := vulnerabilityreport.NewScanJobBuilder().
+			WithPlugin(&testPlugin{}).
+			WithPluginContext(trivyoperator.NewPluginContext().
+				WithName("test-plugin").
+				WithNamespace("trivy-operator-ns").
+				WithServiceAccountName("trivy-operator-sa").
+				Get()).
+			WithTimeout(3 * time.Second).
+			WithObject(&appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-6799fc88d8",
+					Namespace: "prod-ns",
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx:1.16",
+								},
+							},
+						},
+					},
+					Selector: &metav1.LabelSelector{},
+				},
+			}).
+			WithCustomVolumes([]corev1.Volume{
+				{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			}).
+			WithCustomVolumesMount([]corev1.VolumeMount{
+				{
+					Name:      "test-volume",
+					MountPath: "/test-mount-path",
+				},
+			}).
+			Get()
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(job).ToNot(gomega.BeNil())
+		g.Expect(job).To(gomega.Equal(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scan-vulnerabilityreport-64d65c457",
+				Namespace: "trivy-operator-ns",
+				Labels: map[string]string{
+					trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
+					trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
+					trivyoperator.LabelResourceKind:               "ReplicaSet",
+					trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
+					trivyoperator.LabelResourceNamespace:          "prod-ns",
+					trivyoperator.LabelResourceSpecHash:           "788f48d57f",
+				},
+				Annotations: map[string]string{
+					"test-annotation":                       "test-value",
+					trivyoperator.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
+				},
+			},
+			Spec: batchv1.JobSpec{
+				BackoffLimit:          ptr.To[int32](0),
+				Completions:           ptr.To[int32](1),
+				ActiveDeadlineSeconds: ptr.To[int64](3),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
+							trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
+							trivyoperator.LabelResourceKind:               "ReplicaSet",
+							trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
+							trivyoperator.LabelResourceNamespace:          "prod-ns",
+							trivyoperator.LabelResourceSpecHash:           "788f48d57f",
+						},
+						Annotations: map[string]string{
+							"test-annotation": "test-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+		}))
+	})
 }
 
 type testPlugin struct {

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -298,7 +298,7 @@ func TestScanJobBuilder(t *testing.T) {
 	t.Run("Shoud set scan job with custom volume and volume mount", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 		job, _, err := vulnerabilityreport.NewScanJobBuilder().
-			WithPlugin(&testPlugin{}).
+			WithPlugin(&testContainersPlugin{}).
 			WithPluginContext(trivyoperator.NewPluginContext().
 				WithName("test-plugin").
 				WithNamespace("trivy-operator-ns").
@@ -317,10 +317,17 @@ func TestScanJobBuilder(t *testing.T) {
 				Spec: appsv1.ReplicaSetSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "test-init-container",
+									Image: "test-init-image",
+								},
+							},
+
 							Containers: []corev1.Container{
 								{
-									Name:  "nginx",
-									Image: "nginx:1.16",
+									Name:  "test-container",
+									Image: "test-image",
 								},
 							},
 						},
@@ -350,16 +357,15 @@ func TestScanJobBuilder(t *testing.T) {
 				Name:      "scan-vulnerabilityreport-64d65c457",
 				Namespace: "trivy-operator-ns",
 				Labels: map[string]string{
-					trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
-					trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
-					trivyoperator.LabelResourceKind:               "ReplicaSet",
-					trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
-					trivyoperator.LabelResourceNamespace:          "prod-ns",
-					trivyoperator.LabelResourceSpecHash:           "788f48d57f",
+					"app.kubernetes.io/managed-by":      "trivy-operator",
+					"resource-spec-hash":                "7dcdf9f488",
+					"trivy-operator.resource.kind":      "ReplicaSet",
+					"trivy-operator.resource.name":      "nginx-6799fc88d8",
+					"trivy-operator.resource.namespace": "prod-ns",
+					"vulnerabilityReport.scanner":       "test-plugin",
 				},
 				Annotations: map[string]string{
-					"test-annotation":                       "test-value",
-					trivyoperator.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
+					"trivy-operator.container-images": `{"test-container":"test-image","test-init-container":"test-init-image"}`,
 				},
 			},
 			Spec: batchv1.JobSpec{
@@ -369,18 +375,48 @@ func TestScanJobBuilder(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							trivyoperator.LabelK8SAppManagedBy:            "trivy-operator",
-							trivyoperator.LabelVulnerabilityReportScanner: "test-plugin",
-							trivyoperator.LabelResourceKind:               "ReplicaSet",
-							trivyoperator.LabelResourceName:               "nginx-6799fc88d8",
-							trivyoperator.LabelResourceNamespace:          "prod-ns",
-							trivyoperator.LabelResourceSpecHash:           "788f48d57f",
-						},
-						Annotations: map[string]string{
-							"test-annotation": "test-value",
+							"app.kubernetes.io/managed-by":      "trivy-operator",
+							"resource-spec-hash":                "7dcdf9f488",
+							"trivy-operator.resource.kind":      "ReplicaSet",
+							"trivy-operator.resource.name":      "nginx-6799fc88d8",
+							"trivy-operator.resource.namespace": "prod-ns",
+							"vulnerabilityReport.scanner":       "test-plugin",
 						},
 					},
-					Spec: corev1.PodSpec{},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: "test-volume",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:  "test-init-container",
+								Image: "test-init-image",
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "test-volume",
+										MountPath: "/test-mount-path",
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "test-volume",
+										MountPath: "/test-mount-path",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		}))
@@ -399,5 +435,33 @@ func (p *testPlugin) GetScanJobSpec(_ trivyoperator.PluginContext, _ client.Obje
 }
 
 func (p *testPlugin) ParseReportData(_ trivyoperator.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, *v1alpha1.SbomReportData, error) {
+	return v1alpha1.VulnerabilityReportData{}, v1alpha1.ExposedSecretReportData{}, &v1alpha1.SbomReportData{}, nil
+}
+
+type testContainersPlugin struct {
+}
+
+func (p *testContainersPlugin) Init(_ trivyoperator.PluginContext) error {
+	return nil
+}
+
+func (p *testContainersPlugin) GetScanJobSpec(_ trivyoperator.PluginContext, _ client.Object, _ map[string]docker.Auth, _ *corev1.SecurityContext, _ map[string]v1alpha1.SbomReportData) (corev1.PodSpec, []*corev1.Secret, error) {
+	return corev1.PodSpec{
+		InitContainers: []corev1.Container{
+			{
+				Name:  "test-init-container",
+				Image: "test-init-image",
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:  "test-container",
+				Image: "test-image",
+			},
+		},
+	}, nil, nil
+}
+
+func (p *testContainersPlugin) ParseReportData(_ trivyoperator.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, *v1alpha1.SbomReportData, error) {
 	return v1alpha1.VulnerabilityReportData{}, v1alpha1.ExposedSecretReportData{}, &v1alpha1.SbomReportData{}, nil
 }


### PR DESCRIPTION
## Description

A value generated by `range` is pass-by-value and changes will not apply to original array.
Then I used an index to change the array values directly.

## Related issues
- Close #2240 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
