### PR TITLE
ci: bump up Helm Chart to version 0.26.0 (app version v0.24.0)

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -19,7 +19,9 @@ keywords:
   - aquasecurity
   - trivyoperator
   - trivy
+
 # home: https://github.com/aquasecurity/trivy-operator
+
 sources:
   - https://github.com/aquasecurity/trivy-operator
 # maintainers: # (optional)


### PR DESCRIPTION
## Description

There was a mistake in the previous pipeline (https://github.com/aquasecurity/trivy-operator/actions/runs/13191791193/job/36825958183), so Helm Chart with these versions wasn't published.

This PR hits a github workflow to bump up  the Helm Chart to version 0.26.0 (app version v0.24.0) 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
