### PR TITLE
fix: parseImageRef tag parsing (#2411)

### DIFF
--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -158,7 +158,7 @@ func (p *plugin) ParseReportData(ctx trivyoperator.PluginContext, imageRef strin
 	registry, artifact, err := ParseImageRef(imageRef, imageDigest)
 	if err != nil {
 		return vulnReport, secretReport, nil, err
-	}	
+	}
 
 	os := p.parseOSRef(reports)
 
@@ -213,58 +213,58 @@ func (p *plugin) NewConfigForConfigAudit(ctx trivyoperator.PluginContext) (confi
 	return getConfig(ctx)
 }
 
-func ParseImageRef(imageRef string, imageDigest string) (v1alpha1.Registry, v1alpha1.Artifact, error) {
+func ParseImageRef(imageRef, imageDigest string) (v1alpha1.Registry, v1alpha1.Artifact, error) {
 	refParts := strings.Split(imageRef, "@")
 
 	simpleTag := ""
 	nameParts := strings.Split(refParts[0], ":")
-	if len(nameParts)==2 {
+	if len(nameParts) == 2 {
 		simpleTag = nameParts[1]
 	}
-	
+
 	var pTag *containerimage.Tag
 	var pDigest *containerimage.Digest
 
 	var _err error
 
 	_tag, _err := containerimage.NewTag(refParts[0], containerimage.WeakValidation)
-	if  _err==nil {
+	if _err == nil {
 		pTag = &_tag
 	}
 
 	_digest, _err := containerimage.NewDigest(imageRef, containerimage.WeakValidation)
 	if _err == nil {
-		pDigest = &_digest	
+		pDigest = &_digest
 	}
 
-	if pDigest==nil && pTag==nil {
-		return v1alpha1.Registry{}, v1alpha1.Artifact{},_err
+	if pDigest == nil && pTag == nil {
+		return v1alpha1.Registry{}, v1alpha1.Artifact{}, _err
 	}
 
 	server := ""
 	repository := ""
 	digest := ""
 	tag := ""
-	
-	if pDigest!=nil {
+
+	if pDigest != nil {
 		server = pDigest.Context().RegistryStr()
 		repository = pDigest.Context().RepositoryStr()
 		digest = pDigest.DigestStr()
 	}
-	
-	if pTag!=nil {
+
+	if pTag != nil {
 		server = pTag.Context().RegistryStr()
 		repository = pTag.Context().RepositoryStr()
-		if simpleTag!="" {
+		if simpleTag != "" {
 			tag = simpleTag
 		}
 
-		if simpleTag=="" && digest=="" { 
+		if simpleTag == "" && digest == "" {
 			tag = pTag.TagStr() // set default: latest
 		}
 	}
 
-	if digest=="" {
+	if digest == "" {
 		digest = imageDigest
 	}
 
@@ -274,8 +274,8 @@ func ParseImageRef(imageRef string, imageDigest string) (v1alpha1.Registry, v1al
 
 	artifact := v1alpha1.Artifact{
 		Repository: repository,
-		Digest: digest,
-		Tag: tag,
+		Digest:     digest,
+		Tag:        tag,
 	}
 
 	return registry, artifact, nil

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7642,6 +7642,20 @@ func TestParseImageRef(t *testing.T) {
 		err      error
 	}{
 		{
+			name:     "9. short image ref with latest tag",
+			imageRef: "nginx:latest",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
+			},
+			err: nil,
+		},
+		{
 			name:     "1. repo with latest tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
 			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
@@ -7729,20 +7743,6 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "my-app",
 				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 				Tag:        "",
-			},
-			err: nil,
-		},
-		{
-			name:     "9. short image ref with latest tag",
-			imageRef: "nginx:latest",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "index.docker.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "library/nginx",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
 			},
 			err: nil,
 		},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7725,6 +7725,48 @@ func TestParseImageRef(t *testing.T) {
 			},
 		},
 		{
+			name:     "10. artifact registry image ref with tag",
+			imageRef: "europe-west4-docker.pkg.dev/my-project/my-repo/my-app:1.0.0",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "europe-west4-docker.pkg.dev",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-project/my-repo/my-app",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "1.0.0",
+			},
+			err: nil,
+		},
+		{
+			name:     "11. aws registry image ref with latest tag",
+			imageRef: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
+			},
+			err: nil,
+		},
+		{
+			name:     "12. azure registry image ref with tag",
+			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "myregistry.azurecr.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "v2.0.1",
+			},
+			err: nil,
+		},
+		{
 			name:     "3. repo with digest",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7771,48 +7813,6 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "my-app",
 				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 				Tag:        "",
-			},
-			err: nil,
-		},
-		{
-			name:     "10. artifact registry image ref with tag",
-			imageRef: "europe-west4-docker.pkg.dev/my-project/my-repo/my-app:1.0.0",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "europe-west4-docker.pkg.dev",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-project/my-repo/my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "1.0.0",
-			},
-			err: nil,
-		},
-		{
-			name:     "11. aws registry image ref with latest tag",
-			imageRef: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
-			},
-			err: nil,
-		},
-		{
-			name:     "12. azure registry image ref with tag",
-			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "myregistry.azurecr.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "v2.0.1",
 			},
 			err: nil,
 		},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7670,6 +7670,20 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:     "16. well known image without tag & digest",
+			imageRef: "quay.io/centos/centos",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "quay.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "centos/centos",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
+			},
+			err: nil,
+		},
+		{
 			name:     "13. docker registry image ref without tag",
 			imageRef: "docker.io/library/alpine",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7694,6 +7708,34 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "library/alpine",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 				Tag:        "some-tag",
+			},
+			err: nil,
+		},
+		{
+			name:     "12. azure registry image ref with tag",
+			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "myregistry.azurecr.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "v2.0.1",
+			},
+			err: nil,
+		},
+		{
+			name:     "7. short repo with private repo with tag",
+			imageRef: "my-private-repo.company.com/my-app:1.2.3",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "my-private-repo.company.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "1.2.3",
 			},
 			err: nil,
 		},
