### PR TITLE
feat: Add extraEnv option to Helm chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -19,6 +19,7 @@ Keeps security report resources updated
 | compliance.reportType | string | `"summary"` | reportType this flag control the type of report generated (summary or all) |
 | compliance.specs | list | `["k8s-cis-1.23","k8s-nsa-1.0","k8s-pss-baseline-0.1","k8s-pss-restricted-0.1"]` | specs is a list of compliance specs to be used by the cluster compliance scanner  - k8s-cis-1.23  - k8s-nsa-1.0  - k8s-pss-baseline-0.1  - k8s-pss-restricted-0.1  - eks-cis-1.4  - rke2-cis-1.24 |
 | excludeNamespaces | string | `""` | excludeNamespaces is a comma separated list of namespaces (or glob patterns) to be excluded from scanning. Only applicable in the all namespaces install mode, i.e. when the targetNamespaces values is a blank string. |
+| extraEnv | list | `[]` | extraEnv is a list of extra environment variables for the trivy-operator. |
 | fullnameOverride | string | `""` | fullnameOverride override operator full name |
 | global | object | `{"image":{"registry":""}}` | global values provide a centralized configuration for 'image.registry', reducing the potential for errors. If left blank, the chart will default to the individually set 'image.registry' values |
 | image.pullPolicy | string | `"IfNotPresent"` | pullPolicy set the operator pullPolicy |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- with .Values.operator.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-  labels: 
+  labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     {{- with .Values.operator.labels }}
       {{- toYaml . | nindent 4 }}
@@ -50,6 +50,9 @@ spec:
               value: {{ tpl .Values.targetWorkloads . | quote }}
             - name: OPERATOR_SERVICE_ACCOUNT
               value: {{ include "trivy-operator.serviceAccountName" . | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: trivy-operator-config

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -638,9 +638,8 @@ serviceAccount:
 # -- podAnnotations annotations added to the operator's pod
 podAnnotations: {}
 
-podSecurityContext:
-  {}
-  # fsGroup: 2000
+podSecurityContext: {}
+# fsGroup: 2000
 
 # -- securityContext security context
 securityContext:
@@ -662,18 +661,18 @@ volumes:
   - name: cache-policies
     emptyDir: {}
 
-resources:
-  {}
-  # -- We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources: {}
+# -- We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
 # -- nodeSelector set the operator nodeSelector
 nodeSelector: {}
 
@@ -684,10 +683,9 @@ tolerations: []
 affinity: {}
 
 # -- priorityClassName set the operator priorityClassName
-priorityClassName:
-  ""
+priorityClassName: ""
 
-  # -- automountServiceAccountToken the flag to enable automount for service account token
+# -- automountServiceAccountToken the flag to enable automount for service account token
 automountServiceAccountToken: true
 
 policiesBundle:
@@ -697,7 +695,7 @@ policiesBundle:
   repository: aquasec/trivy-checks
   # -- tag version of the policies bundle
   tag: 1
-   # -- registryUser is the user for the registry
+  # -- registryUser is the user for the registry
   registryUser: ~
   # -- registryPassword is the password for the registry
   registryPassword: ~

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -20,6 +20,9 @@ targetNamespaces: ""
 # mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: ""
 
+# -- extraEnv is a list of extra environment variables for the trivy-operator.
+extraEnv: []
+
 # -- targetWorkloads is a comma seperated list of Kubernetes workload resources
 # to be included in the vulnerability and config-audit scans
 # if left blank, all workload resources will be scanned
@@ -635,7 +638,8 @@ serviceAccount:
 # -- podAnnotations annotations added to the operator's pod
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 # -- securityContext security context
@@ -658,7 +662,8 @@ volumes:
   - name: cache-policies
     emptyDir: {}
 
-resources: {}
+resources:
+  {}
   # -- We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -679,7 +684,8 @@ tolerations: []
 affinity: {}
 
 # -- priorityClassName set the operator priorityClassName
-priorityClassName: ""
+priorityClassName:
+  ""
 
   # -- automountServiceAccountToken the flag to enable automount for service account token
 automountServiceAccountToken: true
@@ -702,7 +708,6 @@ policiesBundle:
   existingSecret: false
   # -- insecure is the flag to enable insecure connection to the policy bundle registry
   insecure: false
-
 
 nodeCollector:
   # -- useNodeSelector determine if to use nodeSelector (by auto detecting node name) with node-collector scan job


### PR DESCRIPTION
## Description

This is a small fix to account for the lack of ability to add extra env vars to the trivy-operator deployment.
This allows specifying eg. AWS IAM session names and other options for eg. secret injection.

## Related issues
- Close #2287 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
