### PR TITLE
chore(deps): bump golangci-lint to v2.1.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,21 +40,21 @@ linters:
     gocritic:
       disabled-checks:
         - appendAssign
-        - unnamedResult
-        - whyNoLint
+        - commentedOutCode
+        - hugeParam
         - indexAlloc
         - octalLiteral
-        - hugeParam
         - rangeValCopy
         - regexpSimplify
         - sloppyReassign
-        - commentedOutCode
+        - unnamedResult
+        - whyNoLint
       enabled-tags:
         - diagnostic
-        - style
-        - performance
         - experimental
         - opinionated
+        - performance
+        - style
       settings:
         ruleguard:
           failOn: all
@@ -96,40 +96,13 @@ linters:
     testifylint:
       enable-all: true
   exclusions:
-    generated: lax
     rules:
       - linters:
           - goconst
-          - gosec
-          - unused
         path: .*_test.go$
-      - linters:
-          - govet
-        path: .*_test.go$
-        text: 'copylocks:'
-      - linters:
-          - gocritic
-        path: .*_test.go$
-        text: 'commentFormatting:'
-      - linters:
-          - gocritic
-        path: .*_test.go$
-        text: 'exitAfterDefer:'
-      - linters:
-          - gocritic
-        path: .*_test.go$
-        text: 'importShadow:'
-      - linters:
-          - perfsprint
-        text: fmt.Sprint
-    paths:
-      - mock_*.go$
-      - examples/*
-      - pkg/iac/scanners/terraform/parser/funcs
-      - third_party$
-      - builtin$
-      - examples$
+    warn-unused: true
 issues:
+  max-issues-per-linter: 0
   max-same-issues: 0
 formatters:
   enable:
@@ -148,12 +121,3 @@ formatters:
       rewrite-rules:
         - pattern: interface{}
           replacement: any
-  exclusions:
-    generated: lax
-    paths:
-      - mock_*.go$
-      - examples/*
-      - pkg/iac/scanners/terraform/parser/funcs
-      - third_party$
-      - builtin$
-      - examples$

--- a/magefile.go
+++ b/magefile.go
@@ -360,12 +360,12 @@ func (Lint) Fix() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v2.1.2"
+	const version = "v2.1.6"
 	bin := filepath.Join(GOBIN, "golangci-lint")
 	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil
 	}
-	command := fmt.Sprintf("curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b %s %s", GOBIN, version)
+	command := fmt.Sprintf("curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b %s %s", GOBIN, version)
 	return sh.Run("bash", "-c", command)
 }
 

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	ocpappsv1 "github.com/openshift/api/apps/v1"
@@ -672,7 +673,7 @@ func (o *ObjectResolver) IsActiveReplicationController(ctx context.Context, work
 			return false, err
 		}
 		replicasetRevisionAnnotation := workloadObj.GetAnnotations()
-		latestRevision := fmt.Sprintf("%d", deploymentConfigObj.Status.LatestVersion)
+		latestRevision := strconv.FormatInt(deploymentConfigObj.Status.LatestVersion, 10)
 		return replicasetRevisionAnnotation[deploymentConfigAnnotation] == latestRevision, nil
 	}
 	return true, nil


### PR DESCRIPTION
## Description

Update golangci-lint to 2.1.6 and clean up config

## Related issues
- #2540
- #2558


## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
