### PR TITLE
docs(helm): Add trivy.existingSecret to README

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -136,6 +136,7 @@ Keeps security report resources updated
 | trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
 | trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
+| trivy.existingSecret | bool | `false` | existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...). Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values. Note: The secret has to be named "trivy-operator-trivy-config". |
 | trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies  |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -520,7 +520,7 @@ trivy:
   # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
   # Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values.
   # Note: The secret has to be named "trivy-operator-trivy-config".
-  # existingSecret: true
+  existingSecret: false
 
   # -- serverTokenHeader is the name of the HTTP header used to send the authentication
   # token to Trivy server. Only application in ClientServer mode when


### PR DESCRIPTION
## Description

Remove comment for `trivy.existingSecret` and change the default to `false` for backwards compatibility.

Since the value is now present in the values.yaml it is also generated into the README.md.

## Related issues
- Close #2282

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
