### PR TITLE
fix: skip ConfigMap caching

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -73,6 +73,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 				DisableFor: []client.Object{
 					&corev1.Secret{},
 					&corev1.ServiceAccount{},
+					&corev1.ConfigMap{},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

This PR adds `ConfigMap` in a list of objects that at should never be read from the client's cache.

## Related issues
- Close #2541 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
