### PR TITLE
chore: replace deprecated '--slow' with '--parallel'

### DIFF
--- a/pkg/plugins/trivy/filesystem_test.go
+++ b/pkg/plugins/trivy/filesystem_test.go
@@ -28,7 +28,7 @@ func TestGetSbomFSScanningArgs(t *testing.T) {
 			sbomFile:       "/tmp/scan/bom.json",
 			serverUrl:      "",
 			resultFileName: "",
-			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "sbom", "--format", "json", "--skip-db-update", "/tmp/scan/bom.json", "--slow"},
+			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "sbom", "--format", "json", "--skip-db-update", "/tmp/scan/bom.json", "--parallel 1"},
 			wantCmd:        []string{trivy.SharedVolumeLocationOfTrivy},
 		},
 		{
@@ -37,7 +37,7 @@ func TestGetSbomFSScanningArgs(t *testing.T) {
 			sbomFile:       "/tmp/scan/bom.json",
 			serverUrl:      "http://trivy-server:8080",
 			resultFileName: "",
-			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "sbom", "--format", "json", "--skip-db-update", "/tmp/scan/bom.json", "--server", "http://trivy-server:8080", "--slow"},
+			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "sbom", "--format", "json", "--skip-db-update", "/tmp/scan/bom.json", "--server", "http://trivy-server:8080", "--parallel 1"},
 			wantCmd:        []string{trivy.SharedVolumeLocationOfTrivy},
 		},
 	}
