### PR TITLE
fix: Truncate cname to a max of 63 chars

### DIFF
--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -241,7 +241,13 @@ func CreateSbomDataAsSecret(bom v1alpha1.BOM, secretName string) (corev1.Secret,
 
 // CreateVolumeSbomFiles creates a volume and volume mount for the sbom data
 func CreateVolumeSbomFiles(volumeMounts *[]corev1.VolumeMount, volumes *[]corev1.Volume, secretName *string, fileName string, mountPath string, cname string) {
-	vname := fmt.Sprintf("sbomvol-%s", cname)
+	vnamePrefix := "sbomvol-"
+	// Truncate cname to ensure that vname fits within 63 characters including the prefix
+	maxCnameLength := 62 - len(vnamePrefix)
+	if len(cname) > maxCnameLength {
+		cname = cname[:maxCnameLength]
+	}
+	vname := fmt.Sprintf("%s%s", vnamePrefix, cname)
 	sbomMount := corev1.VolumeMount{
 		Name:      vname,
 		MountPath: mountPath,

--- a/pkg/plugins/trivy/jobspec_test.go
+++ b/pkg/plugins/trivy/jobspec_test.go
@@ -83,6 +83,7 @@ func TestCreateVolumes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			trivy.CreateVolumeSbomFiles(&tc.vm, &tc.v, &tc.sn, tc.fn, tc.mountPath, tc.cName)
 


### PR DESCRIPTION
## Description

## Related issues
- Close #2253

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
