### PR TITLE
fix: enable more revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,9 @@ linters:
         - name: indent-error-flow
           arguments:
             - "preserve-scope"
+        - name: superfluous-else
+          arguments:
+            - "preserve-scope"
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,7 @@ linters:
           arguments:
             - allow-regex: "^_"
         - name: useless-break
+        - name: var-declaration
     staticcheck:
       checks:
         - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,7 @@ linters:
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"
+        - name: useless-break
     staticcheck:
       checks:
         - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,7 @@ linters:
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"
+        - name: use-errors-new
         - name: useless-break
         - name: var-declaration
     staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,9 @@ linters:
           arguments:
             - "preserve-scope"
         - name: if-return
+        - name: indent-error-flow
+          arguments:
+            - "preserve-scope"
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,6 +105,7 @@ linters:
           arguments:
             - allow-types-before: "*testing.T"
         - name: context-keys-type
+        - name: duplicated-imports
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,9 @@ linters:
             - allow-types-before: "*testing.T"
         - name: context-keys-type
         - name: duplicated-imports
+        - name: early-return
+          arguments:
+            - "preserve-scope"
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,7 @@ linters:
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"
+        - name: use-any
         - name: use-errors-new
         - name: useless-break
         - name: var-declaration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,6 +109,7 @@ linters:
         - name: early-return
           arguments:
             - "preserve-scope"
+        - name: if-return
         - name: unused-parameter
           arguments:
             - allow-regex: "^_"

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -35,12 +35,9 @@ type ClusterComplianceReportReconciler struct {
 // +kubebuilder:rbac:groups=aquasecurity.github.io,resources=clustercompliancedetailreports,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ClusterComplianceReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := ctrl.NewControllerManagedBy(mgr).
+	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ClusterComplianceReport{}).
-		Complete(r.reconcileComplianceReport()); err != nil {
-		return err
-	}
-	return nil
+		Complete(r.reconcileComplianceReport())
 }
 
 func (r *ClusterComplianceReportReconciler) reconcileComplianceReport() reconcile.Func {

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -67,13 +67,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 			return fmt.Errorf("failed to check report cron expression %w", err)
 		}
 		if utils.DurationExceeded(durationToNextGeneration) || r.Config.InvokeClusterComplianceOnce {
-			if !r.Config.AltReportStorageEnabled || r.Config.AltReportDir == "" {
-				err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
-				if err != nil {
-					log.Error(err, "failed to generate compliance report")
-					return err
-				}
-			} else {
+			if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 				// Write the compliance report to a file
 				reportDir := r.Config.AltReportDir
 				complianceReportDir := filepath.Join(reportDir, "cluster_compliance_report")
@@ -96,6 +90,11 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 				log.Info("Cluster compliance report written", "path", reportPath)
 
 				return nil
+			}
+			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
+			if err != nil {
+				log.Error(err, "failed to generate compliance report")
+				return err
 			}
 		}
 		if r.Config.InvokeClusterComplianceOnce { // for demo or testing purposes

--- a/pkg/compliance/io.go
+++ b/pkg/compliance/io.go
@@ -83,10 +83,9 @@ func (w *cm) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportS
 		}
 		log.Info("Cluster compliance report written", "path", reportPath)
 		return nil
-	} else {
-		// update compliance report status
-		return w.client.Status().Update(ctx, updatedReport)
 	}
+	// update compliance report status
+	return w.client.Status().Update(ctx, updatedReport)
 }
 
 // createComplianceReport create compliance report

--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -177,18 +177,15 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 		}
 		if b.Config.AltReportStorageEnabled && b.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return writer.WriteClusterReport(ctx, report)
 		}
-	} else {
-		report, err := b.GetReport()
-		if err != nil {
-			return err
-		}
-		if b.Config.AltReportStorageEnabled && b.Config.AltReportDir != "" {
-			return nil
-		} else {
-			return writer.WriteReport(ctx, report)
-		}
+		return writer.WriteClusterReport(ctx, report)
 	}
+	report, err := b.GetReport()
+	if err != nil {
+		return err
+	}
+	if b.Config.AltReportStorageEnabled && b.Config.AltReportDir != "" {
+		return nil
+	}
+	return writer.WriteReport(ctx, report)
 }

--- a/pkg/configauditreport/controller/nodecollector.go
+++ b/pkg/configauditreport/controller/nodecollector.go
@@ -170,11 +170,7 @@ func (r *NodeCollectorJobController) processCompleteScanJob(ctx context.Context,
 		infraReportBuilder.ReportTTL(r.Config.ScannerReportTTL)
 	}
 	// Not writing if alternate storage is enabled