@@ -86,7 +86,7 @@ func TestGetFSScanningArgs(t *testing.T) {
 			name:     "command and args for standalone mode",
 			mode:     trivy.Standalone,
 			command:  trivy.Filesystem,
-			wantArgs: []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--slow", "--include-dev-deps"},
+			wantArgs: []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--parallel 1", "--include-dev-deps"},
 		},
 		{
 			name:           "command and args for client/server mode",
@@ -94,7 +94,7 @@ func TestGetFSScanningArgs(t *testing.T) {
 			command:        trivy.Rootfs,
 			serverUrl:      "http://trivy-server:8080",
 			resultFileName: "",
-			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--server", "http://trivy-server:8080", "--slow", "--include-dev-deps"},
+			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--server", "http://trivy-server:8080", "--parallel 1", "--include-dev-deps"},
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -29,7 +29,7 @@ func Slow(c Config) string {
 		return ""
 	}
 	if c.GetSlow() {
-		return "--slow"
+		return "--parallel 1"
 	}
 	return ""
 }

--- a/pkg/plugins/trivy/flags_test.go
+++ b/pkg/plugins/trivy/flags_test.go
@@ -21,7 +21,7 @@ func TestSlow(t *testing.T) {
 			"trivy.tag":  "0.35.0",
 			"trivy.slow": "true",
 		},
-		want: "--slow",
+		want: "--parallel 1",
 	},
 		{
 			name: "slow param set to false",
@@ -37,7 +37,7 @@ func TestSlow(t *testing.T) {
 				"trivy.tag":  "0.35.0",
 				"trivy.slow": "false2",
 			},
-			want: "--slow",
+			want: "--parallel 1",
 		},
 		{
 			name: "slow param set to true and trivy tag is less then 0.35.0",
@@ -54,7 +54,7 @@ func TestSlow(t *testing.T) {
 				"trivy.slow": "true",
 				"trivy.tag":  "0.36.0",
 			},
-			want: "--slow",
+			want: "--parallel 1",
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/plugins/trivy/image_test.go
+++ b/pkg/plugins/trivy/image_test.go
@@ -79,7 +79,7 @@ func TestGetSbomScanCommandAndArgs(t *testing.T) {
 			serverUrl:      "",
 			resultFileName: "output.json",
 			compressedLogs: "true",
-			wantArgs:       []string{"-c", "trivy sbom --slow /tmp/scan/bom.json  --skip-db-update  --cache-dir /tmp/trivy/.cache --quiet --format json > /tmp/scan/output.json &&  bzip2 -c /tmp/scan/output.json | base64 && sync"},
+			wantArgs:       []string{"-c", "trivy sbom --parallel 1 /tmp/scan/bom.json  --skip-db-update  --cache-dir /tmp/trivy/.cache --quiet --format json > /tmp/scan/output.json &&  bzip2 -c /tmp/scan/output.json | base64 && sync"},
 			wantCmd:        []string{"/bin/sh"},
 		},
 		{
@@ -89,7 +89,7 @@ func TestGetSbomScanCommandAndArgs(t *testing.T) {
 			serverUrl:      "",
 			resultFileName: "",
 			compressedLogs: "false",
-			wantArgs:       []string{"--cache-dir", "/tmp/trivy/.cache", "--quiet", "sbom", "--format", "json", "/tmp/scan/bom.json", "--slow", "--skip-db-update"},
+			wantArgs:       []string{"--cache-dir", "/tmp/trivy/.cache", "--quiet", "sbom", "--format", "json", "/tmp/scan/bom.json", "--parallel 1", "--skip-db-update"},
 			wantCmd:        []string{"trivy"},
 		},
 		{
@@ -99,7 +99,7 @@ func TestGetSbomScanCommandAndArgs(t *testing.T) {
 			serverUrl:      "http://trivy-server:8080",
 			resultFileName: "output.json",
 			compressedLogs: "true",
-			wantArgs:       []string{"-c", "trivy sbom --slow /tmp/scan/bom.json    --cache-dir /tmp/trivy/.cache --quiet --format json --server 'http://trivy-server:8080' > /tmp/scan/output.json &&  bzip2 -c /tmp/scan/output.json | base64 && sync"},
+			wantArgs:       []string{"-c", "trivy sbom --parallel 1 /tmp/scan/bom.json    --cache-dir /tmp/trivy/.cache --quiet --format json --server 'http://trivy-server:8080' > /tmp/scan/output.json &&  bzip2 -c /tmp/scan/output.json | base64 && sync"},
 			wantCmd:        []string{"/bin/sh"},
 		},
 		{
@@ -109,7 +109,7 @@ func TestGetSbomScanCommandAndArgs(t *testing.T) {
 			serverUrl:      "http://trivy-server:8080",
 			resultFileName: "",
 			compressedLogs: "false",
-			wantArgs:       []string{"--cache-dir", "/tmp/trivy/.cache", "--quiet", "sbom", "--format", "json", "--server", "http://trivy-server:8080", "/tmp/scan/bom.json", "--slow"},
+			wantArgs:       []string{"--cache-dir", "/tmp/trivy/.cache", "--quiet", "sbom", "--format", "json", "--server", "http://trivy-server:8080", "/tmp/scan/bom.json", "--parallel 1"},
 			wantCmd:        []string{"trivy"},
 		},
 	}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -342,7 +342,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -630,7 +630,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 						},
 						Args: []string{
 							"-c",
-							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -918,7 +918,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 						},
 						Args: []string{
 							"-c",
-							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --quiet --security-checks vuln --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --quiet --security-checks vuln --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1226,7 +1226,7 @@ CVE-2019-1543`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1539,7 +1539,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1831,7 +1831,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image mirror.io/library/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image mirror.io/library/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -2119,7 +2119,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -2351,7 +2351,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -2580,7 +2580,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -2814,7 +2814,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server https://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server https://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -3048,7 +3048,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --quiet --security-checks vuln --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image poc.myregistry.harbor.com.pl/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --quiet --security-checks vuln --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -3302,7 +3302,7 @@ CVE-2019-1543`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -3562,7 +3562,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks secret --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -3797,7 +3797,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --server http://trivy.trivy:4954 --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -4144,7 +4144,7 @@ default ignore = false`,
 							"--format",
 							"json",
 							"/",
-							"--slow",
+							"--parallel 1",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -4447,7 +4447,7 @@ default ignore = false`,
 							"/",
 							"--server",
 							"http://trivy.trivy:4954",
-							"--slow",
+							"--parallel 1",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -4808,7 +4808,7 @@ default ignore = false`,
 							"--format",
 							"json",
 							"/",
-							"--slow",
+							"--parallel 1",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -5111,7 +5111,7 @@ default ignore = false`,
 							"/",
 							"--server",
 							"http://trivy.trivy:4954",
-							"--slow",
+							"--parallel 1",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -5413,7 +5413,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image 000000000000.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image 000000000000.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -5728,7 +5728,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -6045,7 +6045,7 @@ default ignore = false`,
 						},
 						Args: []string{
 							"-c",
-							"trivy image mirror.io/library/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
+							"trivy image mirror.io/library/nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -6445,7 +6445,7 @@ default ignore = false`,
 						"--format",
 						"json",
 						"/",
-						"--slow",
+						"--parallel 1",
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/tests/envtest/testdata/fixture/cronjob-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/cronjob-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image busybox:1.28 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_hello.json && bzip2 -c /tmp/scan/result_hello.json | base64 && sync
+            - trivy image busybox:1.28 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_hello.json && bzip2 -c /tmp/scan/result_hello.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/daemonset-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/daemonset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image quay.io/fluentd_elasticsearch/fluentd:v2.5.2 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_fluentd-elasticsearch.json && bzip2 -c /tmp/scan/result_fluentd-elasticsearch.json | base64 && sync
+            - trivy image quay.io/fluentd_elasticsearch/fluentd:v2.5.2 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_fluentd-elasticsearch.json && bzip2 -c /tmp/scan/result_fluentd-elasticsearch.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/job-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/job-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image perl:5.34 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_pi.json && bzip2 -c /tmp/scan/result_pi.json | base64 && sync
+            - trivy image perl:5.34 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_pi.json && bzip2 -c /tmp/scan/result_pi.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/pod-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/pod-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image app-image:app-image-tag --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_app.json && bzip2 -c /tmp/scan/result_app.json | base64 && sync
+            - trivy image app-image:app-image-tag --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_app.json && bzip2 -c /tmp/scan/result_app.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/replicaset-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/replicaset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image wordpress:4.9 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_wordpress.json && bzip2 -c /tmp/scan/result_wordpress.json | base64 && sync
+            - trivy image wordpress:4.9 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_wordpress.json && bzip2 -c /tmp/scan/result_wordpress.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/replicationcontroller-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/replicationcontroller-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image nginx --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync
+            - trivy image nginx --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync
           command:
             - /bin/sh
           env:

--- a/tests/envtest/testdata/fixture/statefulset-expected-scan.yaml
+++ b/tests/envtest/testdata/fixture/statefulset-expected-scan.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - args:
             - -c
-            - trivy image k8s.gcr.io/nginx-slim:0.8 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --slow > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync
+            - trivy image k8s.gcr.io/nginx-slim:0.8 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --quiet --security-checks vuln,secret --skip-update --parallel 1 > /tmp/scan/result_nginx.json && bzip2 -c /tmp/scan/result_nginx.json | base64 && sync
           command:
             - /bin/sh
           env:


### PR DESCRIPTION
Relates to https://github.com/aquasecurity/trivy/pull/5572 where --slow was deprecated in the `trivy` project.

With current implementation, each scan job logs the following warning:

```
WARN    "--slow" is deprecated. Use "--parallel 1" instead.
```

This pull request modifies `trivy-operator` to use the `--parallel 1` instead of the deprecated `--slow` flag, while keeping the `trivy-operator`'s own API backward compatible (ie. call it `slow` but under the hood convert it to `parallel`)