### PR TITLE
fix: update default values for configmap

### DIFF
--- a/pkg/plugins/trivy/config_test.go
+++ b/pkg/plugins/trivy/config_test.go
@@ -721,7 +721,7 @@ func TestPlugin_Init(t *testing.T) {
 			},
 			Data: map[string]string{
 				"trivy.repository":                DefaultImageRepository,
-				"trivy.tag":                       "0.52.2",
+				"trivy.tag":                       "0.59.1",
 				"trivy.severity":                  DefaultSeverity,
 				"trivy.slow":                      "true",
 				"trivy.mode":                      string(Standalone),

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -80,7 +80,7 @@ func (p *plugin) Init(ctx trivyoperator.PluginContext) error {
 	return ctx.EnsureConfig(trivyoperator.PluginConfig{
 		Data: map[string]string{
 			keyTrivyImageRepository:           DefaultImageRepository,
-			keyTrivyImageTag:                  "0.52.2",
+			keyTrivyImageTag:                  "0.59.1",
 			KeyTrivySeverity:                  DefaultSeverity,
 			keyTrivySlow:                      "true",
 			keyTrivyMode:                      string(Standalone),

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -121,8 +121,8 @@ func GetDefaultConfig() ConfigData {
 		KeyScanJobcompressLogs:          "true",
 		keyComplianceFailEntriesLimit:   "10",
 		KeyReportRecordFailedChecksOnly: "true",
-		KeyNodeCollectorImageRef:        "ghcr.io/aquasecurity/node-collector:0.2.1",
-		KeyPoliciesBundleOciRef:         "mirror.gcr.io/aquasec/trivy-checks:0",
+		KeyNodeCollectorImageRef:        "gcr.io/aquasecurity/node-collector:0.3.1",
+		KeyPoliciesBundleOciRef:         "mirror.gcr.io/aquasec/trivy-checks:1",
 	}
 }
 


### PR DESCRIPTION
## Description

This PR updates default values for config maps.
It allows to run trivy-operator without any additional settings.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
