### PR TITLE
fix(policy): remove oci artifact construction at startup

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -40,8 +40,6 @@ import (
 	vcontroller "github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport/controller"
 	"github.com/aquasecurity/trivy-operator/pkg/webhook"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/oci"
-	mp "github.com/aquasecurity/trivy/pkg/policy"
 )
 
 var (
@@ -461,7 +459,6 @@ func newWorkloadController(operatorConfig etc.Config,
 func buildPolicyLoader(tc trivyoperator.ConfigData) policy.Loader {
 	registryUser := tc.PolicyBundleOciUser()
 	registryPassword := tc.PolicyBundleOciPassword()
-	artifact := oci.NewArtifact(tc.PolicyBundleOciRef(), types.RegistryOptions{})
 	ro := types.RegistryOptions{}
 	if registryUser != "" && registryPassword != "" {
 		ro.Credentials = []types.Credential{
@@ -472,6 +469,5 @@ func buildPolicyLoader(tc trivyoperator.ConfigData) policy.Loader {
 		}
 	}
 	ro.Insecure = tc.PolicyBundleInsecure()
-	artifact.RegistryOptions = ro
-	return policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(2).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
+	return policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(2).LRU().Build(), ro)
 }


### PR DESCRIPTION
## Description
Remove the artifact construction during operator startup, to allow a new artifact to be created with up to date registry credentials during policy refresh

Tested on a live AKS cluster with no `401 Unauthorized` errors and verified policy bundle refresh:

```
$ kubectl exec -it trivy-operator-... -n trivy-operator -- /bin/sh
/ $ cat /tmp/policy/metadata.json
{"Digest":"sha256:e13d31ec41e7a61a0eeb42afccd73a8e2802244c5c772764a5e2ffb30cab727c","DownloadedAt":"2025-05-25T16:39:15.852887038Z"}
/ $ cat /tmp/policy/metadata.json
{"Digest":"sha256:e13d31ec41e7a61a0eeb42afccd73a8e2802244c5c772764a5e2ffb30cab727c","DownloadedAt":"2025-05-26T16:39:17.508803701Z"}
```

## Related issues
https://github.com/aquasecurity/trivy-operator/issues/2565

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
