### PR TITLE
chore(deps): bump golang.org/x/oauth2 from 0.25.0 to 0.27.0 - resolve CVE-2025-22868

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -324,7 +324,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/oauth2 v0.25.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	google.golang.org/api v0.218.0 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2190,8 +2190,8 @@ golang.org/x/oauth2 v0.4.0/go.mod h1:RznEsdpjGAINPTOF0UH/t+xJ75L18YO3Ho6Pyn+uRec
 golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
 golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
-golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
-golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
### Description

Let's keep the AquaSec Trivy-Operator dependency `golang.org/x/oauth2` up-to-date. The current latest Docker-Image tag `0.25.0` using an older version of oauth2 which could be affected by https://github.com/golang/go/issues/71490 (https://nvd.nist.gov/vuln/detail/CVE-2025-22868). So, let's upgrade oauth2 from `0.25.0` to `0.27.0` for AquaSec Trivy-Operator.

Having this said, I ran:
```
go get golang.org/x/oauth2@v0.27.0
go mod tidy
```

### Note for Reviewers

Basically, this dependency update just aim to silence some (SBOM-based) scanners, while checking `aquasec/trivy-operator:0.25.0` Docker-Image.

I didn't create a linked issue here in the repo yet - If this would be better/required to have an issue, I'm happy to create one and link this here with Close/Fixed reference.