@@ -7753,20 +7795,6 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "12. azure registry image ref with tag",
-			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "myregistry.azurecr.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "v2.0.1",
-			},
-			err: nil,
-		},
-		{
 			name:     "3. repo with digest",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7787,20 +7815,6 @@ func TestParseImageRef(t *testing.T) {
 			registry: v1alpha1.Registry{},
 			artifact: v1alpha1.Artifact{},
 			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
-		},
-		{
-			name:     "7. short repo with private repo with tag",
-			imageRef: "my-private-repo.company.com/my-app:1.2.3",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "my-private-repo.company.com",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "1.2.3",
-			},
-			err: nil,
 		},
 		{
 			name:     "8. repo with private repo with digest",
@@ -7841,20 +7855,6 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "my-app",
 				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 				Tag:        "some-tag",
-			},
-			err: nil,
-		},
-		{
-			name:     "16. well known image without tag & digest",
-			imageRef: "quay.io/centos/centos",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "quay.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "centos/centos",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
 			},
 			err: nil,
 		},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7753,14 +7753,6 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "4. incorrect input",
-			imageRef: "## some incorrect imput ###",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{},
-			artifact: v1alpha1.Artifact{},
-			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
-		},
-		{
 			name:     "15. private registry image ref tag & with digest",
 			imageRef: "my-private-repo.company.com/my-app:some-tag@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7773,6 +7765,14 @@ func TestParseImageRef(t *testing.T) {
 				Tag:        "some-tag",
 			},
 			err: nil,
