### PR TITLE
feat: add Persistent Volume resources

### DIFF
--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -118,6 +118,7 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	clusterResources := []kube.Resource{
+		{Kind: kube.KindPersistentVolume, ForObject: &corev1.PersistentVolume{}, OwnsObject: &v1alpha1.ClusterConfigAuditReport{}},
 		{Kind: kube.KindClusterRole, ForObject: &rbacv1.ClusterRole{}, OwnsObject: &v1alpha1.ClusterRbacAssessmentReport{}},
 		{Kind: kube.KindClusterRoleBindings, ForObject: &rbacv1.ClusterRoleBinding{}, OwnsObject: &v1alpha1.ClusterRbacAssessmentReport{}},
 		{Kind: kube.KindCustomResourceDefinition, ForObject: &apiextensionsv1.CustomResourceDefinition{}, OwnsObject: &v1alpha1.ClusterConfigAuditReport{}},

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -57,6 +57,8 @@ const (
 	KindResourceQuota         Kind = "ResourceQuota"
 	KindLimitRange            Kind = "LimitRange"
 
+	KindPersistentVolume Kind = "PersistentVolume"
+
 	KindClusterRole              Kind = "ClusterRole"
 	KindClusterRoleBindings      Kind = "ClusterRoleBinding"
 	KindCustomResourceDefinition Kind = "CustomResourceDefinition"
@@ -105,7 +107,7 @@ func IsWorkload(kind string) bool {
 // TODO Use discovery client to have a generic implementation.
 func IsClusterScopedKind(kind string) bool {
 	switch kind {
-	case string(KindClusterRole), string(KindClusterRoleBindings), string(KindCustomResourceDefinition), string(KindNode):
+	case string(KindClusterRole), string(KindClusterRoleBindings), string(KindCustomResourceDefinition), string(KindNode), string(KindPersistentVolume):
 		return true
 	default:
 		return false
@@ -232,6 +234,8 @@ func ComputeSpecHash(obj client.Object) (string, error) {
 		return ComputeHash(obj), nil
 	case *apiextensionsv1.CustomResourceDefinition:
 		return ComputeHash(obj), nil
+	case *corev1.PersistentVolume:
+		return ComputeHash(obj), nil
 	default:
 		return "", fmt.Errorf("computing spec hash of unsupported object: %T", t)
 	}
@@ -353,6 +357,8 @@ func (o *ObjectResolver) ObjectFromObjectRef(ctx context.Context, ref ObjectRef)
 		obj = &batchv1.Job{}
 	case KindNode:
 		obj = &corev1.Node{}
+	case KindPersistentVolume:
+		obj = &corev1.PersistentVolume{}
 	case KindService:
 		obj = &corev1.Service{}
 	case KindConfigMap:


### PR DESCRIPTION
## Description

This PR is a small PoC for adding new resources with minimum changes.

```sh
$ kubectl get clusterconfigauditreports.aquasecurity.github.io -A -o wide
NAME                       SCANNER   AGE   CRITICAL   HIGH   MEDIUM   LOW
persistentvolume-demo-pv   Trivy     41m   0          0      0        1

$ kubectl describe clusterconfigauditreports.aquasecurity.github.io persistentvolume-demo-pv
Name:         persistentvolume-demo-pv
Namespace:
Labels:       plugin-config-hash=6ddf87c668
              resource-spec-hash=579589976
              trivy-operator.resource.kind=PersistentVolume
              trivy-operator.resource.name=demo-pv
              trivy-operator.resource.namespace=
Annotations:  <none>
API Version:  aquasecurity.github.io/v1alpha1
Kind:         ClusterConfigAuditReport
Metadata:
  Creation Timestamp:  2025-02-21T10:20:56Z
  Generation:          1
  Owner References:
    API Version:           v1
    Block Owner Deletion:  false
    Controller:            true
    Kind:                  PersistentVolume
    Name:                  demo-pv
    UID:                   3edb48c5-109b-4896-8d98-4c1487769869
  Resource Version:        4485
  UID:                     630647c7-4395-44d3-8db3-a60baba58d90
Report:
  Checks:
    Category:     Kubernetes Security Check
    Check ID:     PVC_CHECK
    Description:  A common set of labels allows tools to work interoperably, describing objects in a common manner that all tools can understand.
    Messages:
      the check should always fail
    Remediation:  Take full advantage of using recommended labels and apply them on every resource object.
    Severity:     LOW
    Success:      false
    Title:        PVC labels
  Scanner:
    Name:     Trivy
    Vendor:   Aqua Security
    Version:  dev
  Summary:
    Critical Count:  0
    High Count:      0
    Low Count:       1
    Medium Count:    0
  Update Timestamp:  2025-02-21T10:20:56Z
```

<details>

<summary>custom REGO check</summary>

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: trivy-operator-policies-config
  namespace: trivy-operator
  labels:
    app.kubernetes.io/name: trivy-operator
    app.kubernetes.io/instance: trivy-operator
    app.kubernetes.io/version: "0.23.0"
    app.kubernetes.io/managed-by: kubectl
data:
  policy.recommended_labels.kinds: "PersistentVolume"
  policy.recommended_labels.rego: |
   package builtin.policy.k8s.custom

   __rego_metadata__ := {
      "id": "PVC_CHECK",
      "title": "PVC labels",
      "severity": "LOW",
      "type": "Kubernetes Security Check",
      "description": "A common set of labels allows tools to work interoperably, describing objects in a common manner that all tools can understand.",
      "recommended_actions": "Take full advantage of using recommended labels and apply them on every resource object.",
      "url": "https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/",
   }

   alwaysTrue {
      1 == 1
   }

   deny[res] {
        alwaysTrue
        res := {
           "msg": "the check should always fail",
        }
   }
```
</details>

<details>

<summary>pv.yaml</summary>

```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: demo-pv
spec:
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 1Gi
  storageClassName: standard
  hostPath:
    path: /tmp/demo-pv
```

</details>

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
