### PR TITLE
fix: Missing credentials for downloading the java-db from private registry

### DIFF
--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -233,6 +233,14 @@ func (c Config) GetSkipJavaDBUpdate() bool {
 	return boolVal
 }
 
+func (c Config) GetJavaDBRepository() string {
+	val, ok := c.Data[keyTrivyJavaDBRepository]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
 func (c Config) TrivyDBRepositoryCredentialsSet() bool {
 	_, userOk := c.SecretData[keyTrivyDBRepositoryUsername]
 	_, passOk := c.SecretData[keyTrivyDBRepositoryPassword]


### PR DESCRIPTION
## Description
The main container with the image command of a scan job fails when pulling the `java-db` from a private registry because of missing credentials. This PR introduces a second init container analogous to the one that downloads the `trivy-db` but downloads the `java-db` if it is to be pulled from a private registry.
This results in the main container not having to download the `java-db` since it is up to date.

## Related issues

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
