### PR TITLE
chore: bump up golangci-lint to version 2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           args: --verbose
-          version: v2.1.5
+          version: v2.1
       - name: Verify YAML code
         uses: ibiqlik/action-yamllint@v3
       - name: Vendor Go modules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,10 +44,10 @@ jobs:
         with:
           aqua_version: v1.25.0
       - name: Verify Go code
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
           args: --verbose
-          version: v1.64
+          version: v2.1.5
       - name: Verify YAML code
         uses: ibiqlik/action-yamllint@v3
       - name: Vendor Go modules

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   go: "1.24"
+  timeout: 30m
 linters:
   default: none
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,112 +1,14 @@
-linters-settings:
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        deny:
-          # Cannot use gomodguard, which examines go.mod, as "golang.org/x/exp/slices" is not a module and doesn't appear in go.mod.
-          - pkg: "golang.org/x/exp/slices"
-            desc: "Use 'slices' instead"
-          - pkg: "golang.org/x/exp/maps"
-            desc: "Use 'maps' or 'github.com/samber/lo' instead"
-  dupl:
-    threshold: 100
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/aquasecurity/)
-      - blank
-      - dot
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    disabled-checks:
-      - appendAssign
-      - unnamedResult
-      - whyNoLint
-      - indexAlloc
-      - octalLiteral
-      - hugeParam
-      - rangeValCopy
-      - regexpSimplify
-      - sloppyReassign
-      - commentedOutCode
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-      - experimental
-      - opinionated
-    settings:
-      ruleguard:
-        failOn: all
-        rules: '${configDir}/misc/lint/rules.go'
-  gocyclo:
-    min-complexity: 40
-  gofmt:
-    simplify: false
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/hashicorp/go-version:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
-        - github.com/Masterminds/semver:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
-  gosec:
-    excludes:
-      - G101
-      - G114
-      - G115
-      - G204
-      - G304
-      - G402
-  govet:
-    disable:
-      - shadow
-  misspell:
-    locale: US
-    ignore-words:
-      - behaviour
-      - licence
-      - optimise
-      - simmilar
-  perfsprint:
-    # Optimizes even if it requires an int or uint type cast.
-    int-conversion: false
-    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
-    err-error: true
-    # Optimizes `fmt.Errorf`.
-    errorf: true
-    # Optimizes `fmt.Sprintf` with only one argument.
-    sprintf1: false
-    # Optimizes into strings concatenation.
-    strconcat: false
-  revive:
-    ignore-generated-header: true
-  testifylint:
-    enable-all: true
+version: "2"
+run:
+  go: "1.24"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - depguard
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - gomodguard
     - gosec
     - govet
@@ -114,47 +16,167 @@ linters:
     - misspell
     - perfsprint
     - revive
-    - tenv
     - testifylint
-    - typecheck
     - unconvert
     - unused
     - usestdlibvars
