### PR TITLE
fix: vuln scan success criteria met

### DIFF
--- a/build/trivy-operator/Dockerfile
+++ b/build/trivy-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19.1
+FROM alpine:3.19.4
 
 RUN apk update
 

--- a/pkg/configauditreport/controller/nodecollector.go
+++ b/pkg/configauditreport/controller/nodecollector.go
@@ -72,7 +72,7 @@ func (r *NodeCollectorJobController) reconcileJobs() reconcile.Func {
 		}
 
 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
-		case batchv1.JobComplete:
+		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:
 			err = r.processCompleteScanJob(ctx, job)
 		case batchv1.JobFailed:
 			err = r.processFailedScanJob(ctx, job)

--- a/pkg/configauditreport/controller/nodecollector.go
+++ b/pkg/configauditreport/controller/nodecollector.go
@@ -74,7 +74,7 @@ func (r *NodeCollectorJobController) reconcileJobs() reconcile.Func {
 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
 		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:
 			err = r.processCompleteScanJob(ctx, job)
-		case batchv1.JobFailed:
+		case batchv1.JobFailed, batchv1.JobFailureTarget:
 			err = r.processFailedScanJob(ctx, job)
 		default:
 			err = fmt.Errorf("unrecognized scan job condition: %v", jobCondition)

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -76,7 +76,7 @@ func (r *ScanJobController) reconcileJobs() reconcile.Func {
 		}
 
 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
-		case batchv1.JobComplete, batchv1.JobFailed:
+		case batchv1.JobComplete, batchv1.JobFailed, batchv1.JobSuccessCriteriaMet:
 			completedContainers, err := r.completedContainers(ctx, job)
 			if err != nil {
 				return ctrl.Result{}, r.deleteJob(ctx, job)

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -76,7 +76,7 @@ func (r *ScanJobController) reconcileJobs() reconcile.Func {
 		}
 
 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
-		case batchv1.JobComplete, batchv1.JobFailed, batchv1.JobSuccessCriteriaMet:
+		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet, batchv1.JobFailed, batchv1.JobFailureTarget:
 			completedContainers, err := r.completedContainers(ctx, job)
 			if err != nil {
 				return ctrl.Result{}, r.deleteJob(ctx, job)


### PR DESCRIPTION
## Description
Scan jobs on k8s 1.31 (certainly on EKS at least) fail to be processed leading to no vulnerability reports.
Could it be as simple as this?

## Related issues
- Close #2251

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
