### PR TITLE
fix: return proper image digest

### DIFF
--- a/pkg/plugins/trivy/testdata/fixture/full_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/full_report.json
@@ -5,7 +5,10 @@
       "Family": "alpine",
       "Name": "3.10.2",
       "EOSL": true
-    }
+    },
+    "RepoDigests": [
+        "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
+      ]
   },
   "Results": [
     {

--- a/pkg/plugins/trivy/testdata/fixture/vulnerability_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/vulnerability_report.json
@@ -5,7 +5,10 @@
       "Family": "alpine",
       "Name": "3.10.2",
       "EOSL": true
-    }
+    },
+    "RepoDigests": [
+        "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
+      ]
   },
   "Results": [
     {


### PR DESCRIPTION
Trivy Operator incorrectly reported imageID as image digest.

Fixes #2259

## Description

## Related issues
- Close #2259 

Remove this section if you don't have related PRs.

## Checklist
- [ x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
