### PR TITLE
chore: bumps up UBI to version 9

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,12 +88,12 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{ .Version }}/"
       - "--platform=linux/amd64"
   - image_templates:
-      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-amd64"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
+      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi9-amd64"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-amd64"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-amd64"
     use: buildx
     goos: linux
-    dockerfile: build/trivy-operator/Dockerfile.ubi8
+    dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: amd64
     ids:
       - trivy-operator
@@ -128,12 +128,12 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{ .Version }}/"
       - "--platform=linux/arm64"
   - image_templates:
-      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-arm64"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
+      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi9-arm64"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-arm64"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-arm64"
     use: buildx
     goos: linux
-    dockerfile: build/trivy-operator/Dockerfile.ubi8
+    dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: arm64
     ids:
       - trivy-operator
@@ -188,12 +188,12 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{ .Version }}/"
       - "--platform=linux/ppc64le"
   - image_templates:
-      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-s390x"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
+      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi9-s390x"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-s390x"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-s390x"
     use: buildx
     goos: linux
-    dockerfile: build/trivy-operator/Dockerfile.ubi8
+    dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: s390x
     ids:
       - trivy-operator
@@ -208,12 +208,12 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{ .Version }}/"
       - "--platform=linux/s390x"
   - image_templates:
-      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi8-ppc64le"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+      - "docker.io/aquasec/trivy-operator:{{ .Version }}-ubi9-ppc64le"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-ppc64le"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-ppc64le"
     use: buildx
     goos: linux
-    dockerfile: build/trivy-operator/Dockerfile.ubi8
+    dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: ppc64le
     ids:
       - trivy-operator
@@ -234,36 +234,36 @@ docker_manifests:
       - "aquasec/trivy-operator:{{ .Version }}-arm64"
       - "aquasec/trivy-operator:{{ .Version }}-s390x"
       - "aquasec/trivy-operator:{{ .Version }}-ppc64le"
-  - name_template: "aquasec/trivy-operator:{{ .Version }}-ubi8"
+  - name_template: "aquasec/trivy-operator:{{ .Version }}-ubi9"
     image_templates:
-      - "aquasec/trivy-operator:{{ .Version }}-ubi8-amd64"
-      - "aquasec/trivy-operator:{{ .Version }}-ubi8-arm64"
-      - "aquasec/trivy-operator:{{ .Version }}-ubi8-s390x"
-      - "aquasec/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+      - "aquasec/trivy-operator:{{ .Version }}-ubi9-amd64"
+      - "aquasec/trivy-operator:{{ .Version }}-ubi9-arm64"
+      - "aquasec/trivy-operator:{{ .Version }}-ubi9-s390x"
+      - "aquasec/trivy-operator:{{ .Version }}-ubi9-ppc64le"
   - name_template: "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}"
     image_templates:
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-amd64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-arm64"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-s390x"
       - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ppc64le"
-  - name_template: "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8"
+  - name_template: "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9"
     image_templates:
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
-      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-amd64"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-arm64"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-s390x"
+      - "public.ecr.aws/aquasecurity/trivy-operator:{{ .Version }}-ubi9-ppc64le"
 #  - name_template: "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}"
 #    image_templates:
 #      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-amd64"
 #      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-arm64"
 #      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-s390x"
 #      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ppc64le"
-#  - name_template: "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8"
+#  - name_template: "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9"
 #    image_templates:
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-amd64"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-arm64"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-s390x"
-#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi8-ppc64le"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-amd64"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-arm64"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-s390x"
+#      - "ghcr.io/aquasecurity/trivy-operator:{{ .Version }}-ubi9-ppc64le"
 
 signs:
   - cmd: cosign

--- a/build/trivy-operator/Dockerfile.ubi9
+++ b/build/trivy-operator/Dockerfile.ubi9
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290
 
 RUN microdnf install shadow-utils
 RUN useradd -u 10000 trivyoperator

--- a/magefile.go
+++ b/magefile.go
@@ -50,7 +50,7 @@ var (
 
 	IMAGE_TAG                 = "dev"
 	TRIVY_OPERATOR_IMAGE      = "aquasecurity/trivy-operator:" + IMAGE_TAG
-	TRIVY_OPERATOR_IMAGE_UBI8 = "aquasecurity/trivy-operator:" + IMAGE_TAG + "-ubi8"
+	TRIVY_OPERATOR_IMAGE_UBI9 = "aquasecurity/trivy-operator:" + IMAGE_TAG + "-ubi9"
 
 	MKDOCS_IMAGE = "aquasec/mkdocs-material:trivy-operator"
 	MKDOCS_PORT  = 8000
@@ -189,7 +189,7 @@ func (t Tool) Clean() {
 func (b Build) DockerAll() {
 	fmt.Println("Building Docker images for all binaries...")
 	b.Docker()
-	b.DockerUbi8()
+	b.DockerUbi9()
 }
 
 // Target for building Docker image for trivy-operator
@@ -198,17 +198,17 @@ func (b Build) Docker() error {
 	return sh.RunV("docker", "build", "--no-cache", "-t", TRIVY_OPERATOR_IMAGE, "-f", "build/trivy-operator/Dockerfile", "bin")
 }
 
-// Target for building Docker image for trivy-operator ubi8
-func (b Build) DockerUbi8() error {
-	fmt.Println("Building Docker image for trivy-operator ubi8...")
-	return sh.RunV("docker", "build", "--no-cache", "-f", "build/trivy-operator/Dockerfile.ubi8", "-t", TRIVY_OPERATOR_IMAGE_UBI8, "bin")
+// Target for building Docker image for trivy-operator ubi9
+func (b Build) DockerUbi9() error {
+	fmt.Println("Building Docker image for trivy-operator ubi9...")
+	return sh.RunV("docker", "build", "--no-cache", "-f", "build/trivy-operator/Dockerfile.ubi9", "-t", TRIVY_OPERATOR_IMAGE_UBI9, "bin")
 }
 
 // Target for loading Docker images into the KIND cluster
 func (b Build) KindLoadImages() error {
 	fmt.Println("Loading Docker images into the KIND cluster...")
-	mg.Deps(b.Docker, b.DockerUbi8)
-	return sh.RunV(KIND, "load", "docker-image", TRIVY_OPERATOR_IMAGE, TRIVY_OPERATOR_IMAGE_UBI8)
+	mg.Deps(b.Docker, b.DockerUbi9)
+	return sh.RunV(KIND, "load", "docker-image", TRIVY_OPERATOR_IMAGE, TRIVY_OPERATOR_IMAGE_UBI9)
 }
 
 type Docs mg.Namespace


### PR DESCRIPTION
## Description
This PR bumps up UBI to the latest version https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5

Before:
```sh
$ mage build:dockerUbi8
$ trivy i aquasecurity/trivy-operator:dev-ubi8
...
Report Summary

┌───────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                       │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ aquasecurity/trivy-operator:dev-ubi8 (redhat 8.5) │  redhat  │       252       │    -    │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                      │ gobinary │        0        │    -    │
└───────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
```
After:
```sh
$ mage build:dockerUbi9
$ trivy i aquasecurity/trivy-operator:dev-ubi9
...
Report Summary

┌───────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                       │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6) │  redhat  │       46        │    -    │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                      │ gobinary │        0        │    -    │
└───────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
