### PR TITLE
fix(helm): use map for `scanJobAffinity` in the Helm Chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -197,7 +197,7 @@ Keeps security report resources updated
 | trivyOperator.policiesConfig | string | `""` | policiesConfig Custom Rego Policies to be used by the config audit scanner See https://github.com/aquasecurity/trivy-operator/blob/main/docs/tutorials/writing-custom-configuration-audit-policies.md for more details. |
 | trivyOperator.reportRecordFailedChecksOnly | bool | `true` | reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment) |
 | trivyOperator.reportResourceLabels | string | `""` | reportResourceLabels comma-separated scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app` |
-| trivyOperator.scanJobAffinity | list | `[]` | scanJobAffinity affinity to be applied to the scanner pods and node-collector |
+| trivyOperator.scanJobAffinity | object | `{}` | scanJobAffinity affinity to be applied to the scanner pods and node-collector |
 | trivyOperator.scanJobAnnotations | string | `""` | scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner jobs and pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner jobs and pods with the annotations `foo: bar` and `env: stage` |
 | trivyOperator.scanJobAutomountServiceAccountToken | bool | `false` | scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job |
 | trivyOperator.scanJobCompressLogs | bool | `true` | scanJobCompressLogs control whether scanjob output should be compressed or plain |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -253,7 +253,7 @@ trivyOperator:
   # -- scanJobCompressLogs control whether scanjob output should be compressed or plain
   scanJobCompressLogs: true
   # -- scanJobAffinity affinity to be applied to the scanner pods and node-collector
-  scanJobAffinity: []
+  scanJobAffinity: {}
   # -- scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints
   scanJobTolerations: []
   # -- If you do want to specify tolerations, uncomment the following lines, adjust them as necessary, and remove the


### PR DESCRIPTION
## Description

This PR sets a default value for `scanJobAffinity` field as a map.

Prepare
```sh
$ git clone --depth=1 https://github.com/aquasecurity/trivy-operator.git
$ tee ./trivy-operator-values.yaml <<EOF
trivyOperator:
  scanJobAffinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: cloud.google.com/gke-spot
                operator: In
                values:
                  - "true"
EOF
```
Before:
```sh
$ helm install trivy-operator ./trivy-operator/deploy/helm --namespace trivy-system --create-namespace --values ./trivy-operator-values.yaml
coalesce.go:289: warning: destination for trivy-operator.trivyOperator.scanJobAffinity is a table. Ignoring non-table value ([])
NAME: trivy-operator
LAST DEPLOYED: Tue Mar  4 18:29:21 2025
NAMESPACE: trivy-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
After:
```sh
$ helm install trivy-operator ./trivy-operator/deploy/helm --namespace trivy-system --create-namespace --values ./trivy-operator-values.yaml
NAME: trivy-operator
LAST DEPLOYED: Tue Mar  4 18:27:20 2025
NAMESPACE: trivy-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## Related issues
- Close #2456 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
