### PR TITLE
fix(policy): show passed checks

### DIFF
--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -119,7 +119,7 @@ func evaluate(ctx context.Context, policies *policy.Policies, resource client.Ob
 		return Misconfiguration{}, err
 	}
 
-	return filter(results, resource, bi, cd, c, policies.GetDefaultPolicies()), nil
+	return filter(results, resource, bi, cd, c, policies.GetDefaultSeverity()), nil
 }
 
 func scanner(bi trivyoperator.BuildInfo) v1alpha1.Scanner {

--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -78,7 +78,7 @@ func evaluate(ctx context.Context, policies *policy.Policies, resource client.Ob
 			continue
 		}
 		currentCheck := getCheck(result, id)
-		if len(currentCheck.Messages) == 0 || (len(currentCheck.Messages) == 1 && strings.TrimSpace(currentCheck.Messages[0]) == "") {
+		if currentCheck == nil {
 			continue
 		}
 		if infraCheck(id) {
@@ -86,11 +86,11 @@ func evaluate(ctx context.Context, policies *policy.Policies, resource client.Ob
 				continue
 			}
 			if k8sCoreComponent(resource) {
-				infraChecks = append(infraChecks, currentCheck)
+				infraChecks = append(infraChecks, *currentCheck)
 			}
 			continue
 		}
-		checks = append(checks, currentCheck)
+		checks = append(checks, *currentCheck)
 	}
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
 	if kube.IsRoleTypes(kube.Kind(kind)) && !c.MergeRbacFindingWithConfigAudit {

--- a/pkg/configauditreport/controller/helper.go
+++ b/pkg/configauditreport/controller/helper.go
@@ -55,6 +55,7 @@ func ConfigurePolicies(ctx context.Context, config etc.Config, c client.Client, 
 	}
 	return policies, nil
 }
+
 func filter(results scan.Results, resource client.Object, bi trivyoperator.BuildInfo, cd trivyoperator.ConfigData, c etc.Config, defaultSeverity string) Misconfiguration {
 	misconfiguration := Misconfiguration{}
 	infraChecks := make([]v1alpha1.Check, 0)

--- a/pkg/configauditreport/controller/helper_test.go
+++ b/pkg/configauditreport/controller/helper_test.go
@@ -1,0 +1,131 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/aquasecurity/trivy/pkg/iac/scan"
+	"github.com/aquasecurity/trivy/pkg/iac/types"
+)
+
+const messageKSV048 = "ClusterRole 'system:controller:replicaset-controller' should not have access to resources ['pods', 'deployments', 'jobs', 'cronjobs', 'statefulsets', 'daemonsets', 'replicasets'ß, 'replicationcontrollers'] for verbs ['create', 'update', 'patch', 'delete', 'deletecollection', 'impersonate', '*']"
+
+func newTestResource(kind string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetKind(kind)
+	obj.SetAPIVersion("v1")
+	return obj
+}
+
+type demoResult struct {
+	md types.Metadata
+}
+
+func (r demoResult) GetMetadata() types.Metadata {
+	return r.md
+}
+func (_ demoResult) GetRawValue() any {
+	return nil
+}
+
+func newDemoResult(filename string, start, end int) demoResult {
+	return demoResult{
+		md: types.NewMetadata(types.NewRange(filename, start, end, "", nil), ""),
+	}
+}
+
+func newResults() scan.Results {
+	results := scan.Results{}
+	results.AddPassedRego("builtin.kubernetes.KCV0001", "deny", nil, newDemoResult("inputs/file_0.yaml", 0, 0))
+	results.AddRego(messageKSV048, "builtin.kubernetes.KSV048", "deny", nil, newDemoResult("inputs/file_0.yaml", 0, 0))
+	return results
+}
+
+func TestFilter(t *testing.T) {
+	results := newResults()
+
+	tests := []struct {
+		name                     string
+		resource                 client.Object
+		bi                       trivyoperator.BuildInfo
+		configData               trivyoperator.ConfigData
+		config                   etc.Config
+		defaultSeverity          string
+		expectedMisconfiguration Misconfiguration
+	}{
+		{
+			name:            "good case",
+			resource:        newTestResource("Pod"),
+			bi:              trivyoperator.BuildInfo{},
+			configData:      trivyoperator.ConfigData{},
+			config:          etc.Config{},
+			defaultSeverity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+			expectedMisconfiguration: Misconfiguration{
+				configAuditReportData: v1alpha1.ConfigAuditReportData{
+					Scanner: v1alpha1.Scanner{
+						Name:   "Trivy",
+						Vendor: "Aqua Security",
+					},
+					Checks: []v1alpha1.Check{
+						{
+							Category: "Kubernetes Security Check",
+							Success:  true,
+						},
+						{
+							Category: "Kubernetes Security Check",
+							Success:  false,
+							Messages: []string{
+								messageKSV048,
+							},
+						},
+					},
+				},
+				rbacAssessmentReportData:  v1alpha1.RbacAssessmentReportData{},
+				infraAssessmentReportData: v1alpha1.InfraAssessmentReportData{},
+			},
+		},
+		{
+			name:     "failed checks only",
+			resource: newTestResource("Pod"),
+			bi:       trivyoperator.BuildInfo{},
+			configData: trivyoperator.ConfigData{
+				trivyoperator.KeyReportRecordFailedChecksOnly: "true",
+			},
+			config:          etc.Config{},
+			defaultSeverity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+			expectedMisconfiguration: Misconfiguration{
+				configAuditReportData: v1alpha1.ConfigAuditReportData{
+					Scanner: v1alpha1.Scanner{
+						Name:   "Trivy",
+						Vendor: "Aqua Security",
+					},
+					Checks: []v1alpha1.Check{
+						{
+							Category: "Kubernetes Security Check",
+							Success:  false,
+							Messages: []string{
+								messageKSV048,
+							},
+						},
+					},
+				},
+				rbacAssessmentReportData:  v1alpha1.RbacAssessmentReportData{},
+				infraAssessmentReportData: v1alpha1.InfraAssessmentReportData{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			misconfiguration := filter(results, test.resource, test.bi, test.configData, test.config, test.defaultSeverity)
+			misconfiguration.configAuditReportData.UpdateTimestamp = test.expectedMisconfiguration.configAuditReportData.UpdateTimestamp
+			assert.Equal(t, test.expectedMisconfiguration, misconfiguration)
+		})
+	}
+}

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -356,16 +356,22 @@ func k8sCoreComponent(resource client.Object) bool {
 				strings.Contains(resource.GetName(), "etcd")))
 }
 
