### PR TITLE
perf: Exclude kube-bench pods from being evaluated in the Trivy operator

### DIFF
--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -130,6 +130,7 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 		}).For(resource.ForObject, builder.WithPredicates(
 			predicate.Not(predicate.ManagedByTrivyOperator),
 			predicate.Not(predicate.IsBeingTerminated),
+			predicate.Not(predicate.ManagedByKubeEnforcer),
 		)).Owns(resource.OwnsObject).Complete(r.reconcileResource(resource.Kind)); err != nil {
 			return fmt.Errorf("constructing controller for %s: %w", resource.Kind, err)
 		}
@@ -147,6 +148,7 @@ func (r *ResourceController) buildControlMgr(mgr ctrl.Manager, configResource ku
 			predicate.Not(predicate.ManagedByTrivyOperator),
 			predicate.Not(predicate.IsLeaderElectionResource),
 			predicate.Not(predicate.IsBeingTerminated),
+			predicate.Not(predicate.ManagedByKubeEnforcer),
 			installModePredicate,
 		)).
 		Owns(configResource.OwnsObject)

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -74,6 +74,7 @@ func (r *ClusterController) SetupWithManager(mgr ctrl.Manager) error {
 			For(resource.ForObject, builder.WithPredicates(
 				predicate.IsCoreComponents,
 				predicate.Not(predicate.ManagedByTrivyOperator),
+				predicate.Not(predicate.ManagedByKubeEnforcer),
 				predicate.Not(predicate.IsBeingTerminated))).
 			Owns(resource.OwnsObject).
 			Complete(r.reconcileClusterComponents(resource.Kind)); err != nil {

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -88,6 +88,16 @@ var ManagedByTrivyOperator = predicate.NewPredicateFuncs(func(obj client.Object)
 	return false
 })
 
+var ManagedByKubeEnforcer = predicate.NewPredicateFuncs(func(obj client.Object) bool {
+	if managedBy, ok := obj.GetLabels()["app.kubernetes.io/managed-by"]; ok {
+		return managedBy == "KubeEnforcer"
+	}
+	if app, ok := obj.GetLabels()["app"]; ok {
+		return app == "kube-bench"
+	}
+	return false
+})
+
 // IsBeingTerminated is a predicate.Predicate that returns true if the specified
 // client.Object is being terminated, i.e. its DeletionTimestamp property is set to non nil value.
 var IsBeingTerminated = predicate.NewPredicateFuncs(func(obj client.Object) bool {

--- a/pkg/operator/predicate/predicate_test.go
+++ b/pkg/operator/predicate/predicate_test.go
@@ -476,4 +476,57 @@ var _ = Describe("Predicate", func() {
 			})
 		})
 	})
+
+	Describe("When checking a ManagedByKubeEnforcer predicate", func() {
+		instance := predicate.ManagedByKubeEnforcer
+
+		Context("Where object is managed by kube-enforcer", func() {
+			It("Should return true", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "KubeEnforcer",
+						},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeTrue())
+			})
+		})
+
+		Context("Where object is managed by foo app", func() {
+			It("Should return false", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "foo",
+						},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+
+		Context("Where object is not managed by any app", func() {
+			It("Should return false", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+	})
 })


### PR DESCRIPTION
In a scaled 800-node cluster, running the Trivy operator with KE results in 1600 pods being created for kube-bench. Since kube-bench is an internal Aqua component, its evaluation can be safely skipped. By excluding kube-bench from the Trivy operator's scope, we can reduce the overall memory consumption of the Trivy operator, optimizing its performance in large-scale environments.