+		},
+		{
+			name:     "4. incorrect input",
+			imageRef: "## some incorrect imput ###",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{},
+			artifact: v1alpha1.Artifact{},
+			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7670,6 +7670,20 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:     "13. docker registry image ref without tag",
+			imageRef: "docker.io/library/alpine",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/alpine",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
+			},
+			err: nil,
+		},
+		{
 			name:     "1. repo with latest tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
 			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
@@ -7785,20 +7799,6 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "my-app",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 				Tag:        "v2.0.1",
-			},
-			err: nil,
-		},
-		{
-			name:     "13. docker registry image ref without tag",
-			imageRef: "docker.io/library/alpine",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "index.docker.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "library/alpine",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
 			},
 			err: nil,
 		},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7642,7 +7642,7 @@ func TestParseImageRef(t *testing.T) {
 		err      error
 	}{
 		{
-			name:     "9. short image ref with latest tag",
+			name:     "1. short image ref with latest tag",
 			imageRef: "nginx:latest",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7656,7 +7656,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "6. short repo with default lib with latest tag",
+			name:     "2. short repo with default lib with latest tag",
 			imageRef: "library/nginx:latest",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7670,7 +7670,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "16. well known image without tag & digest",
+			name:     "3. well known image without tag & digest",
 			imageRef: "quay.io/centos/centos",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7684,7 +7684,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "13. docker registry image ref with tag",
+			name:     "4. docker registry image ref with tag",
 			imageRef: "docker.io/library/alpine:some-tag",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7698,7 +7698,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "7. short repo with private repo with tag",
+			name:     "5. short repo with private repo with tag",
 			imageRef: "my-private-repo.company.com/my-app:1.2.3",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7712,7 +7712,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "2. with tag",
+			name:     "6. with tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:v0.63.0",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7725,7 +7725,7 @@ func TestParseImageRef(t *testing.T) {
 			},
 		},
 		{
-			name:     "10. artifact registry image ref with tag",
+			name:     "7. artifact registry image ref with tag",
 			imageRef: "europe-west4-docker.pkg.dev/my-project/my-repo/my-app:1.0.0",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7739,7 +7739,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "3. repo with digest",
+			name:     "8. repo with digest",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7753,7 +7753,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "15. private registry image ref tag & with digest",
+			name:     "9. private registry image ref tag & with digest",
 			imageRef: "my-private-repo.company.com/my-app:some-tag@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
@@ -7767,7 +7767,7 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "4. incorrect input",
+			name:     "10. incorrect input",
 			imageRef: "## some incorrect imput ###",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7643,7 +7643,7 @@ func TestParseImageRef(t *testing.T) {
 	}{
 		{
 			name:     "1. short image ref with latest tag",
-			imageRef: "nginx:latest",
+			imageRef: "nginx:v1.3.4",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
@@ -7651,13 +7651,13 @@ func TestParseImageRef(t *testing.T) {
 			artifact: v1alpha1.Artifact{
 				Repository: "library/nginx",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
+				Tag:        "v1.3.4",
 			},
 			err: nil,
 		},
 		{
 			name:     "2. short repo with default lib with latest tag",
-			imageRef: "library/nginx:latest",
+			imageRef: "library/nginx:v.4.5.6",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
@@ -7665,7 +7665,7 @@ func TestParseImageRef(t *testing.T) {
 			artifact: v1alpha1.Artifact{
 				Repository: "library/nginx",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
+				Tag:        "v.4.5.6",
 			},
 			err: nil,
 		},
@@ -7685,7 +7685,7 @@ func TestParseImageRef(t *testing.T) {
 		},
 		{
 			name:     "4. docker registry image ref with tag",
-			imageRef: "docker.io/library/alpine:some-tag",
+			imageRef: "docker.io/library/alpine:v2.3.4",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
@@ -7693,7 +7693,7 @@ func TestParseImageRef(t *testing.T) {
 			artifact: v1alpha1.Artifact{
 				Repository: "library/alpine",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "some-tag",
+				Tag:        "v2.3.4",
 			},
 			err: nil,
 		},

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7684,20 +7684,6 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "13. docker registry image ref without tag",
-			imageRef: "docker.io/library/alpine",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "index.docker.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "library/alpine",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
-			},
-			err: nil,
-		},
-		{
 			name:     "13. docker registry image ref with tag",
 			imageRef: "docker.io/library/alpine:some-tag",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7712,20 +7698,6 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "12. azure registry image ref with tag",
-			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "myregistry.azurecr.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "v2.0.1",
-			},
-			err: nil,
-		},
-		{
 			name:     "7. short repo with private repo with tag",
 			imageRef: "my-private-repo.company.com/my-app:1.2.3",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7736,20 +7708,6 @@ func TestParseImageRef(t *testing.T) {
 				Repository: "my-app",
 				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 				Tag:        "1.2.3",
-			},
-			err: nil,
-		},
-		{
-			name:     "1. repo with latest tag",
-			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
-			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			registry: v1alpha1.Registry{
-				Server: "quay.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "prometheus-operator/prometheus-operator",
-				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag:        "latest",
 			},
 			err: nil,
 		},
@@ -7781,20 +7739,6 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "11. aws registry image ref with latest tag",
-			imageRef: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
-			},
-			err: nil,
-		},
-		{
 			name:     "3. repo with digest",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
@@ -7815,34 +7759,6 @@ func TestParseImageRef(t *testing.T) {
 			registry: v1alpha1.Registry{},
 			artifact: v1alpha1.Artifact{},
 			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
-		},
-		{
-			name:     "8. repo with private repo with digest",
-			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "my-private-repo.company.com",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag:        "",
-			},
-			err: nil,
-		},
-		{
-			name:     "14. private registry image ref with digest",
-			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "my-private-repo.company.com",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "my-app",
-				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag:        "",
-			},
-			err: nil,
 		},
 		{
 			name:     "15. private registry image ref tag & with digest",

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -40,7 +39,7 @@ import (
 var (
 	fixedTime  = time.Now()
 	fixedClock = ext.NewFixedClock(fixedTime)
-) 
+)
 
 func TestPlugin_GetScanJobSpec(t *testing.T) {
 
@@ -7633,242 +7632,240 @@ func TestExcludeImages(t *testing.T) {
 
 func TestParseImageRef(t *testing.T) {
 	testCases := []struct {
-		name       string
+		name string
 		// args:
 		imageRef string
-		imageID string 
+		imageID  string
 		// result:
 		registry v1alpha1.Registry
 		artifact v1alpha1.Artifact
-		err error
+		err      error
 	}{
 		{
-			name: "1. repo with latest tag",
+			name:     "1. repo with latest tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
-			imageID: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
 			registry: v1alpha1.Registry{
 				Server: "quay.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "prometheus-operator/prometheus-operator",
-				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag: "latest",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
 		{
-			name: "2. with tag",
+			name:     "2. with tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:v0.63.0",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "quay.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "prometheus-operator/prometheus-operator",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "v0.63.0",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "v0.63.0",
 			},
 		},
 		{
-			name: "3. repo with digest",
+			name:     "3. repo with digest",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "quay.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "prometheus-operator/prometheus-operator",
-				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag: "",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "",
 			},
 			err: nil,
 		},
 		{
-			name: "4. incorrect input",
+			name:     "4. incorrect input",
 			imageRef: "## some incorrect imput ###",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{},
-			artifact: v1alpha1.Artifact{}, 
-			err: fmt.Errorf("could not parse reference: ## some incorrect imput ###"),
+			artifact: v1alpha1.Artifact{},
+			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
 		},
 		{
-			name: "5. short repo with tag",
+			name:     "5. short repo with tag",
 			imageRef: "prometheus-operator:local",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "library/prometheus-operator",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "local",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "local",
 			},
 			err: nil,
 		},
 		{
-			name: "6. short repo with default lib with latest tag",
+			name:     "6. short repo with default lib with latest tag",
 			imageRef: "library/nginx:latest",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "library/nginx",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "latest",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
 		{
-			name: "7. short repo with private repo with tag",
+			name:     "7. short repo with private repo with tag",
 			imageRef: "my-private-repo.company.com/my-app:1.2.3",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "my-private-repo.company.com",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "1.2.3",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "1.2.3",
 			},
 			err: nil,
 		},
 		{
-			name: "8. repo with private repo with digest",
+			name:     "8. repo with private repo with digest",
 			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "my-private-repo.company.com",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag: "",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "",
 			},
 			err: nil,
 		},
 		{
-			name: "9. short image ref with latest tag",
+			name:     "9. short image ref with latest tag",
 			imageRef: "nginx:latest",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "library/nginx",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "latest",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
 		{
-			name: "10. artifact registry image ref with tag",
+			name:     "10. artifact registry image ref with tag",
 			imageRef: "europe-west4-docker.pkg.dev/my-project/my-repo/my-app:1.0.0",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "europe-west4-docker.pkg.dev",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-project/my-repo/my-app",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "1.0.0",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "1.0.0",
 			},
 			err: nil,
 		},
 		{
-			name: "11. aws registry image ref with latest tag",
+			name:     "11. aws registry image ref with latest tag",
 			imageRef: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "latest",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
 		{
-			name: "12. azure registry image ref with tag",
+			name:     "12. azure registry image ref with tag",
 			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "myregistry.azurecr.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "v2.0.1",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "v2.0.1",
 			},
 			err: nil,
 		},
 		{
-			name: "13. docker registry image ref without tag",
+			name:     "13. docker registry image ref without tag",
 			imageRef: "docker.io/library/alpine",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "index.docker.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "library/alpine",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "latest",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
 		{
-			name: "14. private registry image ref with digest",
+			name:     "14. private registry image ref with digest",
 			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "my-private-repo.company.com",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag: "",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "",
 			},
 			err: nil,
 		},
 		{
-			name: "15. private registry image ref tag & with digest",
+			name:     "15. private registry image ref tag & with digest",
 			imageRef: "my-private-repo.company.com/my-app:some-tag@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "my-private-repo.company.com",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "my-app",
-				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
-				Tag: "some-tag",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "some-tag",
 			},
 			err: nil,
 		},
 		{
-			name: "16. well known image without tag & digest",
+			name:     "16. well known image without tag & digest",
 			imageRef: "quay.io/centos/centos",
-			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
 			registry: v1alpha1.Registry{
 				Server: "quay.io",
 			},
 			artifact: v1alpha1.Artifact{
 				Repository: "centos/centos",
-				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag: "latest",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
 			},
 			err: nil,
 		},
-	};
+	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			registry,artifact,err := trivy.ParseImageRef(tc.imageRef,tc.imageID)
+			registry, artifact, err := trivy.ParseImageRef(tc.imageRef, tc.imageID)
 			assert.Equal(t, tc.registry, registry)
 			assert.Equal(t, tc.artifact, artifact)
-			if tc.err!=nil {
-				if !assert.Error(t,err) {
-					assert.Failf(t,"expected","%v but got %v",tc.err,err)
-				}
+			if tc.err != nil {
+				require.Errorf(t, err, "expected: %v", tc.err)
 			}
 		})
 	}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7684,6 +7684,20 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:     "13. docker registry image ref with tag",