-func getCheck(result scan.Result, id string) v1alpha1.Check {
-	return v1alpha1.Check{
+func getCheck(result scan.Result, id string) *v1alpha1.Check {
+	if result.Status() != scan.StatusPassed && result.Description() == "" {
+		return nil
+	}
+	var messages []string
+	if result.Description() != "" {
+		messages = []string{result.Description()}
+	}
+	return &v1alpha1.Check{
 		ID:          id,
 		Title:       result.Rule().Summary,
 		Description: result.Rule().Explanation,
 		Severity:    v1alpha1.Severity(result.Rule().Severity),
 		Category:    "Kubernetes Security Check",
-
 		Success:     result.Status() == scan.StatusPassed,
-		Messages:    []string{result.Description()},
+		Messages:    messages,
 		Remediation: result.Rule().Resolution,
 	}
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -343,10 +343,6 @@ func resourceBytes(resource client.Object, inputs [][]byte) ([]byte, error) {
 	return inputResource, nil
 }
 
-func (p *Policies) GetDefaultPolicies() string {
-	return p.cac.GetSeverity()
-}
-
 // GetResultID return the result id found in aliases (legacy) otherwise use AvdID
 func GetResultID(result scan.Result) string {
 	id := result.Rule().AVDID
@@ -356,7 +352,12 @@ func GetResultID(result scan.Result) string {
 	return id
 }
 
-// HasSeverity checks if the result severity is in the default severity (ConfigAuditConfig.GetSeverity()
+// GetDefaultSeverity returns the default severity from ConfigAuditConfig
+func (p *Policies) GetDefaultSeverity() string {
+	return p.cac.GetSeverity()
+}
+
+// HasSeverity checks if the result severity is in the default severity
 func HasSeverity(resultSeverity severity.Severity, defaultSeverity string) bool {
 	if defaultSeverity == "" {
 		defaultSeverity = trivy.DefaultSeverity

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -343,8 +343,12 @@ func resourceBytes(resource client.Object, inputs [][]byte) ([]byte, error) {
 	return inputResource, nil
 }
 
+func (p *Policies) GetDefaultPolicies() string {
+	return p.cac.GetSeverity()
+}
+
 // GetResultID return the result id found in aliases (legacy) otherwise use AvdID
-func (r *Policies) GetResultID(result scan.Result) string {
+func GetResultID(result scan.Result) string {
 	id := result.Rule().AVDID
 	if len(result.Rule().Aliases) > 0 {
 		id = result.Rule().Aliases[0]
@@ -352,8 +356,8 @@ func (r *Policies) GetResultID(result scan.Result) string {
 	return id
 }
 
-func (r *Policies) HasSeverity(resultSeverity severity.Severity) bool {
-	defaultSeverity := r.cac.GetSeverity()
+// HasSeverity checks if the result severity is in the default severity (ConfigAuditConfig.GetSeverity()
+func HasSeverity(resultSeverity severity.Severity, defaultSeverity string) bool {
 	if defaultSeverity == "" {
 		defaultSeverity = trivy.DefaultSeverity
 	}


### PR DESCRIPTION
## Description

In some cases, a check result may not contain a message — more details can be found here: https://github.com/aquasecurity/trivy-operator/issues/1742 (fixed https://github.com/aquasecurity/trivy-operator/pull/1845).

Previously, messages were also missing for all successfully passed checks, and those were being skipped as well.

This PR changes that behavior to ensure successful checks are no longer skipped even if they lack a message.

## Related issues
- Close #2527

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
