### PR TITLE
chore: bump up base alpine image to 3.20.3

### DIFF
--- a/build/trivy-operator/Dockerfile
+++ b/build/trivy-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19.4
+FROM alpine:3.20.3
 
 RUN apk update
 


### PR DESCRIPTION
## Description

This PR bump up a basic image Alpine to version 3.20.3.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
