### PR TITLE
fix: set `follow` to false when retrieving logs

### DIFF
--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -42,7 +42,7 @@ func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batc
 
 	return r.clientset.CoreV1().Pods(pod.Namespace).
 		GetLogs(pod.Name, &corev1.PodLogOptions{
-			Follow:    true,
+			Follow:    false,
 			Container: containerName,
 		}).Stream(ctx)
 }


### PR DESCRIPTION
## Description
Set Follow=false when retrieving logs from completed job.
Using Follow mode in this case is unnecessary because:
* Follow is used to wait for additional logs that may come from the container
* By the time the operator is collecting the container logs, the container has already completed and will not generate more logs

In cases where the underlying node has resources (fsnotify handle) exhaustion this causes the logs to return an error after the base64 data "failed to create fsnotify watcher: too many open files", and trivy fails to process that scan job due to "illegal base64 data".

I tested this simple change in a cluster that was having the issue, and the operator processed and deleted all the completed scan jobs that were previously being continuously re-processed with base64 failures.

## Related issues
- Close #2264 

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
