### PR TITLE
feat: add package purl in VulnerabilityReport CRD

### DIFF
--- a/deploy/helm/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
+++ b/deploy/helm/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
@@ -234,6 +234,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    packagePURL:
+                      type: string
                     packagePath:
                       type: string
                     packageType:

--- a/deploy/helm/crds/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/deploy/helm/crds/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -235,6 +235,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    packagePURL:
+                      type: string
                     packagePath:
                       type: string
                     packageType:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1441,6 +1441,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    packagePURL:
+                      type: string
                     packagePath:
                       type: string
                     packageType:
@@ -2879,6 +2881,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    packagePURL:
+                      type: string
                     packagePath:
                       type: string
                     packageType:

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -111,6 +111,7 @@ type Vulnerability struct {
 	Class       string `json:"class,omitempty"`
 	PackageType string `json:"packageType,omitempty"`
 	PkgPath     string `json:"packagePath,omitempty"`
+	PkgPURL     string `json:"packagePURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/vulnerabilityreport/io.go
+++ b/pkg/vulnerabilityreport/io.go
@@ -162,6 +162,10 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 			Score:            GetScoreFromCVSS(GetCvssV3(sr.CVSS)),
 		}
 
+		if sr.PkgIdentifier.PURL != nil {
+			vulnerability.PkgPURL = sr.PkgIdentifier.PURL.String()
+		}
+
 		if addFields.Description {
 			vulnerability.Description = sr.Description
 		}


### PR DESCRIPTION
## Description
This adds package url (pURL) information into the vulnerability report CRD. 
Having the pURL here defines a clear definition of which package this report is actually generated. Also the pURL can be used much better to integrate into other systems.
Since this information is in the trivy scan result anyways it's beneficial to include it in the CR too.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
