### PR TITLE
ci: bump up GoReleaser to v2.4.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,8 +165,8 @@ jobs:
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.7.0
-          args: release -f=goreleaser-e2e.yaml --snapshot --skip-publish --rm-dist
+          version: v2.4.8
+          args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
       - name: Install kind and create cluster
         run: >
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -40,8 +40,8 @@ jobs:
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.7.0
-          args: release -f=goreleaser-e2e.yaml --snapshot --skip-publish --rm-dist
+          version: v2.4.8
+          args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,8 +116,8 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.7.0
-          args: release --rm-dist
+          version: v2.4.8
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,20 +25,22 @@ builds:
     goarm:
       - "7"
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm" }}ARM
+      {{- else if eq .Arch "arm64" }}ARM64
+      {{- else }}{{ .Arch }}{{ end }}
     builds:
       - trivy-operator
-    replacements:
-      amd64: x86_64
-      arm: ARM
-      arm64: ARM64
     format_overrides:
       - goos: windows
         format: zip
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .FullCommit }}"
+  version_template: "{{ .FullCommit }}"
 changelog:
   filters:
     exclude:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+project_name: trivy_operator
 release:
   draft: false
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 version: 2
+
 project_name: trivy_operator
 release:
   draft: false

--- a/goreleaser-e2e.yaml
+++ b/goreleaser-e2e.yaml
@@ -28,7 +28,7 @@ archives:
 checksum:
   name_template: checksums.txt
 snapshot:
-  name_template: "{{ .FullCommit }}"
+  version_template: "{{ .FullCommit }}"
 changelog:
   sort: asc
   filters:

--- a/goreleaser-e2e.yaml
+++ b/goreleaser-e2e.yaml
@@ -1,4 +1,5 @@
 version: 2
+
 project_name: build_e2e
 release:
   draft: false

--- a/goreleaser-e2e.yaml
+++ b/goreleaser-e2e.yaml
@@ -1,4 +1,5 @@
----
+version: 2
+project_name: build_e2e
 release:
   draft: false
   prerelease: auto


### PR DESCRIPTION
## Description
This PR bumps up GoReleaser to the latest version (2.4.8):
* change deprecated flags
* add new fields on the config

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
