### PR TITLE
chore(ci): Free up space to build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,14 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          remove-android: "true"
+          remove-docker-images: "true"
+          remove-dotnet: "true"
+          remove-haskell: "true"
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Frees up space to avoid issues such as https://github.com/aquasecurity/trivy-operator/actions/runs/14788590999/job/41521687003 where no disk space is left on device.
