### PR TITLE
chore: bump up base alpine image to 3.20.6

### DIFF
--- a/build/trivy-operator/Dockerfile
+++ b/build/trivy-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN apk update
 


### PR DESCRIPTION
## Description

This PR bump up the base image to version 3.20.6 of Alpine Linux. It's just a minor-update to improve security of trivy-operator docker-image.

## Related issues
This bump from `3.20.3` to `3.20.6` resolving following CVEs in the current docker-image:

`openssl`:
* CVE-2024-9143 (fixed via 3.20.4)
* CVE-2024-13176 (fixed via 3.20.6)
* CVE-2024-12797 (fixed via 3.20.6)

`musl`:
* CVE-2025-26519 (fixed via 3.20.6)



## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
