### PR TITLE
docs: update trivy fs source

### DIFF
--- a/docs/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
+++ b/docs/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
@@ -221,4 +221,4 @@ With this approach trivy operator will not have to worry about managing(create/d
   
 [ECR registry configuration]: https://aquasecurity.github.io/trivy-operator/v0.25.0/integrations/managed-registries/#amazon-elastic-container-registry-ecr
 [IAM role to service account]: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
-[Trivy fs command]: https://github.com/aquasecurity/trivy-operator/blob/main/docs/design/design_trivy_file_system_scanner.md
+[Trivy fs command]: https://aquasecurity.github.io/trivy-operator/latest/docs/design/design_trivy_file_system_scanner/


### PR DESCRIPTION
## Description
This small PR updates the `Trivy fs command` source guide to point to:
```markdown
https://aquasecurity.github.io/trivy-operator/latest/docs/design/design_trivy_file_system_scanner/
```
Relevant page: https://aquasecurity.github.io/trivy-operator/latest/docs/design/design_vuln_scan_job_in_same_namespace_of_workload/

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