-	if !r.Config.AltReportStorageEnabled || r.Config.AltReportDir == "" {
-		if err := infraReportBuilder.Write(ctx, r.InfraReadWriter); err != nil {
-			return err
-		}
-	} else {
+	if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 		log.V(1).Info("Writing infra assessment report to alternate storage", "dir", r.Config.AltReportDir)
 		clusterInfraReport, err := infraReportBuilder.GetClusterReport()
 		if err != nil {
@@ -202,7 +198,9 @@ func (r *NodeCollectorJobController) processCompleteScanJob(ctx context.Context,
 			return fmt.Errorf("failed to write compliance report: %w", err)
 		}
 		return nil
-
+	}
+	if err := infraReportBuilder.Write(ctx, r.InfraReadWriter); err != nil {
+		return err
 	}
 	log.V(1).Info("Deleting complete scan job", "owner", job)
 	return r.deleteJob(ctx, job)

--- a/pkg/configauditreport/io.go
+++ b/pkg/configauditreport/io.go
@@ -65,21 +65,19 @@ func (r *readWriter) WriteReport(ctx context.Context, report v1alpha1.ConfigAudi
 	if err == nil {
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			copied := existing.DeepCopy()
-			copied.Labels = report.Labels
-			copied.Report = report.Report
-			return r.Update(ctx, copied)
 		}
+		copied := existing.DeepCopy()
+		copied.Labels = report.Labels
+		copied.Report = report.Report
+		return r.Update(ctx, copied)
 	}
 
 	if errors.IsNotFound(err) {
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return r.Create(ctx, &report)
 		}
+		return r.Create(ctx, &report)
 	}
 
 	return err
@@ -94,21 +92,19 @@ func (r *readWriter) WriteClusterReport(ctx context.Context, report v1alpha1.Clu
 	if err == nil {
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			copied := existing.DeepCopy()
-			copied.Labels = report.Labels
-			copied.Report = report.Report
-			return r.Update(ctx, copied)
 		}
+		copied := existing.DeepCopy()
+		copied.Labels = report.Labels
+		copied.Report = report.Report
+		return r.Update(ctx, copied)
 	}
 
 	if errors.IsNotFound(err) {
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return r.Create(ctx, &report)
 		}
+		return r.Create(ctx, &report)
 	}
 
 	return err

--- a/pkg/infraassessment/builder.go
+++ b/pkg/infraassessment/builder.go
@@ -205,9 +205,8 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 				return fmt.Errorf("failed to write cluster infra assessment report: %w", err)
 			}
 			return nil
-		} else {
-			return writer.WriteClusterReport(ctx, report)
 		}
+		return writer.WriteClusterReport(ctx, report)
 	}
 	report, err := b.GetReport()
 	if err != nil {
@@ -215,7 +214,6 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 	}
 	if b.Config.AltReportStorageEnabled && b.Config.AltReportDir != "" {
 		return nil
-	} else {
-		return writer.WriteReport(ctx, report)
 	}
+	return writer.WriteReport(ctx, report)
 }

--- a/pkg/infraassessment/io.go
+++ b/pkg/infraassessment/io.go
@@ -65,21 +65,19 @@ func (r *readWriter) WriteReport(ctx context.Context, report v1alpha1.InfraAsses
 	if err == nil {
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			copied := existing.DeepCopy()
-			copied.Labels = report.Labels
-			copied.Report = report.Report
-			return r.Update(ctx, copied)
 		}
+		copied := existing.DeepCopy()
+		copied.Labels = report.Labels
+		copied.Report = report.Report
+		return r.Update(ctx, copied)
 	}
 
 	if errors.IsNotFound(err) {
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return r.Create(ctx, &report)
 		}
+		return r.Create(ctx, &report)
 	}
 	return err
 }

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -158,11 +158,11 @@ func ObjectRefFromObjectMeta(objectMeta metav1.ObjectMeta) (ObjectRef, error) {
 	}
 	var objname string
 	if _, found := objectMeta.Labels[trivyoperator.LabelResourceName]; !found {
-		if _, found := objectMeta.Annotations[trivyoperator.LabelResourceName]; found {
-			objname = objectMeta.Annotations[trivyoperator.LabelResourceName]
-		} else {
+		_, found := objectMeta.Annotations[trivyoperator.LabelResourceName]
+		if !found {
 			return ObjectRef{}, fmt.Errorf("required label does not exist: %s", trivyoperator.LabelResourceName)
 		}
+		objname = objectMeta.Annotations[trivyoperator.LabelResourceName]
 	} else {
 		objname = objectMeta.Labels[trivyoperator.LabelResourceName]
 	}

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -210,26 +210,25 @@ func (r *ClusterController) reconcileClusterComponents(resourceKind kube.Kind) r
 		sbomReport := sbomReportBuilder.ClusterReport()
 		if !r.Config.AltReportStorageEnabled || r.Config.AltReportDir == "" {
 			return ctrl.Result{}, r.SbomReadWriter.WriteCluster(ctx, []v1alpha1.ClusterSbomReport{sbomReport})
-		} else {
-			// Write the sbom report to a file
-			reportDir := r.Config.AltReportDir
-			sbomReportDir := filepath.Join(reportDir, "cluster_sbom_reports")
-			if err := os.MkdirAll(sbomReportDir, 0750); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to make sbomReportDir %s: %w", sbomReportDir, err)
-			}
-
-			reportData, err := json.Marshal(sbomReport)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to marshal sbom report: %w", err)
-			}
-
-			reportPath := filepath.Join(sbomReportDir, fmt.Sprintf("%s.json", sbomReport.Name))
-			err = os.WriteFile(reportPath, reportData, 0600)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to write sbom report: %w", err)
-			}
-			return ctrl.Result{}, nil
 		}