+			imageRef: "docker.io/library/alpine:some-tag",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/alpine",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "some-tag",
+			},
+			err: nil,
+		},
+		{
 			name:     "1. repo with latest tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
 			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7656,6 +7656,20 @@ func TestParseImageRef(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:     "6. short repo with default lib with latest tag",
+			imageRef: "library/nginx:latest",
+			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag:        "latest",
+			},
+			err: nil,
+		},
+		{
 			name:     "1. repo with latest tag",
 			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
 			imageID:  "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
@@ -7703,20 +7717,6 @@ func TestParseImageRef(t *testing.T) {
 			registry: v1alpha1.Registry{},
 			artifact: v1alpha1.Artifact{},
 			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
-		},
-		{
-			name:     "6. short repo with default lib with latest tag",
-			imageRef: "library/nginx:latest",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "index.docker.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "library/nginx",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "latest",
-			},
-			err: nil,
 		},
 		{
 			name:     "7. short repo with private repo with tag",

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -39,7 +40,7 @@ import (
 var (
 	fixedTime  = time.Now()
 	fixedClock = ext.NewFixedClock(fixedTime)
-)
+) 
 
 func TestPlugin_GetScanJobSpec(t *testing.T) {
 
@@ -7626,6 +7627,249 @@ func TestExcludeImages(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := trivy.ExcludeImage(tc.excludePattern, tc.imageName)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseImageRef(t *testing.T) {
+	testCases := []struct {
+		name       string
+		// args:
+		imageRef string
+		imageID string 
+		// result:
+		registry v1alpha1.Registry
+		artifact v1alpha1.Artifact
+		err error
+	}{
+		{
+			name: "1. repo with latest tag",
+			imageRef: "quay.io/prometheus-operator/prometheus-operator:latest",
+			imageID: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			registry: v1alpha1.Registry{
+				Server: "quay.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "prometheus-operator/prometheus-operator",
+				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+		{
+			name: "2. with tag",
+			imageRef: "quay.io/prometheus-operator/prometheus-operator:v0.63.0",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "quay.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "prometheus-operator/prometheus-operator",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "v0.63.0",
+			},
+		},
+		{
+			name: "3. repo with digest",
+			imageRef: "quay.io/prometheus-operator/prometheus-operator@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "quay.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "prometheus-operator/prometheus-operator",
+				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag: "",
+			},
+			err: nil,
+		},
+		{
+			name: "4. incorrect input",
+			imageRef: "## some incorrect imput ###",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{},
+			artifact: v1alpha1.Artifact{}, 
+			err: fmt.Errorf("could not parse reference: ## some incorrect imput ###"),
+		},
+		{
+			name: "5. short repo with tag",
+			imageRef: "prometheus-operator:local",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/prometheus-operator",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "local",
+			},
+			err: nil,
+		},
+		{
+			name: "6. short repo with default lib with latest tag",
+			imageRef: "library/nginx:latest",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/nginx",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+		{
+			name: "7. short repo with private repo with tag",
+			imageRef: "my-private-repo.company.com/my-app:1.2.3",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "my-private-repo.company.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "1.2.3",
+			},
+			err: nil,
+		},
+		{
+			name: "8. repo with private repo with digest",
+			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "my-private-repo.company.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag: "",
+			},
+			err: nil,
+		},
+		{
+			name: "9. short image ref with latest tag",
+			imageRef: "nginx:latest",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/nginx",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+		{
+			name: "10. artifact registry image ref with tag",
+			imageRef: "europe-west4-docker.pkg.dev/my-project/my-repo/my-app:1.0.0",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "europe-west4-docker.pkg.dev",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-project/my-repo/my-app",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "1.0.0",
+			},
+			err: nil,
+		},
+		{
+			name: "11. aws registry image ref with latest tag",
+			imageRef: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app:latest",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+		{
+			name: "12. azure registry image ref with tag",
+			imageRef: "myregistry.azurecr.io/my-app:v2.0.1",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "myregistry.azurecr.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "v2.0.1",
+			},
+			err: nil,
+		},
+		{
+			name: "13. docker registry image ref without tag",
+			imageRef: "docker.io/library/alpine",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "library/alpine",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+		{
+			name: "14. private registry image ref with digest",
+			imageRef: "my-private-repo.company.com/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "my-private-repo.company.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag: "",
+			},
+			err: nil,
+		},
+		{
+			name: "15. private registry image ref tag & with digest",
+			imageRef: "my-private-repo.company.com/my-app:some-tag@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "my-private-repo.company.com",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag: "some-tag",
+			},
+			err: nil,
+		},
+		{
+			name: "16. well known image without tag & digest",
+			imageRef: "quay.io/centos/centos",
+			imageID: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			registry: v1alpha1.Registry{
+				Server: "quay.io",
+			},
+			artifact: v1alpha1.Artifact{
+				Repository: "centos/centos",
+				Digest: "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+				Tag: "latest",
+			},
+			err: nil,
+		},
+	};
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry,artifact,err := trivy.ParseImageRef(tc.imageRef,tc.imageID)
+			assert.Equal(t, tc.registry, registry)
+			assert.Equal(t, tc.artifact, artifact)
+			if tc.err!=nil {
+				if !assert.Error(t,err) {
+					assert.Failf(t,"expected","%v but got %v",tc.err,err)
+				}
+			}
 		})
 	}
 }

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7691,20 +7691,6 @@ func TestParseImageRef(t *testing.T) {
 			err:      errors.New("could not parse reference: ## some incorrect imput ###"),
 		},
 		{
-			name:     "5. short repo with tag",
-			imageRef: "prometheus-operator:local",
-			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-			registry: v1alpha1.Registry{
-				Server: "index.docker.io",
-			},
-			artifact: v1alpha1.Artifact{
-				Repository: "library/prometheus-operator",
-				Digest:     "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
-				Tag:        "local",
-			},
-			err: nil,
-		},
-		{
 			name:     "6. short repo with default lib with latest tag",
 			imageRef: "library/nginx:latest",
 			imageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",


### PR DESCRIPTION
## Description

I've changed behaviour of parseImageRef func. 
before: 
In case when imageRef -> "my-private-repo.company.com/my-app:some-tag@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f"
It returns empty tag in Artifact.Tag;

after: 
In new version this behaviour fixed and it returns tag instead empty string. 
you can see it it "15. private registry image ref tag & with digest" test.

## Related issues
- Close #2411

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ Not need] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [Not need] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
