### PR TITLE
chore: use mirror.gcr.io for trivy-check by default

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -95,10 +95,10 @@ Keeps security report resources updated
 | podSecurityContext | object | `{}` |  |
 | policiesBundle.existingSecret | bool | `false` | existingSecret if a secret containing registry credentials that have been created outside the chart (e.g external-secrets, sops, etc...). Keys must be at least one of the following: policies.bundle.oci.user, policies.bundle.oci.password Overrides policiesBundle.registryUser, policiesBundle.registryPassword values. Note: The secret has to be named "trivy-operator". |
 | policiesBundle.insecure | bool | `false` | insecure is the flag to enable insecure connection to the policy bundle registry |
-| policiesBundle.registry | string | `"ghcr.io"` | registry of the policies bundle |
+| policiesBundle.registry | string | `"mirror.gcr.io"` | registry of the policies bundle |
 | policiesBundle.registryPassword | string | `nil` | registryPassword is the password for the registry |
 | policiesBundle.registryUser | string | `nil` | registryUser is the user for the registry |
-| policiesBundle.repository | string | `"aquasecurity/trivy-checks"` | repository of the policies bundle |
+| policiesBundle.repository | string | `"aquasec/trivy-checks"` | repository of the policies bundle |
 | policiesBundle.tag | int | `1` | tag version of the policies bundle |
 | priorityClassName | string | `""` | priorityClassName set the operator priorityClassName |
 | rbac.create | bool | `true` |  |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -686,9 +686,9 @@ automountServiceAccountToken: true
 
 policiesBundle:
   # -- registry of the policies bundle
-  registry: ghcr.io
+  registry: mirror.gcr.io
   # -- repository of the policies bundle
-  repository: aquasecurity/trivy-checks
+  repository: aquasec/trivy-checks
   # -- tag version of the policies bundle
   tag: 1
    # -- registryUser is the user for the registry

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -2970,7 +2970,7 @@ data:
   compliance.failEntriesLimit: "10"
   report.recordFailedChecksOnly: "true"
   node.collector.imageRef: "ghcr.io/aquasecurity/node-collector:0.3.1"
-  policies.bundle.oci.ref: "ghcr.io/aquasecurity/trivy-checks:1"
+  policies.bundle.oci.ref: "mirror.gcr.io/aquasec/trivy-checks:1"
   policies.bundle.insecure: "false"
 
   node.collector.nodeSelector: "true"


### PR DESCRIPTION
## Description

This PR adds `mirror.gcr.io` as a source for `trivy-checks` by default.


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