-
-run:
-  go: '1.24'
-  timeout: 30m
-
+  settings:
+    revive:
+      max-open-files: 2048
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
+      rules:
+        - name: early-return
+          arguments:
+            - preserve-scope
+        - name: indent-error-flow
+          arguments:
+            - preserve-scope
+        - name: superfluous-else
+          arguments:
+            - preserve-scope
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            # Cannot use gomodguard, which examines go.mod, as "golang.org/x/exp/slices" is not a module and doesn't appear in go.mod.
+            - pkg: golang.org/x/exp/slices
+              desc: Use 'slices' instead
+            - pkg: golang.org/x/exp/maps
+              desc: Use 'maps' or 'github.com/samber/lo' instead
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - unnamedResult
+        - whyNoLint
+        - indexAlloc
+        - octalLiteral
+        - hugeParam
+        - rangeValCopy
+        - regexpSimplify
+        - sloppyReassign
+        - commentedOutCode
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - experimental
+        - opinionated
+      settings:
+        ruleguard:
+          failOn: all
+          rules: ${base-path}/misc/lint/rules.go
+    gocyclo:
+      min-complexity: 40
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/hashicorp/go-version:
+              recommendations:
+                - github.com/aquasecurity/go-version
+              reason: '`aquasecurity/go-version` is designed for our use-cases'
+          - github.com/Masterminds/semver:
+              recommendations:
+                - github.com/aquasecurity/go-version
+              reason: '`aquasecurity/go-version` is designed for our use-cases'
+    gosec:
+      excludes:
+        - G101
+        - G114
+        - G115
+        - G204
+        - G304
+        - G402
+    govet:
+      disable:
+        - shadow
+    misspell:
+      locale: US
+      ignore-rules:
+        - behaviour
+        - licence
+        - optimise
+        - simmilar
+    perfsprint:
+      # Optimizes even if it requires an int or uint type cast.
+      int-conversion: false
+      # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+      err-error: true
+      # Optimizes `fmt.Errorf`.
+      errorf: true
+      # Optimizes `fmt.Sprintf` with only one argument.
+      sprintf1: false
+      # Optimizes into strings concatenation.
+      strconcat: false
+    testifylint:
+      enable-all: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - goconst
+          - gosec
+          - unused
+        path: .*_test.go$
+      - linters:
+          - govet
+        path: .*_test.go$
+        text: 'copylocks:'
+      - linters:
+          - gocritic
+        path: .*_test.go$
+        text: 'commentFormatting:'
+      - linters:
+          - gocritic
+        path: .*_test.go$
+        text: 'exitAfterDefer:'
+      - linters:
+          - gocritic
+        path: .*_test.go$
+        text: 'importShadow:'
+      - linters:
+          - perfsprint
+        text: fmt.Sprint
+    paths:
+      - mock_*.go$
+      - examples/*
+      - pkg/iac/scanners/terraform/parser/funcs
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-files:
-    - "mock_*.go$"
-    - "examples/*"
-  exclude-dirs:
-    - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions
-  exclude-rules:
-    - path: ".*_test.go$"
-      linters:
-        - goconst
-        - gosec
-        - unused
-    - path: ".*_test.go$"
-      linters:
-        - govet
-      text: "copylocks:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "commentFormatting:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "exitAfterDefer:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "importShadow:"
-    - linters:
-        - perfsprint
-      text: "fmt.Sprint"
-  exclude-use-default: false
   max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/aquasecurity/)
+        - blank
+        - dot
+    gofmt:
+      simplify: false
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+  exclusions:
+    generated: lax
+    paths:
+      - mock_*.go$
+      - examples/*
+      - pkg/iac/scanners/terraform/parser/funcs
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/apis/aquasecurity/register.go
+++ b/pkg/apis/aquasecurity/register.go
@@ -1,6 +1,4 @@
 package aquasecurity
 
 // GroupName is the group name used in this package.
-const (
-	GroupName = "aquasecurity.github.io"
-)
+const GroupName = "aquasecurity.github.io"

--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -174,11 +174,11 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 			return err
 		}
 		return writer.WriteClusterReport(ctx, report)
-	} else {
-		report, err := b.GetReport()
-		if err != nil {
-			return err
-		}
-		return writer.WriteReport(ctx, report)
 	}
+
+	report, err := b.GetReport()
+	if err != nil {
+		return err
+	}
+	return writer.WriteReport(ctx, report)
 }

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -157,11 +157,10 @@ func ObjectRefFromObjectMeta(objectMeta metav1.ObjectMeta) (ObjectRef, error) {
 	}
 	var objname string
 	if _, found := objectMeta.Labels[trivyoperator.LabelResourceName]; !found {
-		if _, found := objectMeta.Annotations[trivyoperator.LabelResourceName]; found {
-			objname = objectMeta.Annotations[trivyoperator.LabelResourceName]
-		} else {
+		if _, found := objectMeta.Annotations[trivyoperator.LabelResourceName]; !found {
 			return ObjectRef{}, fmt.Errorf("required label does not exist: %s", trivyoperator.LabelResourceName)
 		}
+		objname = objectMeta.Annotations[trivyoperator.LabelResourceName]
 	} else {
 		objname = objectMeta.Labels[trivyoperator.LabelResourceName]
 	}

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -194,9 +194,8 @@ var IsCoreComponents = predicate.NewPredicateFuncs(func(obj client.Object) bool 
 			return true
 		} else if _, ok := v.GetLabels()[trivyoperator.LabelOpenShiftEtcd]; ok {
 			return true
-		} else {
-			return false
 		}
+		return false
 	case *corev1.Node:
 		return true
 	}

--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -80,7 +80,7 @@ func (r *TTLReportReconciler) reconcileReport(reportType client.Object) reconcil
 	}
 }
 
-func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName, reportType client.Object, arr ...string) (ctrl.Result, error) {
+func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName, reportType client.Object, _ ...string) (ctrl.Result, error) {
 	log := r.Logger.WithValues("report", namespacedName)
 
 	err := r.Client.Get(ctx, namespacedName, reportType)

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -399,7 +399,7 @@ func (c Config) GenerateIgnoreFileVolumeIfAvailable(trivyConfigName string) (*co
 	return &volume, &volumeMount
 }
 
-func (c Config) GenerateSslCertDirVolumeIfAvailable(trivyConfigName string) (*corev1.Volume, *corev1.VolumeMount) {
+func (c Config) GenerateSslCertDirVolumeIfAvailable() (*corev1.Volume, *corev1.VolumeMount) {
 	var sslCertDirHost string
 	if sslCertDirHost = c.GetSslCertDir(); sslCertDirHost == "" {
 		return nil, nil

--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -100,7 +100,7 @@ func GetPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, config Confi
 			},
 		},
 	}
-	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}
@@ -375,7 +375,7 @@ func GetPodSpecForClientServerFSMode(ctx trivyoperator.PluginContext, config Con
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}
-	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -116,7 +116,7 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 		},
 	}
 
-	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}
@@ -407,7 +407,7 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}
 
-	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
 	}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6105,7 +6105,7 @@ default ignore = false`,
 			jobSpec, secrets, err := instance.GetScanJobSpec(pluginContext, tc.workloadSpec, tc.credentials, securityContext, make(map[string]v1alpha1.SbomReportData))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedJobSpec, jobSpec)
-			assert.Equal(t, len(tc.expectedSecretsData), len(secrets))
+			assert.Len(t, len(tc.expectedSecretsData), len(secrets))
 			for i := 0; i < len(secrets); i++ {
 				assert.Equal(t, tc.expectedSecretsData[i], secrets[i].Data)
 			}
@@ -6517,7 +6517,7 @@ default ignore = false`,
 			jobSpec, secrets, err := instance.GetScanJobSpec(pluginContext, tc.workloadSpec, tc.credentials, securityContext, make(map[string]v1alpha1.SbomReportData))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedJobSpec, jobSpec)
-			assert.Equal(t, len(tc.expectedSecretsData), len(secrets))
+			assert.Len(t, len(tc.expectedSecretsData), len(secrets))
 			for i := 0; i < len(secrets); i++ {
 				assert.Equal(t, tc.expectedSecretsData[i], secrets[i].Data)
 			}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6105,7 +6105,7 @@ default ignore = false`,
 			jobSpec, secrets, err := instance.GetScanJobSpec(pluginContext, tc.workloadSpec, tc.credentials, securityContext, make(map[string]v1alpha1.SbomReportData))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedJobSpec, jobSpec)
-			assert.Len(t, len(tc.expectedSecretsData), len(secrets))
+			assert.Len(t, secrets, len(tc.expectedSecretsData))
 			for i := 0; i < len(secrets); i++ {
 				assert.Equal(t, tc.expectedSecretsData[i], secrets[i].Data)
 			}
@@ -6517,7 +6517,7 @@ default ignore = false`,
 			jobSpec, secrets, err := instance.GetScanJobSpec(pluginContext, tc.workloadSpec, tc.credentials, securityContext, make(map[string]v1alpha1.SbomReportData))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedJobSpec, jobSpec)
-			assert.Len(t, len(tc.expectedSecretsData), len(secrets))
+			assert.Len(t, secrets, len(tc.expectedSecretsData))
 			for i := 0; i < len(secrets); i++ {
 				assert.Equal(t, tc.expectedSecretsData[i], secrets[i].Data)
 			}

--- a/pkg/policy/loader.go
+++ b/pkg/policy/loader.go
@@ -123,7 +123,7 @@ func (pl *policyLoader) getBuiltInPolicies(ctx context.Context) ([]string, error
 func LoadPoliciesData(policyPath []string) ([]string, error) {
 	var policiesList []string
 	var fileList []string
-	err := filepath.Walk(policyPath[0], func(path string, f os.FileInfo, err error) error {
+	err := filepath.Walk(policyPath[0], func(path string, _ os.FileInfo, _ error) error {
 		if strings.Contains(path, "policies/kubernetes/") { // load only k8s policies
 			fileList = append(fileList, path)
 		}

--- a/pkg/vulnerabilityreport/controller/trivyserver_test.go
+++ b/pkg/vulnerabilityreport/controller/trivyserver_test.go
@@ -76,6 +76,6 @@ type dummyHttpServer struct {
 	err error
 }
 
-func (dhs dummyHttpServer) ServerHealthy(serverURL string) error {
+func (dhs dummyHttpServer) ServerHealthy(_ string) error {
 	return dhs.err
 }

--- a/pkg/webhook/webhookreporter_test.go
+++ b/pkg/webhook/webhookreporter_test.go
@@ -81,7 +81,7 @@ func Test_sendReports(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				b, _ := io.ReadAll(r.Body)
 				assert.JSONEq(t, tc.want, string(b))
 			}))


### PR DESCRIPTION
## Description

This PR bumps up GolangCi linter confing to version 2, fixes the linter errors and adds settiings for `revive` linter in favor of Trivy https://github.com/aquasecurity/trivy/pull/8796
 
## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
