### PR TITLE
refactor: Rename scanJobsRetryDelay param to avoid confusion

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -77,7 +77,7 @@ Keeps security report resources updated
 | operator.scanJobTTL | string | `""` | scanJobTTL the set automatic cleanup time after the job is completed |
 | operator.scanJobTimeout | string | `"5m"` | scanJobTimeout the length of time to wait before giving up on a scan job |
 | operator.scanJobsConcurrentLimit | int | `10` | scanJobsConcurrentLimit the maximum number of scan jobs create by the operator |
-| operator.scanJobsRetryDelay | string | `"30s"` | scanJobsRetryDelay the duration to wait before retrying a failed scan job |
+| operator.scanJobsRetryAfter | string | `"30s"` | scanJobsRetryAfter the duration to wait before retrying a failed scan job |
 | operator.scanNodeCollectorLimit | int | `1` | scanNodeCollectorLimit the maximum number of node collector jobs create by the operator |
 | operator.scanSecretTTL | string | `""` | scanSecretTTL set an automatic cleanup for scan job secrets |
 | operator.scannerReportTTL | string | `"24h"` | scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled |

--- a/deploy/helm/templates/configmaps/trivy-operator-config.yaml
+++ b/deploy/helm/templates/configmaps/trivy-operator-config.yaml
@@ -10,7 +10,7 @@ data:
   OPERATOR_SCAN_JOB_TIMEOUT: {{ .Values.operator.scanJobTimeout | quote }}
   OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
   OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: {{ .Values.operator.scanNodeCollectorLimit | quote }}
-  OPERATOR_SCAN_JOB_RETRY_AFTER: {{ .Values.operator.scanJobsRetryDelay | quote }}
+  OPERATOR_SCAN_JOB_RETRY_AFTER: {{ .Values.operator.scanJobsRetryAfter | quote }}
   OPERATOR_BATCH_DELETE_LIMIT: {{ .Values.operator.batchDeleteLimit | quote }}
   OPERATOR_BATCH_DELETE_DELAY: {{ .Values.operator.batchDeleteDelay | quote }}
   OPERATOR_METRICS_BIND_ADDRESS: ":8080"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -71,8 +71,8 @@ operator:
   # -- scanNodeCollectorLimit the maximum number of node collector jobs create by the operator
   scanNodeCollectorLimit: 1
 
-  # -- scanJobsRetryDelay the duration to wait before retrying a failed scan job
-  scanJobsRetryDelay: 30s
+  # -- scanJobsRetryAfter the duration to wait before retrying a failed scan job
+  scanJobsRetryAfter: 30s
 
   # -- the flag to enable vulnerability scanner
   vulnerabilityScannerEnabled: true


### PR DESCRIPTION
## Description

Recently I've worked with trivy-operator and was confused because of the difference in naming the same value. In [documentation](https://aquasecurity.github.io/trivy-operator/latest/getting-started/installation/configuration/) it's called `OPERATOR_SCAN_JOB_RETRY_AFTER` or similarly, the same is for [deploy/helm/templates/configmaps/trivy-operator-config.yaml](https://github.com/aquasecurity/trivy-operator/blob/18e40db60a957cf233afeb442bddca62a03e45e9/deploy/helm/templates/configmaps/trivy-operator-config.yaml#L13) and [deploy/static/trivy-operator.yaml](https://github.com/aquasecurity/trivy-operator/blob/18e40db60a957cf233afeb442bddca62a03e45e9/deploy/static/trivy-operator.yaml#L2987). 

Howhever, in [deploy/helm/values.yaml](https://github.com/aquasecurity/trivy-operator/blob/18e40db60a957cf233afeb442bddca62a03e45e9/deploy/helm/values.yaml#L75) the name of the value is `scanJobsRetryDelay`. 

It took some time for me to understand. That's why I suggest using the same value name - `scanJobsRetryAfter`. What do you think, @chen-keinan ? 


- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant iblob/main/CONTRIBUTING.md) to this repository.
