### PR TITLE
fix: set actual size for policies cache

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -475,6 +475,6 @@ func buildPolicyLoader(tc trivyoperator.ConfigData) (policy.Loader, error) {
 	}
 	ro.Insecure = tc.PolicyBundleInsecure()
 	artifact.RegistryOptions = ro
-	policyLoader := policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(1).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
+	policyLoader := policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(2).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
 	return policyLoader, nil
 }


### PR DESCRIPTION
## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
