### PR TITLE
docs: Fix mage build command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ have to
 To build all Trivy-operator binary, run:
 
 ```
-mage build:all
+mage build:binary
 ```
 
 This uses the `go build` command and builds binaries in the `./bin` directory.


### PR DESCRIPTION
## Description
Replace `mage  build:all` with `mage build:binary`.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