+		// Write the sbom report to a file
+		reportDir := r.Config.AltReportDir
+		sbomReportDir := filepath.Join(reportDir, "cluster_sbom_reports")
+		if err := os.MkdirAll(sbomReportDir, 0750); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to make sbomReportDir %s: %w", sbomReportDir, err)
+		}
+
+		reportData, err := json.Marshal(sbomReport)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to marshal sbom report: %w", err)
+		}
+
+		reportPath := filepath.Join(sbomReportDir, fmt.Sprintf("%s.json", sbomReport.Name))
+		err = os.WriteFile(reportPath, reportData, 0600)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to write sbom report: %w", err)
+		}
+		return ctrl.Result{}, nil
 	}
 }
 

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -194,9 +194,8 @@ var IsCoreComponents = predicate.NewPredicateFuncs(func(obj client.Object) bool 
 			return true
 		} else if _, ok := v.GetLabels()[trivyoperator.LabelOpenShiftEtcd]; ok {
 			return true
-		} else {
-			return false
 		}
+		return false
 	case *corev1.Node:
 		return true
 	}

--- a/pkg/rbacassessment/builder.go
+++ b/pkg/rbacassessment/builder.go
@@ -205,9 +205,8 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 				return fmt.Errorf("failed to write cluster RBAC assessment report: %w", err)
 			}
 			return nil
-		} else {
-			return writer.WriteClusterReport(ctx, report)
 		}
+		return writer.WriteClusterReport(ctx, report)
 	}
 	report, err := b.GetReport()
 	if err != nil {
@@ -215,8 +214,7 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 	}
 	if b.Config.AltReportStorageEnabled && b.Config.AltReportDir != "" {
 		return nil
-	} else {
-		return writer.WriteReport(ctx, report)
 	}
+	return writer.WriteReport(ctx, report)
 
 }

--- a/pkg/rbacassessment/io.go
+++ b/pkg/rbacassessment/io.go
@@ -67,22 +67,20 @@ func (r *readWriter) WriteReport(ctx context.Context, report v1alpha1.RbacAssess
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			copied := existing.DeepCopy()
-			copied.Labels = report.Labels
-			copied.Report = report.Report
-
-			return r.Update(ctx, copied)
 		}
+		copied := existing.DeepCopy()
+		copied.Labels = report.Labels
+		copied.Report = report.Report
+
+		return r.Update(ctx, copied)
 	}
 
 	if errors.IsNotFound(err) {
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return r.Create(ctx, &report)
 		}
+		return r.Create(ctx, &report)
 	}
 
 	return err
@@ -98,22 +96,20 @@ func (r *readWriter) WriteClusterReport(ctx context.Context, report v1alpha1.Clu
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			copied := existing.DeepCopy()
-			copied.Labels = report.Labels
-			copied.Report = report.Report
-
-			return r.Update(ctx, copied)
 		}
+		copied := existing.DeepCopy()
+		copied.Labels = report.Labels
+		copied.Report = report.Report
+
+		return r.Update(ctx, copied)
 	}
 
 	if errors.IsNotFound(err) {
 		// Not writing to ETCD memory because altReport storage is enabled
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			return r.Create(ctx, &report)
 		}
+		return r.Create(ctx, &report)
 	}
 
 	return err

--- a/pkg/sbomreport/io.go
+++ b/pkg/sbomreport/io.go
@@ -65,11 +65,10 @@ func (r *readWriter) Write(ctx context.Context, reports []v1alpha1.SbomReport) e
 	for _, report := range reports {
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			err := r.createOrUpdate(ctx, report)
-			if err != nil {
-				return err
-			}
+		}
+		err := r.createOrUpdate(ctx, report)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -79,11 +78,10 @@ func (r *readWriter) WriteCluster(ctx context.Context, reports []v1alpha1.Cluste
 	for _, report := range reports {
 		if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
 			return nil
-		} else {
-			err := r.createOrUpdateCluster(ctx, report)
-			if err != nil {
-				return err
-			}
+		}
+		err := r.createOrUpdateCluster(ctx, report)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -417,9 +417,8 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 		}
 		// Return empty reports since alternate write method is used
 		return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, nil
-	} else {
-		return vulnerabilityReports, secretReports, sbomReports, nil
 	}
+	return vulnerabilityReports, secretReports, sbomReports, nil
 }
 
 func (r *ScanJobController) completedContainers(ctx context.Context, scanJob *batchv1.Job) ([]string, error) {


### PR DESCRIPTION
## Description

This enables the following revive rules:

* [duplicated-imports](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#duplicated-imports)
* [early-return](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return)
* [if-return](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#if-return)
* [indent-error-flow](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#indent-error-flow)
* [superfluous-else](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#superfluous-else)
* [use-any](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-any)
* [use-errors-new](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-errors-new)
* [useless-break](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#useless-break)
* [var-declaration](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-declaration)

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
