### PR TITLE
fix: enable contextcheck and usetesting linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - contextcheck
     - depguard
     - goconst
     - gocritic
@@ -15,10 +16,12 @@ linters:
     - ineffassign
     - misspell
     - perfsprint
+    - revive
     - testifylint
     - unconvert
     - unused
     - usestdlibvars
+    - usetesting
   settings:
     depguard:
       rules:
@@ -93,6 +96,16 @@ linters:
       errorf: true
       sprintf1: false
       strconcat: false
+    revive:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
+      rules:
+        - name: context-as-argument
+          arguments:
+            - allow-types-before: "*testing.T"
+        - name: context-keys-type
+        - name: unused-parameter
+          arguments:
+            - allow-regex: "^_"
     testifylint:
       enable-all: true
   exclusions:

--- a/pkg/compliance/io.go
+++ b/pkg/compliance/io.go
@@ -32,7 +32,7 @@ type cm struct {
 
 // GenerateComplianceReport generate and public compliance report by spec
 func (w *cm) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportSpec) error {
-	trivyResults, err := misconfigReportToTrivyResults(w.client, ctx)
+	trivyResults, err := misconfigReportToTrivyResults(ctx, w.client)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (w *cm) buildComplianceReport(spec v1alpha1.ReportSpec, complianceResults [
 }
 
 // MisconfigReportToTrivyResults convert misconfig and infra assessment report Data to trivy results
-func misconfigReportToTrivyResults(cli client.Client, ctx context.Context) ([]ttypes.Results, error) {
+func misconfigReportToTrivyResults(ctx context.Context, cli client.Client) ([]ttypes.Results, error) {
 	resultsArray := make([]ttypes.Results, 0)
 	// collect configaudit report data
 	caObjList := &v1alpha1.ConfigAuditReportList{}

--- a/pkg/compliance/io_test.go
+++ b/pkg/compliance/io_test.go
@@ -264,9 +264,9 @@ func TestGenerateComplianceReport(t *testing.T) {
 				WithStatusSubresource(tt.clusterComplianceReport).
 				Build()
 			mgr := NewMgr(c)
-			err := mgr.GenerateComplianceReport(context.Background(), tt.clusterComplianceReport.Spec)
+			err := mgr.GenerateComplianceReport(t.Context(), tt.clusterComplianceReport.Spec)
 			require.NoError(t, err)
-			ccr, err := getReport(context.Background(), c)
+			ccr, err := getReport(t.Context(), c)
 			require.NoError(t, err)
 			if tt.reportType == "summary" {
 				assert.True(t, reflect.DeepEqual(ccr.Status.SummaryReport, tt.wantStatus.SummaryReport))

--- a/pkg/configauditreport/io_test.go
+++ b/pkg/configauditreport/io_test.go
@@ -1,7 +1,6 @@
 package configauditreport_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +25,7 @@ func TestReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.ConfigAuditReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.ConfigAuditReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ConfigAuditReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -50,7 +49,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ConfigAuditReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "deployment-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "deployment-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ConfigAuditReport{
@@ -103,7 +102,7 @@ func TestReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.ConfigAuditReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.ConfigAuditReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ConfigAuditReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -128,7 +127,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ConfigAuditReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "deployment-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "deployment-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ConfigAuditReport{
@@ -184,7 +183,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",
@@ -240,7 +239,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindRole,
 			Name:      "system:controller:token-cleaner",
 			Namespace: "kube-system",
@@ -268,7 +267,7 @@ func TestReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		err := readWriter.WriteClusterReport(context.TODO(), v1alpha1.ClusterConfigAuditReport{
+		err := readWriter.WriteClusterReport(t.Context(), v1alpha1.ClusterConfigAuditReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterConfigAuditReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -290,7 +289,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ClusterConfigAuditReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ClusterConfigAuditReport{
@@ -342,7 +341,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		err := readWriter.WriteClusterReport(context.TODO(), v1alpha1.ClusterConfigAuditReport{
+		err := readWriter.WriteClusterReport(t.Context(), v1alpha1.ClusterConfigAuditReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterConfigAuditReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -365,7 +364,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ClusterConfigAuditReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ClusterConfigAuditReport{
@@ -422,7 +421,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := configauditreport.NewReadWriter(&resolver)
-		found, err := readWriter.FindClusterReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindClusterReportByOwner(t.Context(), kube.ObjectRef{
 			Kind: "ClusterRole",
 			Name: "editor",
 		})

--- a/pkg/exposedsecretreport/io_test.go
+++ b/pkg/exposedsecretreport/io_test.go
@@ -1,7 +1,6 @@
 package exposedsecretreport_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,7 @@ func TestNewReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := exposedsecretreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.ExposedSecretReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.ExposedSecretReport{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deployment-app1-container1",
@@ -54,7 +53,7 @@ func TestNewReadWriter(t *testing.T) {
 		})
 		require.NoError(t, err)
 		var list v1alpha1.ExposedSecretReportList
-		err = testClient.List(context.TODO(), &list)
+		err = testClient.List(t.Context(), &list)
 		require.NoError(t, err)
 		reports := make(map[string]v1alpha1.ExposedSecretReport)
 		for _, item := range list.Items {
@@ -132,7 +131,7 @@ func TestNewReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := exposedsecretreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.ExposedSecretReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.ExposedSecretReport{
 			{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -167,7 +166,7 @@ func TestNewReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ExposedSecretReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container1",
 		}, &found)
@@ -191,7 +190,7 @@ func TestNewReadWriter(t *testing.T) {
 			},
 		}, found)
 
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container2",
 		}, &found)
@@ -256,7 +255,7 @@ func TestNewReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := exposedsecretreport.NewReadWriter(&resolver)
-		list, err := readWriter.FindByOwner(context.TODO(), kube.ObjectRef{
+		list, err := readWriter.FindByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",

--- a/pkg/infraassessment/io_test.go
+++ b/pkg/infraassessment/io_test.go
@@ -1,7 +1,6 @@
 package infraassessment_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,7 @@ func TestReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := infraassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.InfraAssessmentReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.InfraAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "InfraAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -48,7 +47,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.InfraAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.InfraAssessmentReport{
@@ -101,7 +100,7 @@ func TestReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := infraassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.InfraAssessmentReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.InfraAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "InfraAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -126,7 +125,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.InfraAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.InfraAssessmentReport{
@@ -182,7 +181,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := infraassessment.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "role-my-deploy",
 			Namespace: "my-namespace",
@@ -238,7 +237,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := infraassessment.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindRole,
 			Name:      "system:controller:token-cleaner",
 			Namespace: "kube-system",

--- a/pkg/kube/object_test.go
+++ b/pkg/kube/object_test.go
@@ -1,7 +1,6 @@
 package kube_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -653,7 +652,7 @@ func TestObjectResolver_RelatedReplicaSetName(t *testing.T) {
 	instance := kube.NewObjectResolver(kubClient, &kube.CompatibleObjectMapper{})
 
 	t.Run("Should return error for unsupported kind", func(t *testing.T) {
-		_, err := instance.RelatedReplicaSetName(context.Background(), kube.ObjectRef{
+		_, err := instance.RelatedReplicaSetName(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindStatefulSet,
 			Name:      "statefulapp",
 			Namespace: corev1.NamespaceDefault,
@@ -662,7 +661,7 @@ func TestObjectResolver_RelatedReplicaSetName(t *testing.T) {
 	})
 
 	t.Run("Should return ReplicaSet name for the specified Deployment", func(t *testing.T) {
-		name, err := instance.RelatedReplicaSetName(context.Background(), kube.ObjectRef{
+		name, err := instance.RelatedReplicaSetName(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "nginx",
 			Namespace: corev1.NamespaceDefault,
@@ -672,7 +671,7 @@ func TestObjectResolver_RelatedReplicaSetName(t *testing.T) {
 	})
 
 	t.Run("Should return ReplicaSet name for the specified Deployment", func(t *testing.T) {
-		name, err := instance.RelatedReplicaSetName(context.Background(), kube.ObjectRef{
+		name, err := instance.RelatedReplicaSetName(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindPod,
 			Name:      "nginx-549f5fcb58-7cr5b",
 			Namespace: corev1.NamespaceDefault,
@@ -877,14 +876,14 @@ func TestGetActivePodsMatchingLabels(t *testing.T) {
 	).Build()
 
 	t.Run("found active pods", func(t *testing.T) {
-		ctx := context.TODO()
+		ctx := t.Context()
 		or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		pods, err := or.GetActivePodsMatchingLabels(ctx, nginxReplicaSet.Namespace, nginxReplicaSet.GetLabels())
 		require.NoError(t, err)
 		assert.Len(t, pods, 1)
 	})
 	t.Run("active pods not found", func(t *testing.T) {
-		ctx := context.TODO()
+		ctx := t.Context()
 		or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		pods, err := or.GetActivePodsMatchingLabels(ctx, nginxReplicaSet.Namespace, map[string]string{
 			"app":               "nginx",
@@ -1125,7 +1124,7 @@ func TestObjectResolver_ReportOwner(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
-			owner, err := or.ReportOwner(context.TODO(), tc.resource)
+			owner, err := or.ReportOwner(t.Context(), tc.resource)
 			require.NoError(t, err)
 			assert.Equal(t, tc.owner, owner)
 		})
@@ -1306,7 +1305,7 @@ func TestObjectResolver_IsActiveReplicaSet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 			controller := metav1.GetControllerOf(tc.resource)
-			isActive, err := or.IsActiveReplicaSet(context.TODO(), tc.resource, controller)
+			isActive, err := or.IsActiveReplicaSet(t.Context(), tc.resource, controller)
 			require.NoError(t, err)
 			assert.Equal(t, isActive, tc.result)
 		})
@@ -1341,11 +1340,13 @@ func TestObjectResolver_IsActiveReplicationController(t *testing.T) {
 					Labels: map[string]string{"deploymentconfig": "busybox"},
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{corev1.Container{
-						Name:    "busybox",
-						Image:   "busybox",
-						Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
-					}},
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
+						},
+					},
 				},
 			},
 		},
@@ -1402,11 +1403,13 @@ func TestObjectResolver_IsActiveReplicationController(t *testing.T) {
 					Labels: map[string]string{"deploymentconfig": "busybox"},
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{corev1.Container{
-						Name:    "busybox",
-						Image:   "busybox",
-						Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
-					}},
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
+						},
+					},
 				},
 			},
 		},
@@ -1455,11 +1458,13 @@ func TestObjectResolver_IsActiveReplicationController(t *testing.T) {
 					Labels: map[string]string{"deploymentconfig": "busybox"},
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{corev1.Container{
-						Name:    "busybox",
-						Image:   "busybox",
-						Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
-					}},
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
+						},
+					},
 				},
 			},
 		},
@@ -1490,11 +1495,13 @@ func TestObjectResolver_IsActiveReplicationController(t *testing.T) {
 					Labels: map[string]string{"deploymentconfig": "busybox"},
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{corev1.Container{
-						Name:    "busybox",
-						Image:   "busybox",
-						Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
-					}},
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"/bin/sh", "-c", "while true ; do date; sleep 1; done;"},
+						},
+					},
 				},
 			},
 		},
@@ -1530,7 +1537,7 @@ func TestObjectResolver_IsActiveReplicationController(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			or := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 			controller := metav1.GetControllerOf(tc.resource)
-			isActive, err := or.IsActiveReplicationController(context.TODO(), tc.resource, controller)
+			isActive, err := or.IsActiveReplicationController(t.Context(), tc.resource, controller)
 			require.NoError(t, err)
 			assert.Equal(t, isActive, tc.result)
 		})

--- a/pkg/kube/secrets_test.go
+++ b/pkg/kube/secrets_test.go
@@ -1,7 +1,6 @@
 package kube_test
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -125,7 +124,7 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&saSecret).WithObjects(&secret).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Len(t, foundsecret, 2)
 		auths, err := kube.MapDockerRegistryServersToAuths(foundsecret, false)
@@ -158,7 +157,7 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&saSecret).WithObjects(&secret).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Len(t, foundsecret, 2)
 		auths, err := kube.MapDockerRegistryServersToAuths(foundsecret, true)
@@ -272,7 +271,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).Build()
 		spec := corev1.PodSpec{}
 		sr := kube.NewSecretsReader(client)
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Empty(t, foundsecret)
 	})
@@ -287,7 +286,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&secret).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Len(t, foundsecret, 1)
 	})
@@ -302,7 +301,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&secret).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Len(t, foundsecret, 1)
 	})
@@ -320,7 +319,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&saSecret).WithObjects(&secret).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Len(t, foundsecret, 2)
 	})
