### PR TITLE
ci: bump GoReleaser up for private registry test

### DIFF
--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -77,8 +77,8 @@ jobs:
 
           kubectl create secret docker-registry artcred \
             --docker-server=https://index.docker.io/v1 \
-            --docker-username=${{ secrets.DOCKERHUB_USER }} \
-            --docker-password=${{ secrets.DOCKERHUB_TOKEN }} \
+            --docker-username="private-dockerhub" \
+            --docker-password="password-dockerhub" \
             --docker-email=private@gmail.com \
             -n private
       - name: Load operator image to cluster

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -11,7 +11,7 @@ on:
       - mkdocs.yml
       - LICENSE
       - NOTICE
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths-ignore:
@@ -77,8 +77,8 @@ jobs:
 
           kubectl create secret docker-registry artcred \
             --docker-server=https://index.docker.io/v1 \
-            --docker-username="private-dockerhub" \
-            --docker-password="password-dockerhub" \
+            --docker-username=${{ secrets.DOCKERHUB_USER }} \
+            --docker-password=${{ secrets.DOCKERHUB_TOKEN }} \
             --docker-email=private@gmail.com \
             -n private
       - name: Load operator image to cluster

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -11,7 +11,7 @@ on:
       - mkdocs.yml
       - LICENSE
       - NOTICE
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:
@@ -52,8 +52,8 @@ jobs:
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.7.0
-          args: release -f=goreleaser-e2e.yaml --snapshot --skip-publish --rm-dist
+          version: v2.4.8
+          args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
       - name: Install kind and create cluster
         run: >
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION


### PR DESCRIPTION
## Description

This PR fixes skipped update in #2323 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
