### PR TITLE
chore(test): update images for integration tests

### DIFF
--- a/tests/itest/helper/helper.go
+++ b/tests/itest/helper/helper.go
@@ -62,10 +62,12 @@ func (b *PodBuilder) WithNamespace(namespace string) *PodBuilder {
 	return b
 }
 
-func (b *PodBuilder) WithContainer(name, image string) *PodBuilder {
+func (b *PodBuilder) WithContainer(name, image string, commands, args []string) *PodBuilder {
 	b.containers = append(b.containers, corev1.Container{
-		Name:  name,
-		Image: image,
+		Name:    name,
+		Image:   image,
+		Command: commands,
+		Args:    args,
 	})
 	return b
 }

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -107,7 +107,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContagit iner("wordpress", "wordpress:4.9").
+					WithContainer("wordpress", "wordpress:4.9").
 					Build()
 
 				err := inputs.Create(ctx, deploy)

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -44,9 +44,9 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 			BeforeEach(func() {
 				ctx = context.Background()
 				pod = helper.NewPod().
-					WithRandomName("unmanaged-nginx").
+					WithRandomName("unmanaged-vuln-image").
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("nginx", "nginx:1.16").
+					WithContainer("vuln-image", "knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
 					Build()
 
 				err := inputs.Create(ctx, pod)
@@ -107,7 +107,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContagit iner("wordpress", "wordpress:4.9").
 					Build()
 
 				err := inputs.Create(ctx, deploy)
@@ -220,9 +220,9 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 			BeforeEach(func() {
 				ctx = context.Background()
 				pod = helper.NewPod().
-					WithRandomName("unmanaged-nginx").
+					WithRandomName("unmanaged-vuln-image").
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("nginx", "nginx:1.16").
+					WithContainer("vuln-image", "knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
 					Build()
 
 				err := inputs.Create(ctx, pod)


### PR DESCRIPTION
## Description
This PR uses a pre-built vuln image based on `alpine` instead of `nginx` images for integration tests. This image doesn't contain any jar files, so there is no need to download `trivy-java-db`.

it's more stable and improves scan time.

Before:
```
Ran 9 of 9 Specs in 429.834 seconds
FAIL! -- 8 Passed | 1 Failed | 0 Pending | 0 Skipped

Ginkgo ran 1 suite in 10m58.489077216s


Ran 9 of 9 Specs in 128.973 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped

Ginkgo ran 1 suite in 5m59.034072499s
```

After:
```
Build / Run integration tests (pull_request)Successful in 6m

Ran 9 of 9 Specs in 96.032 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped

Ginkgo ran 1 suite in 4m43.909739935s
```

## Related issues
- Close #2460 


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