@@ -329,7 +328,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Empty(t, foundsecret)
 	})
@@ -341,7 +340,7 @@ func TestListImagePullSecretsByPodSpec(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).WithObjects(&sa).Build()
 		sr := kube.NewSecretsReader(client)
 		spec := corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}, {Name: "notexist"}}, ServiceAccountName: "default"}
-		foundsecret, err := sr.ListImagePullSecretsByPodSpec(context.Background(), spec, "default")
+		foundsecret, err := sr.ListImagePullSecretsByPodSpec(t.Context(), spec, "default")
 		require.NoError(t, err)
 		assert.Empty(t, foundsecret)
 	})
@@ -380,7 +379,7 @@ func Test_secretsReader_CredentialsByServer(t *testing.T) {
 			},
 		}
 
-		auths, err := sr.CredentialsByServer(context.Background(), &pod, map[string]string{
+		auths, err := sr.CredentialsByServer(t.Context(), &pod, map[string]string{
 			"default": "regcred",
 		}, false)
 		require.NoError(t, err)

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -277,7 +277,7 @@ func (r *ClusterController) numOfCoreComponentPodsAndNodes(ctx context.Context) 
 		"": trivyoperator.LabelCoreComponent,
 	}
 
-	if r.isOpenShift() {
+	if r.isOpenShift(ctx) {
 		coreK8slabels = map[string]string{
 			"openshift-kube-apiserver":          trivyoperator.LabelOpenShiftAPIServer,
 			"openshift-kube-controller-manager": trivyoperator.LabelOpenShiftControllerManager,
@@ -307,8 +307,7 @@ func (r *ClusterController) numOfCoreComponentPodsAndNodes(ctx context.Context) 
 	return corePodsCount + len(addonPods.Items), len(nodes.Items), nil
 }
 
-func (r *ClusterController) isOpenShift() bool {
-	ctx := context.Background()
+func (r *ClusterController) isOpenShift(ctx context.Context) bool {
 	_, err := r.clientset.CoreV1().Namespaces().Get(ctx, "openshift-kube-apiserver", metav1.GetOptions{})
 	return !k8sapierror.IsNotFound(err)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -156,7 +156,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	}
 
 	configManager := trivyoperator.NewConfigManager(clientSet, operatorNamespace)
-	err = configManager.EnsureDefault(context.Background())
+	err = configManager.EnsureDefault(ctx)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 	if err != nil {
 		return err
 	}
-	trivyOperatorConfig, err := configManager.Read(context.Background())
+	trivyOperatorConfig, err := configManager.Read(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ttl_report.go
+++ b/pkg/operator/ttl_report.go
@@ -80,7 +80,7 @@ func (r *TTLReportReconciler) reconcileReport(reportType client.Object) reconcil
 	}
 }
 
-func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName, reportType client.Object, arr ...string) (ctrl.Result, error) {
+func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName, reportType client.Object, _ ...string) (ctrl.Result, error) {
 	log := r.Logger.WithValues("report", namespacedName)
 
 	err := r.Client.Get(ctx, namespacedName, reportType)
@@ -102,7 +102,7 @@ func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespa
 	}
 	ttlExpired, durationToTTLExpiration := utils.IsTTLExpired(reportTTLTime, reportType.GetCreationTimestamp().Time, r.Clock)
 
-	if ttlExpired && r.applicableForDeletion(reportType, ttlReportAnnotationStr) {
+	if ttlExpired && r.applicableForDeletion(ctx, reportType, ttlReportAnnotationStr) {
 		log.V(1).Info("Removing report with expired TTL or Historical")
 		err := r.Client.Delete(ctx, reportType, &client.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
@@ -118,7 +118,7 @@ func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespa
 	return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
 }
 
-func (r *TTLReportReconciler) applicableForDeletion(report client.Object, ttlReportAnnotationStr string) bool {
+func (r *TTLReportReconciler) applicableForDeletion(ctx context.Context, report client.Object, ttlReportAnnotationStr string) bool {
 	reportKind := report.GetObjectKind().GroupVersionKind().Kind
 	if reportKind == "VulnerabilityReport" || reportKind == "ExposedSecretReport" || reportKind == "ClusterSbomReport" {
 		return true
@@ -141,7 +141,7 @@ func (r *TTLReportReconciler) applicableForDeletion(report client.Object, ttlRep
 	if err != nil {
 		return false
 	}
-	policies, err := control.Policies(context.Background(), r.Config, r.Client, cac, r.Logger, r.PolicyLoader)
+	policies, err := control.Policies(ctx, r.Config, r.Client, cac, r.Logger, r.PolicyLoader)
 	if err != nil {
 		return false
 	}

--- a/pkg/operator/ttl_report_test.go
+++ b/pkg/operator/ttl_report_test.go
@@ -1,7 +1,6 @@
 package operator_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -115,7 +114,7 @@ func TestRegenerateReportIfExpired(t *testing.T) {
 			nsName := types.NamespacedName{Namespace: ns, Name: vulnReport.Name}
 
 			// Check if TTL expired for the vulnerability report
-			_, err := instance.DeleteReportIfExpired(context.TODO(), nsName, &v1alpha1.VulnerabilityReport{})
+			_, err := instance.DeleteReportIfExpired(t.Context(), nsName, &v1alpha1.VulnerabilityReport{})
 			if tt.wantError {
 				require.Error(t, err)
 				return
@@ -123,7 +122,7 @@ func TestRegenerateReportIfExpired(t *testing.T) {
 			require.NoError(t, err)
 
 			vr := v1alpha1.VulnerabilityReport{}
-			err = instance.Client.Get(context.TODO(), nsName, &vr)
+			err = instance.Client.Get(t.Context(), nsName, &vr)
 
 			if tt.wantReportDeleted {
 				require.Error(t, err)

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -432,7 +432,7 @@ func (c Config) GenerateConfigFileVolumeIfAvailable(trivyConfigName string) (*co
 	return &volume, &volumeMount
 }
 
-func (c Config) GenerateSslCertDirVolumeIfAvailable(trivyConfigName string) (*corev1.Volume, *corev1.VolumeMount) {
+func (c Config) GenerateSslCertDirVolumeIfAvailable(_ string) (*corev1.Volume, *corev1.VolumeMount) {
 	var sslCertDirHost string
 	if sslCertDirHost = c.GetSslCertDir(); sslCertDirHost == "" {
 		return nil, nil

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -399,7 +399,7 @@ func (c Config) GenerateIgnoreFileVolumeIfAvailable(trivyConfigName string) (*co
 	return &volume, &volumeMount
 }
 
-func (c Config) GenerateSslCertDirVolumeIfAvailable(trivyConfigName string) (*corev1.Volume, *corev1.VolumeMount) {
+func (c Config) GenerateSslCertDirVolumeIfAvailable(_ string) (*corev1.Volume, *corev1.VolumeMount) {
 	var sslCertDirHost string
 	if sslCertDirHost = c.GetSslCertDir(); sslCertDirHost == "" {
 		return nil, nil

--- a/pkg/plugins/trivy/config_test.go
+++ b/pkg/plugins/trivy/config_test.go
@@ -1,7 +1,6 @@
 package trivy
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -705,7 +704,7 @@ func TestPlugin_Init(t *testing.T) {
 		err := p.Init(pluginContext)
 		require.NoError(t, err)
 		var cm corev1.ConfigMap
-		err = testClient.Get(context.Background(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
 			Name:      "trivy-operator-trivy-config",
 		}, &cm)
@@ -770,7 +769,7 @@ func TestPlugin_Init(t *testing.T) {
 		err := p.Init(pluginContext)
 		require.NoError(t, err)
 		var cm corev1.ConfigMap
-		err = testClient.Get(context.Background(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "trivyoperator-ns",
 			Name:      "trivy-operator-trivy-config",
 		}, &cm)

--- a/pkg/policy/loader.go
+++ b/pkg/policy/loader.go
@@ -123,7 +123,7 @@ func (pl *policyLoader) getBuiltInPolicies(ctx context.Context) ([]string, error
 func LoadPoliciesData(policyPath []string) ([]string, error) {
 	var policiesList []string
 	var fileList []string
-	err := filepath.Walk(policyPath[0], func(path string, f os.FileInfo, err error) error {
+	err := filepath.Walk(policyPath[0], func(path string, _ os.FileInfo, _ error) error {
 		if strings.Contains(path, "policies/kubernetes/") { // load only k8s policies
 			fileList = append(fileList, path)
 		}

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1,7 +1,6 @@
 package policy_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -693,7 +692,7 @@ func TestPolicies_Eval(t *testing.T) {
 			log := ctrl.Log.WithName("resourcecontroller")
 			p := policy.NewPolicies(tc.policies, newTestConfig(tc.useBuiltInPolicies), log, &TestLoader{}, "1.27.1", &cacheReportTTL)
 			g.Expect(p.Load()).ToNot(HaveOccurred())
-			checks, err := p.Eval(context.TODO(), tc.resource)
+			checks, err := p.Eval(t.Context(), tc.resource)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/pkg/rbacassessment/io_test.go
+++ b/pkg/rbacassessment/io_test.go
@@ -1,7 +1,6 @@
 package rbacassessment_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ func TestReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.RbacAssessmentReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.RbacAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "RbacAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -49,7 +48,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.RbacAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.RbacAssessmentReport{
@@ -102,7 +101,7 @@ func TestReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteReport(context.TODO(), v1alpha1.RbacAssessmentReport{
+		err := readWriter.WriteReport(t.Context(), v1alpha1.RbacAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "RbacAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -127,7 +126,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.RbacAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Namespace: "qa", Name: "role-app"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.RbacAssessmentReport{
@@ -183,7 +182,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "role-my-deploy",
 			Namespace: "my-namespace",
@@ -239,7 +238,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindReportByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindRole,
 			Name:      "system:controller:token-cleaner",
 			Namespace: "kube-system",
@@ -267,7 +266,7 @@ func TestReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteClusterReport(context.TODO(), v1alpha1.ClusterRbacAssessmentReport{
+		err := readWriter.WriteClusterReport(t.Context(), v1alpha1.ClusterRbacAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRbacAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -289,7 +288,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ClusterRbacAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ClusterRbacAssessmentReport{
@@ -342,7 +341,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		err := readWriter.WriteClusterReport(context.TODO(), v1alpha1.ClusterRbacAssessmentReport{
+		err := readWriter.WriteClusterReport(t.Context(), v1alpha1.ClusterRbacAssessmentReport{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRbacAssessmentReport",
 				APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -365,7 +364,7 @@ func TestReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.ClusterRbacAssessmentReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
+		err = testClient.Get(t.Context(), types.NamespacedName{Name: "clusterrole-admin"}, &found)
 		require.NoError(t, err)
 
 		assert.Equal(t, v1alpha1.ClusterRbacAssessmentReport{
@@ -422,7 +421,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := rbacassessment.NewReadWriter(&resolver)
-		found, err := readWriter.FindClusterReportByOwner(context.TODO(), kube.ObjectRef{
+		found, err := readWriter.FindClusterReportByOwner(t.Context(), kube.ObjectRef{
 			Kind: "ClusterRole",
 			Name: "editor",
 		})

--- a/pkg/sbomreport/io_test.go
+++ b/pkg/sbomreport/io_test.go
@@ -1,7 +1,6 @@
 package sbomreport_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,7 @@ func TestNewReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := sbomreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.SbomReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.SbomReport{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deployment-app1-container1",
@@ -54,7 +53,7 @@ func TestNewReadWriter(t *testing.T) {
 		})
 		require.NoError(t, err)
 		var list v1alpha1.SbomReportList
-		err = testClient.List(context.TODO(), &list)
+		err = testClient.List(t.Context(), &list)
 		require.NoError(t, err)
 		reports := make(map[string]v1alpha1.SbomReport)
 		for _, item := range list.Items {
@@ -132,7 +131,7 @@ func TestNewReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := sbomreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.SbomReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.SbomReport{
 			{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -171,7 +170,7 @@ func TestNewReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.SbomReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container1",
 		}, &found)
@@ -195,7 +194,7 @@ func TestNewReadWriter(t *testing.T) {
 			},
 		}, found)
 
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container2",
 		}, &found)
@@ -260,7 +259,7 @@ func TestNewReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := sbomreport.NewReadWriter(&resolver)
-		list, err := readWriter.FindByOwner(context.TODO(), kube.ObjectRef{
+		list, err := readWriter.FindByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",

--- a/pkg/trivyoperator/config_test.go
+++ b/pkg/trivyoperator/config_test.go
@@ -1,7 +1,6 @@
 package trivyoperator_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -903,7 +902,7 @@ func TestConfigManager_Read(t *testing.T) {
 	)
 
 	data, err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).
-		Read(context.TODO())
+		Read(t.Context())
 
 	require.NoError(t, err)
 	assert.Equal(t, trivyoperator.ConfigData{
@@ -920,16 +919,16 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 		namespace := "trivyoperator-ns"
 		clientset := fake.NewSimpleClientset()
 
-		err := trivyoperator.NewConfigManager(clientset, namespace).EnsureDefault(context.TODO())
+		err := trivyoperator.NewConfigManager(clientset, namespace).EnsureDefault(t.Context())
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 
 		cm, err := clientset.CoreV1().ConfigMaps(namespace).
-			Get(context.TODO(), trivyoperator.ConfigMapName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.ConfigMapName, metav1.GetOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(cm.Data).To(gomega.BeEquivalentTo(trivyoperator.GetDefaultConfig()))
 
 		secret, err := clientset.CoreV1().Secrets(namespace).
-			Get(context.TODO(), trivyoperator.SecretName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.SecretName, metav1.GetOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(secret.Data).To(gomega.BeEmpty())
 	})
@@ -968,11 +967,11 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 			},
 		)
 
-		err := trivyoperator.NewConfigManager(clientset, namespace).EnsureDefault(context.TODO())
+		err := trivyoperator.NewConfigManager(clientset, namespace).EnsureDefault(t.Context())
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 
 		cm, err := clientset.CoreV1().ConfigMaps(namespace).
-			Get(context.TODO(), trivyoperator.ConfigMapName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.ConfigMapName, metav1.GetOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(cm.Data).To(gomega.Equal(map[string]string{
 			"foo":                        "bar",
@@ -980,14 +979,14 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 		}))
 
 		secret, err := clientset.CoreV1().Secrets(namespace).
-			Get(context.TODO(), trivyoperator.SecretName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.SecretName, metav1.GetOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(secret.Data).To(gomega.Equal(map[string][]byte{
 			"baz": []byte("s3cret"),
 		}))
 
 		pluginConfig, err := clientset.CoreV1().ConfigMaps(namespace).
-			Get(context.TODO(), trivyoperator.GetPluginConfigMapName("Trivy"), metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.GetPluginConfigMapName("Trivy"), metav1.GetOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(pluginConfig.Data).To(gomega.Equal(map[string]string{
 			"trivy.policy.my-check.rego": "<REGO>",
@@ -999,7 +998,7 @@ func TestConfigManager_EnsureDefault(t *testing.T) {
 func TestConfigManager_Delete(t *testing.T) {
 	t.Run("Should not return error when ConfigMap and secret do not exist", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
-		err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).Delete(context.TODO())
+		err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).Delete(t.Context())
 		require.NoError(t, err)
 	})
 
@@ -1025,15 +1024,15 @@ func TestConfigManager_Delete(t *testing.T) {
 			},
 		)
 
-		err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).Delete(context.TODO())
+		err := trivyoperator.NewConfigManager(clientset, trivyoperator.NamespaceName).Delete(t.Context())
 		require.NoError(t, err)
 
 		_, err = clientset.CoreV1().ConfigMaps(trivyoperator.NamespaceName).
-			Get(context.TODO(), trivyoperator.ConfigMapName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.ConfigMapName, metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 
 		_, err = clientset.CoreV1().Secrets(trivyoperator.NamespaceName).
-			Get(context.TODO(), trivyoperator.SecretName, metav1.GetOptions{})
+			Get(t.Context(), trivyoperator.SecretName, metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 	})
 }

--- a/pkg/vulnerabilityreport/controller/trivyserver_test.go
+++ b/pkg/vulnerabilityreport/controller/trivyserver_test.go
@@ -76,6 +76,6 @@ type dummyHttpServer struct {
 	err error
 }
 
-func (dhs dummyHttpServer) ServerHealthy(serverURL string) error {
+func (dhs dummyHttpServer) ServerHealthy(_ string) error {
 	return dhs.err
 }

--- a/pkg/vulnerabilityreport/io_test.go
+++ b/pkg/vulnerabilityreport/io_test.go
@@ -1,7 +1,6 @@
 package vulnerabilityreport_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,7 @@ func TestNewReadWriter(t *testing.T) {
 		testClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := vulnerabilityreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.VulnerabilityReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.VulnerabilityReport{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deployment-app1-container1",
@@ -54,7 +53,7 @@ func TestNewReadWriter(t *testing.T) {
 		})
 		require.NoError(t, err)
 		var list v1alpha1.VulnerabilityReportList
-		err = testClient.List(context.TODO(), &list)
+		err = testClient.List(t.Context(), &list)
 		require.NoError(t, err)
 		reports := make(map[string]v1alpha1.VulnerabilityReport)
 		for _, item := range list.Items {
@@ -132,7 +131,7 @@ func TestNewReadWriter(t *testing.T) {
 			}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := vulnerabilityreport.NewReadWriter(&resolver)
-		err := readWriter.Write(context.TODO(), []v1alpha1.VulnerabilityReport{
+		err := readWriter.Write(t.Context(), []v1alpha1.VulnerabilityReport{
 			{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "aquasecurity.github.io/v1alpha1",
@@ -171,7 +170,7 @@ func TestNewReadWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		var found v1alpha1.VulnerabilityReport
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container1",
 		}, &found)
@@ -195,7 +194,7 @@ func TestNewReadWriter(t *testing.T) {
 			},
 		}, found)
 
-		err = testClient.Get(context.TODO(), types.NamespacedName{
+		err = testClient.Get(t.Context(), types.NamespacedName{
 			Namespace: "qa",
 			Name:      "deployment-app1-container2",
 		}, &found)
@@ -260,7 +259,7 @@ func TestNewReadWriter(t *testing.T) {
 		}).Build()
 		resolver := kube.NewObjectResolver(testClient, &kube.CompatibleObjectMapper{})
 		readWriter := vulnerabilityreport.NewReadWriter(&resolver)
-		list, err := readWriter.FindByOwner(context.TODO(), kube.ObjectRef{
+		list, err := readWriter.FindByOwner(t.Context(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",

--- a/pkg/webhook/webhookreporter_test.go
+++ b/pkg/webhook/webhookreporter_test.go
@@ -81,7 +81,7 @@ func Test_sendReports(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				b, _ := io.ReadAll(r.Body)
 				assert.JSONEq(t, tc.want, string(b))
 			}))

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -54,7 +54,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 			})
 
 			It("Should create VulnerabilityReport", func() {
-				Eventually(inputs.HasVulnerabilityReportOwnedBy(pod), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, pod), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -79,15 +79,15 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 
 				err := inputs.Create(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			It("Should create VulnerabilityReport", func() {
-				rs, err := inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err := inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
-				Eventually(inputs.HasVulnerabilityReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -112,31 +112,31 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 
 				err := inputs.Create(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			It("Should create VulnerabilityReport for new ReplicaSet", func() {
 				By("Getting current active ReplicaSet")
-				rs, err := inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err := inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
 				By("Waiting for VulnerabilityReport")
-				Eventually(inputs.HasVulnerabilityReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 
 				By("Updating deployment image to wordpress:6.7")
-				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
+				err = inputs.UpdateDeploymentImage(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 
 				By("Getting new active replicaset")
-				rs, err = inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err = inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
 				By("Waiting for new VulnerabilityReport")
-				Eventually(inputs.HasVulnerabilityReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -186,7 +186,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 			})
 
 			It("Should create VulnerabilityReport", func() {
-				Eventually(inputs.HasVulnerabilityReportOwnedBy(cronJob), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, cronJob), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -230,7 +230,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 			})
 
 			It("Should create ConfigAuditReport", func() {
-				Eventually(inputs.HasConfigAuditReportOwnedBy(pod), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, pod), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -255,15 +255,15 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 
 				err := inputs.Create(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			It("Should create ConfigAuditReport", func() {
-				rs, err := inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err := inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
-				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -288,31 +288,31 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 
 				err := inputs.Create(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			It("Should create ConfigAuditReport for new ReplicaSet", func() {
 				By("Getting current active ReplicaSet")
-				rs, err := inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err := inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
 				By("Waiting for ConfigAuditReport")
-				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 
 				By("Updating deployment image to wordpress:6.7")
-				err = inputs.UpdateDeploymentImage(inputs.PrimaryNamespace, deploy.Name)
+				err = inputs.UpdateDeploymentImage(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 
 				By("Getting new active replicaset")
-				rs, err = inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err = inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
 				By("Waiting for new Config Audit Report")
-				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -362,7 +362,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 			})
 
 			It("Should create ConfigAuditReport", func() {
-				Eventually(inputs.HasConfigAuditReportOwnedBy(cronJob), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, cronJob), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -387,23 +387,23 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 
 				err := inputs.Create(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(inputs.HasActiveReplicaSet(inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasActiveReplicaSet(ctx, inputs.PrimaryNamespace, deploy.Name), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			It("Should rescan Deployment when ConfigAuditReport is deleted", func() {
 				By("Getting active ReplicaSet")
-				rs, err := inputs.GetActiveReplicaSetForDeployment(inputs.PrimaryNamespace, deploy.Name)
+				rs, err := inputs.GetActiveReplicaSetForDeployment(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs).ToNot(BeNil())
 
 				By("Waiting for ConfigAuditReport")
-				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 				By("Deleting ConfigAuditReport")
-				err = inputs.DeleteConfigAuditReportOwnedBy(rs)
+				err = inputs.DeleteConfigAuditReportOwnedBy(ctx, rs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for new ConfigAuditReport")
-				Eventually(inputs.HasConfigAuditReportOwnedBy(rs), inputs.AssertTimeout).Should(BeTrue())
+				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
## Description

Enable and fixes contextcheck and usetesting linters, this helpshandling contexts in running code as in testing.
Also use revive to be sur that the contexts are used while being provided as function arguments

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
