### PR TITLE
test: improve integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,12 +131,6 @@ jobs:
           kubectl wait --for=condition=Ready nodes --all --timeout=300s
           kubectl describe node
 
-      - name: Login to docker.io registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Run integration tests
         run: |
           kubectl create -k deploy/static

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,6 +131,12 @@ jobs:
           kubectl wait --for=condition=Ready nodes --all --timeout=300s
           kubectl describe node
 
+      - name: Login to docker.io registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run integration tests
         run: |
           kubectl create -k deploy/static

--- a/magefile.go
+++ b/magefile.go
@@ -142,7 +142,7 @@ func prepareImages() error {
 	images := []string{
 		"mirror.gcr.io/knqyf263/vuln-image:1.2.3",
 		"wordpress:4.9",
-		"wordpress:6.1",
+		"wordpress:6.7",
 	}
 	fmt.Printf("Preparing %d image(s) for Trivy Operator...\n", len(images))
 	for _, image := range images {

--- a/magefile.go
+++ b/magefile.go
@@ -122,7 +122,7 @@ func (t Test) Unit() error {
 // Target for running integration tests for Trivy Operator.
 func (t Test) Integration() error {
 	fmt.Println("Running integration tests for Trivy Operator...")
-	mg.Deps(checkKubeconfig, getGinkgo)
+	mg.Deps(checkEnvKubeconfig, checkEnvOperatorNamespace, checkEnvOperatorTargetNamespace, getGinkgo)
 	return sh.RunV(GINKGO, "-coverprofile=coverage.txt",
 		"-coverpkg=github.com/aquasecurity/trivy-operator/pkg/operator,"+
 			"github.com/aquasecurity/trivy-operator/pkg/operator/predicate,"+
@@ -134,14 +134,23 @@ func (t Test) Integration() error {
 		"./tests/itest/trivy-operator")
 }
 
-// Target for checking if KUBECONFIG environment variable is set.
-func checkKubeconfig() error {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		return fmt.Errorf("Environment variable KUBECONFIG is not set")
+// Targets for checking if environment variables are set.
+func checkEnvironmentVariable(name string) error {
+	envVar := os.Getenv(name)
+	if envVar == "" {
+		return fmt.Errorf("Environment variable %q is not set", name)
 	}
-	fmt.Println("KUBECONFIG=", kubeconfig)
+	fmt.Println(name, "=", envVar)
 	return nil
+}
+func checkEnvKubeconfig() error {
+	return checkEnvironmentVariable("KUBECONFIG")
+}
+func checkEnvOperatorNamespace() error {
+	return checkEnvironmentVariable("OPERATOR_NAMESPACE")
+}
+func checkEnvOperatorTargetNamespace() error {
+	return checkEnvironmentVariable("OPERATOR_TARGET_NAMESPACES")
 }
 
 // Target for removing build artifacts

--- a/magefile.go
+++ b/magefile.go
@@ -121,11 +121,12 @@ func (t Test) Unit() error {
 
 // Target for running integration tests for Trivy Operator.
 func (t Test) Integration() error {
-	fmt.Println("Running integration tests for Trivy Operator...")
+	fmt.Println("Preparing integration tests for Trivy Operator...")
 	mg.Deps(checkEnvKubeconfig, checkEnvOperatorNamespace, checkEnvOperatorTargetNamespace, getGinkgo)
 	mg.Deps(prepareImages)
 
-	return sh.RunV(GINKGO, "-coverprofile=coverage.txt",
+	fmt.Println("Running integration tests for Trivy Operator...")
+	return sh.RunV(GINKGO, "-v", "-coverprofile=coverage.txt",
 		"-coverpkg=github.com/aquasecurity/trivy-operator/pkg/operator,"+
 			"github.com/aquasecurity/trivy-operator/pkg/operator/predicate,"+
 			"github.com/aquasecurity/trivy-operator/pkg/operator/controller,"+

--- a/magefile.go
+++ b/magefile.go
@@ -142,6 +142,7 @@ func prepareImages() error {
 	images := []string{
 		"mirror.gcr.io/knqyf263/vuln-image:1.2.3",
 		"wordpress:4.9",
+		"wordpress:6.1",
 	}
 	fmt.Printf("Preparing %d image(s) for Trivy Operator...\n", len(images))
 	for _, image := range images {

--- a/tests/itest/helper/helper.go
+++ b/tests/itest/helper/helper.go
@@ -441,7 +441,7 @@ func (h *Helper) UpdateDeploymentImage(namespace, name string) error {
 		}
 
 		dcDeploy := deployment.DeepCopy()
-		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:5"
+		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:6.1"
 		err = h.kubeClient.Update(context.TODO(), dcDeploy)
 		if err != nil && errors.IsConflict(err) {
 			return false, nil

--- a/tests/itest/helper/helper.go
+++ b/tests/itest/helper/helper.go
@@ -441,7 +441,7 @@ func (h *Helper) UpdateDeploymentImage(namespace, name string) error {
 		}
 
 		dcDeploy := deployment.DeepCopy()
-		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:6.1"
+		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:6.7"
 		err = h.kubeClient.Update(context.TODO(), dcDeploy)
 		if err != nil && errors.IsConflict(err) {
 			return false, nil

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -124,7 +124,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				By("Waiting for VulnerabilityReport")
 				Eventually(inputs.HasVulnerabilityReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:5")
+				By("Updating deployment image to wordpress:6.1")
 				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -300,7 +300,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				By("Waiting for ConfigAuditReport")
 				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:5")
+				By("Updating deployment image to wordpress:6.1")
 				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -46,7 +46,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				pod = helper.NewPod().
 					WithRandomName("unmanaged-vuln-image").
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("vuln-image", "knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
+					WithContainer("vuln-image", "mirror.gcr.io/knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
 					Build()
 
 				err := inputs.Create(ctx, pod)
@@ -222,7 +222,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				pod = helper.NewPod().
 					WithRandomName("unmanaged-vuln-image").
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("vuln-image", "knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
+					WithContainer("vuln-image", "mirror.gcr.io/knqyf263/vuln-image:1.2.3", []string{"/bin/sh", "-c", "--"}, []string{"while true; do sleep 30; done;"}).
 					Build()
 
 				err := inputs.Create(ctx, pod)

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -124,7 +124,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				By("Waiting for VulnerabilityReport")
 				Eventually(inputs.HasVulnerabilityReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:6.1")
+				By("Updating deployment image to wordpress:6.7")
 				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -300,7 +300,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				By("Waiting for ConfigAuditReport")
 				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:6.1")
+				By("Updating deployment image to wordpress:6.7")
 				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Description

This PR adds pre-downloading test images and upload them into KinD.

Also it uses `wordpress:6.7` instead of `wordpress:5` for Replicaset Integration test.
It allowed to decrease a report size from 24 837 814 to 4 810 124 bytes.

```sh
$ trivy image wordpress:4.9 --format json --image-config-scanners secret --quiet --scanners vuln,secret --skip-db-update --slow --list-all-pkgs -o result_wordpress-4.9.json
$ ls -l
-rw-r--r--@ 1 amf  staff   5567245 Mar 25 19:38 result_wordpress-4.9.json
```

Before:
```sh
$ trivy image wordpress:5 --format json --image-config-scanners secret --quiet --scanners vuln,secret --skip-db-update --slow --list-all-pkgs -o result_wordpress.json
$ ls -l
-rw-r--r--@ 1 amf  staff  24837814 Mar 25 18:56 result_wordpress.json
```
After:
```sh
$ trivy image wordpress:6.7 --format json --image-config-scanners secret --quiet --scanners vuln,secret --skip-db-update --slow --list-all-pkgs -o result_wordpress-6.7.json
$ ls -l
-rw-r--r--@ 1 amf  staff   4810124 Mar 25 19:53 result_wordpress-6.7.json
```

## Related issues
- Close #2496

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
