### PR TITLE
chore: improve cache for policies

### DIFF
--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -38,7 +38,7 @@ func Policies(ctx context.Context, config etc.Config, c client.Client, cac confi
 	if len(clusterVersion) > 0 {
 		version = clusterVersion[0]
 	}
-	return policy.NewPolicies(cm.Data, cac, log, pl, version), nil
+	return policy.NewPolicies(cm.Data, cac, log, pl, version, config.CacheReportTTL), nil
 }
 
 func ConfigurePolicies(ctx context.Context, config etc.Config, c client.Client, cac configauditreport.ConfigAuditConfig, log logr.Logger, pl policy.Loader, clusterVersion ...string) (*policy.Policies, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -230,10 +230,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	var policyLoader policy.Loader
 	var checksLoader *controller.ChecksLoader
 	if operatorConfig.ConfigAuditScannerEnabled {
-		policyLoader, err = buildPolicyLoader(trivyOperatorConfig)
-		if err != nil {
-			return fmt.Errorf("unable to constract policy loader: %w", err)
-		}
+		policyLoader = buildPolicyLoader(trivyOperatorConfig)
 		checksLoader = controller.NewChecksLoader(
 			operatorConfig,
 			ctrl.Log.WithName("checks-loader"),
@@ -460,7 +457,7 @@ func newWorkloadController(operatorConfig etc.Config,
 	}, nil
 }
 
-func buildPolicyLoader(tc trivyoperator.ConfigData) (policy.Loader, error) {
+func buildPolicyLoader(tc trivyoperator.ConfigData) policy.Loader {
 	registryUser := tc.PolicyBundleOciUser()
 	registryPassword := tc.PolicyBundleOciPassword()
 	artifact := oci.NewArtifact(tc.PolicyBundleOciRef(), types.RegistryOptions{})
@@ -475,6 +472,5 @@ func buildPolicyLoader(tc trivyoperator.ConfigData) (policy.Loader, error) {
 	}
 	ro.Insecure = tc.PolicyBundleInsecure()
 	artifact.RegistryOptions = ro
-	policyLoader := policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(1).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
-	return policyLoader, nil
+	return policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(2).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
 }

--- a/pkg/policy/hash_bench_test.go
+++ b/pkg/policy/hash_bench_test.go
@@ -1,14 +1,16 @@
 package policy
 
 import (
-	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
-	"github.com/aquasecurity/trivy-operator/pkg/utils"
-	"github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/bluele/gcache"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/bluele/gcache"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
+	"github.com/aquasecurity/trivy-operator/pkg/utils"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
 var (

--- a/pkg/policy/hash_bench_test.go
+++ b/pkg/policy/hash_bench_test.go
@@ -1,0 +1,93 @@
+package policy
+
+import (
+	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
+	"github.com/aquasecurity/trivy-operator/pkg/utils"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/bluele/gcache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	k8sresources = []string{
+		"Pod",
+		"Deployment",
+		"DaemonSet",
+		"StatefulSet",
+		"ReplicaSet",
+	}
+)
+
+type testConfig struct {
+	builtInPolicies  bool
+	embeddedPolicies bool
+}
+
+func newTestConfig(builtInPolicies bool) testConfig {
+	return testConfig{builtInPolicies: builtInPolicies}
+}
+
+// GetUseBuiltinRegoPolicies return trivy config which associated to configauditreport plugin
+func (tc testConfig) GetUseBuiltinRegoPolicies() bool {
+	return tc.builtInPolicies
+}
+
+// GetUseBuiltinRegoPolicies return trivy config which associated to configauditreport plugin
+func (tc testConfig) GetUseEmbeddedRegoPolicies() bool {
+	return tc.embeddedPolicies
+}
+
+// GetSupportedConfigAuditKinds list of supported kinds to be scanned by the config audit scanner
+func (tc testConfig) GetSupportedConfigAuditKinds() []string {
+	return utils.MapKinds(strings.Split(trivy.SupportedConfigAuditKinds, ","))
+}
+
+func (tc testConfig) GetSeverity() string {
+	return trivy.KeyTrivySeverity
+}
+
+func benchmarkHash10000(b *testing.B, p *Policies) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < 10000; i++ {
+		for _, resource := range k8sresources {
+			_, _ = p.Hash(resource)
+		}
+	}
+}
+
+func BenchmarkPolicies_Hash(b *testing.B) {
+	expiration := 24 * time.Hour
+	pl := NewPolicyLoader("", gcache.New(2).LRU().Build(), types.RegistryOptions{})
+	p := NewPolicies(map[string]string{
+		"policy.valid.rego":  "<REGO_CONTENT>",
+		"policy.valid.kinds": "Pod",
+	}, newTestConfig(true), ctrl.Log.WithName("policy logger"), pl, "v1.23.0", &expiration)
+	benchmarkHash10000(b, p)
+}
+
+func BenchmarkPolicies_HashWithoutCache(b *testing.B) {
+	expiration := 24 * time.Hour
+	pl := NewPolicyLoader("", gcache.New(2).LRU().Build(), types.RegistryOptions{})
+	p := NewPolicies(map[string]string{
+		"policy.valid.rego":  "<REGO_CONTENT>",
+		"policy.valid.kinds": "Pod",
+	}, newTestConfig(true), ctrl.Log.WithName("policy logger"), pl, "v1.23.0", &expiration)
+	p.cache = nil
+	benchmarkHash10000(b, p)
+}
+
+func BenchmarkPolicies_HashWithoutCacheAndIncorrectSize(b *testing.B) {
+	expiration := 24 * time.Hour
+	pl := NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{})
+	p := NewPolicies(map[string]string{
+		"policy.valid.rego":  "<REGO_CONTENT>",
+		"policy.valid.kinds": "Pod",
+	}, newTestConfig(true), ctrl.Log.WithName("policy logger"), pl, "v1.23.0", &expiration)
+	p.cache = nil
+	benchmarkHash10000(b, p)
+}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -131,7 +131,7 @@ func (p *Policies) PoliciesByKind(kind string) (map[string]string, error) {
 }
 
 func (p *Policies) getCachedHash(kind string) (string, error) {
-	// without cache, we don't need to check the hash
+	// without cache, we don't keep the hashes
 	if p.cache == nil {
 		return "", nil
 	}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/bluele/gcache"
@@ -60,7 +59,6 @@ type Policies struct {
 	policyFS       *memoryfs.FS
 	loaded         []string
 	scanner        k8sScanner
-	mutex          sync.RWMutex
 	cache          gcache.Cache
 	cacheExpire    time.Duration
 }
@@ -135,8 +133,6 @@ func (p *Policies) getCachedHash(kind string) (string, error) {
 	if p.cache == nil {
 		return "", nil
 	}
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
 	value, err := p.cache.Get(kind)
 	if err != nil {
 		if !errors.Is(err, gcache.KeyNotFoundError) {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -167,8 +167,8 @@ func (p *Policies) Hash(kind string) (string, error) {
 		return "", fmt.Errorf("failed to load built-in / external policies: %s: %w", kind, err)
 	}
 
-  // TODO(simar7): What if len(policies) is 0?
-  
+	// TODO(simar7): What if len(policies) is 0?
+
 	hash = kube.ComputeHash(policies)
 	if err := p.setCachedHash(kind, hash); err != nil {
 		return "", fmt.Errorf("failed to set cached hash for kind %s: %v", kind, err)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -55,22 +55,12 @@ func TestPolicies_Hash(t *testing.T) {
 		config := policy.NewPolicies(map[string]string{
 			"policy.valid.rego":  "<REGO_CONTENT>",
 			"policy.valid.kinds": "Pod",
-		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
+		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL)
 
 		hash, err := config.Hash("Pod")
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(hash).ToNot(BeEmpty())
 	})
-	/*
-		t.Run("Should return error when no policies are found", func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			config := policy.NewPolicies(make(map[string]string), testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
-
-			_, err := config.Hash("Pod")
-			g.Expect(err).To(HaveOccurred())
-			g.Expect(err.Error()).To(ContainSubstring("no policies found"))
-		})
-	*/
 	t.Run("Should compute correct hash for given policies", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		policies := map[string]string{
@@ -79,7 +69,7 @@ func TestPolicies_Hash(t *testing.T) {
 			"policy.policy2.rego":  "package test\nallow = false",
 			"policy.policy2.kinds": "Workload",
 		}
-		config := policy.NewPolicies(policies, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
+		config := policy.NewPolicies(policies, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL)
 
 		// Sort policy content before computing the expected hash
 		policyContents := []string{

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bluele/gcache"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +29,8 @@ import (
 )
 
 var (
+	cacheReportTTL = time.Hour * 24
+
 	simpleNginxPod = &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -52,7 +55,7 @@ func TestPolicies_PoliciesByKind(t *testing.T) {
 			"library.kubernetes.rego":        "<REGO_A>",
 			"library.utils.rego":             "<REGO_B>",
 			"policy.access_to_host_pid.rego": "<REGO_C>",
-		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
+		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL)
 		_, err := config.PoliciesByKind("Pod")
 		g.Expect(err).To(MatchError("kinds not defined for policy: policy.access_to_host_pid.rego"))
 	})
@@ -61,7 +64,7 @@ func TestPolicies_PoliciesByKind(t *testing.T) {
 		g := NewGomegaWithT(t)
 		config := policy.NewPolicies(map[string]string{
 			"policy.access_to_host_pid.kinds": "Workload",
-		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
+		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL)
 		_, err := config.PoliciesByKind("Pod")
 		g.Expect(err).To(MatchError("expected policy not found: policy.access_to_host_pid.rego"))
 	})
@@ -88,7 +91,7 @@ func TestPolicies_PoliciesByKind(t *testing.T) {
 			"policy.privileged": "<REGO_E>",
 			// This one should be skipped (no policy. prefix)
 			"foo": "bar",
-		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1")
+		}, testConfig{}, ctrl.Log.WithName("policy logger"), policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL)
 		g.Expect(config.PoliciesByKind("Pod")).To(Equal(map[string]string{
 			"policy.access_to_host_pid.rego":                "<REGO_C>",
 			"policy.cpu_not_limited.rego":                   "<REGO_D>",
@@ -162,7 +165,7 @@ func TestPolicies_Supported(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			log := ctrl.Log.WithName("resourcecontroller")
-			ready, err := policy.NewPolicies(tc.data, testConfig{}, log, policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1").SupportedKind(tc.resource, tc.rbacEnable)
+			ready, err := policy.NewPolicies(tc.data, testConfig{}, log, policy.NewPolicyLoader("", gcache.New(1).LRU().Build(), types.RegistryOptions{}), "1.27.1", &cacheReportTTL).SupportedKind(tc.resource, tc.rbacEnable)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ready).To(Equal(tc.expected))
 		})
@@ -650,7 +653,7 @@ func TestPolicies_Eval(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			log := ctrl.Log.WithName("resourcecontroller")
-			p := policy.NewPolicies(tc.policies, newTestConfig(tc.useBuiltInPolicies), log, &TestLoader{}, "1.27.1")
+			p := policy.NewPolicies(tc.policies, newTestConfig(tc.useBuiltInPolicies), log, &TestLoader{}, "1.27.1", &cacheReportTTL)
 			g.Expect(p.Load()).ToNot(HaveOccurred())
 			checks, err := p.Eval(context.TODO(), tc.resource)
 			if tc.expectedError != "" {


### PR DESCRIPTION
## Description

This PR introduces the following improvements:
* Caching for Computed Hash Values: Adds a caching mechanism to store computed values for each Kubernetes resource type. This improves performance by avoiding redundant calculations.
* Correct Cache Size for Downloaded Policies: Sets an appropriate cache size limit for storing downloaded policies.

Benchmark Results:
```go
% go test -bench=. -benchtime=10s -count=3
goos: darwin
goarch: arm64
pkg: github.com/aquasecurity/trivy-operator/pkg/policy
cpu: Apple M3 Max
BenchmarkPolicies_Hash-14                                       29993532               378.2 ns/op            81 B/op          5 allocs/op
BenchmarkPolicies_Hash-14                                       29637028               377.1 ns/op            81 B/op          5 allocs/op
BenchmarkPolicies_Hash-14                                       29042407               378.5 ns/op            81 B/op          5 allocs/op
BenchmarkPolicies_HashWithoutCache-14                               4954           2262165 ns/op         8057780 B/op        992 allocs/op
BenchmarkPolicies_HashWithoutCache-14                               5211           2253266 ns/op         8057535 B/op        992 allocs/op
BenchmarkPolicies_HashWithoutCache-14                               4982           2321768 ns/op         8057752 B/op        992 allocs/op
BenchmarkPolicies_HashWithoutCacheAndIncorrectSize-14                  2        5830538292 ns/op        120772640 B/op    145026 allocs/op
BenchmarkPolicies_HashWithoutCacheAndIncorrectSize-14                  2        5508156125 ns/op        120464356 B/op    144918 allocs/op
BenchmarkPolicies_HashWithoutCacheAndIncorrectSize-14                  2        5478692312 ns/op        120577780 B/op    144950 allocs/op
```
`BenchmarkPolicies_HashWithoutCacheAndIncorrectSize` is the current state.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
