### PR TITLE
fix: return the image manifest digest instead of image id

### DIFF
--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6542,6 +6542,7 @@ var (
 		Artifact: v1alpha1.Artifact{
 			Repository: "library/alpine",
 			Tag:        "3.10.2",
+			Digest:     "sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",
 		},
 		OS: v1alpha1.OS{
 			Family: "alpine",
@@ -6592,6 +6593,7 @@ var (
 		Artifact: v1alpha1.Artifact{
 			Repository: "library/alpine",
 			Tag:        "3.10.2",
+			Digest:     "sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",
 		},
 		Summary: v1alpha1.ExposedSecretSummary{
 			CriticalCount: 3,
@@ -6648,6 +6650,7 @@ var (
 		Artifact: v1alpha1.Artifact{
 			Repository: "library/alpine",
 			Tag:        "3.10.2",
+			Digest:     "sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",
 		},
 		OS: v1alpha1.OS{
 			Family: "alpine",
@@ -6678,6 +6681,7 @@ var (
 		Artifact: v1alpha1.Artifact{
 			Repository: "library/alpine",
 			Tag:        "3.10.2",
+			Digest:     "sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",
 		},
 		Summary: v1alpha1.ExposedSecretSummary{
 			CriticalCount: 0,

--- a/pkg/plugins/trivy/testdata/fixture/exposedsecret_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/exposedsecret_report.json
@@ -5,7 +5,17 @@
       "Family": "alpine",
       "Name": "3.10.2",
       "EOSL": true
-    }
+    },
+    "ImageID": "sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4",
+    "DiffIDs": [
+      "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
+    ],
+    "RepoTags": [
+      "alpine:3.10.2"
+    ],
+    "RepoDigests": [
+      "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
+    ]
   },
   "Results": [
     {

--- a/pkg/plugins/trivy/testdata/fixture/full_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/full_report.json
@@ -5,7 +5,17 @@
       "Family": "alpine",
       "Name": "3.10.2",
       "EOSL": true
-    }
+    },
+    "ImageID": "sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4",
+    "DiffIDs": [
+      "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
+    ],
+    "RepoTags": [
+      "alpine:3.10.2"
+    ],
+    "RepoDigests": [
+      "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
+    ]
   },
   "Results": [
     {

--- a/pkg/plugins/trivy/testdata/fixture/vulnerability_report.json
+++ b/pkg/plugins/trivy/testdata/fixture/vulnerability_report.json
@@ -5,7 +5,17 @@
       "Family": "alpine",
       "Name": "3.10.2",
       "EOSL": true
-    }
+    },
+    "ImageID": "sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4",
+    "DiffIDs": [
+      "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
+    ],
+    "RepoTags": [
+      "alpine:3.10.2"
+    ],
+    "RepoDigests": [
+      "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
+    ]
   },
   "Results": [
     {


### PR DESCRIPTION
## Description

This PR supersedes #2310, fixes tests and adds safety around the image manifest digest extraction from the report

@afdesk for you review

## Related issues
- Close #2259


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
