### PR TITLE
feat: Add ability to control scanJobsInSameNamespace in the helm chart

### DIFF
--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -66,6 +66,7 @@ data:
   {{- end }}
   {{- if or .Values.operator.vulnerabilityScannerEnabled .Values.operator.exposedSecretScannerEnabled .Values.operator.scannerReportTTL }}
   vulnerabilityReports.scanner: {{ .Values.trivyOperator.vulnerabilityReportsPlugin | quote }}
+  vulnerabilityReports.scanJobsInSameNamespace: {{ .Values.trivyOperator.scanJobsInSameNamespace | quote }}
   {{- end }}
   {{- if .Values.operator.configAuditScannerEnabled }}
   configAuditReports.scanner: {{ .Values.trivyOperator.configAuditReportsPlugin | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -252,6 +252,8 @@ trivyOperator:
   configAuditReportsPlugin: "Trivy"
   # -- scanJobCompressLogs control whether scanjob output should be compressed or plain
   scanJobCompressLogs: true
+  # -- scanJobsInSameNamespace control whether to run vulnerability scan jobs in same namespace of workload.
+  scanJobsInSameNamespace: false
   # -- scanJobAffinity affinity to be applied to the scanner pods and node-collector
   scanJobAffinity: {}
   # -- scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints


### PR DESCRIPTION
## Description
I would like to have the ability to change vulnerabilityReports.scanJobsInSameNamespace to true when deploying trivy-operator using the Helm chart.

## Checklist
- [ x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ x] I've added tests that prove my fix is effective or that my feature works.
- [ x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ x] I've added usage information (if the PR introduces new options)
- [ x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
