### PR TITLE
fix: enable more go-critic rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
         - commentedOutCode
         - hugeParam
         - rangeValCopy
-        - regexpSimplify
         - sloppyReassign
         - unnamedResult
         - whyNoLint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
         - appendAssign
         - commentedOutCode
         - hugeParam
-        - indexAlloc
         - octalLiteral
         - rangeValCopy
         - regexpSimplify

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
         - appendAssign
         - commentedOutCode
         - hugeParam
-        - octalLiteral
         - rangeValCopy
         - regexpSimplify
         - sloppyReassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
         - commentedOutCode
         - hugeParam
         - rangeValCopy
-        - sloppyReassign
         - unnamedResult
         - whyNoLint
       enabled-tags:

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -68,7 +68,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 				// Write the compliance report to a file
 				reportDir := r.Config.AltReportDir
 				complianceReportDir := filepath.Join(reportDir, "cluster_compliance_report")
-				if err := os.MkdirAll(complianceReportDir, 0750); err != nil {
+				if err := os.MkdirAll(complianceReportDir, 0o750); err != nil {
 					return fmt.Errorf("failed to create report directory: %w", err)
 				}
 				reportData, err := json.Marshal(report)
@@ -79,7 +79,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 
 				reportPath := filepath.Join(complianceReportDir, fmt.Sprintf("%s-%s.json", report.Kind, report.Name))
 				log.Info("Writing cluster compliance report to alternate storage", "path", reportPath)
-				err = os.WriteFile(reportPath, reportData, 0600)
+				err = os.WriteFile(reportPath, reportData, 0o600)
 				if err != nil {
 					log.Error(err, "Failed to write compliance report", "path", reportPath)
 					return err

--- a/pkg/compliance/io.go
+++ b/pkg/compliance/io.go
@@ -65,7 +65,7 @@ func (w *cm) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportS
 		// Write the compliance report to a file
 		reportDir := w.Config.AltReportDir
 		complianceReportDir := filepath.Join(reportDir, "cluster_compliance_report")
-		if err := os.MkdirAll(complianceReportDir, 0750); err != nil {
+		if err := os.MkdirAll(complianceReportDir, 0o750); err != nil {
 			w.Logger.Error(err, "could not create compliance report directory")
 			return err
 		}
@@ -77,7 +77,7 @@ func (w *cm) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportS
 
 		reportPath := filepath.Join(complianceReportDir, fmt.Sprintf("%s-%s.json", updatedReport.Kind, updatedReport.Name))
 		log.Info("Writing cluster compliance report to alternate storage", "path", reportPath)
-		err = os.WriteFile(reportPath, reportData, 0600)
+		err = os.WriteFile(reportPath, reportData, 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to write compliance report: %w", err)
 		}

--- a/pkg/configauditreport/controller/nodecollector.go
+++ b/pkg/configauditreport/controller/nodecollector.go
@@ -179,7 +179,7 @@ func (r *NodeCollectorJobController) processCompleteScanJob(ctx context.Context,
 		// Write the cluster infra assessment report to a file
 		reportDir := r.Config.AltReportDir
 		clusterInfraReportDir := filepath.Join(reportDir, "cluster_infra_assessment_reports")
-		if err := os.MkdirAll(clusterInfraReportDir, 0750); err != nil {
+		if err := os.MkdirAll(clusterInfraReportDir, 0o750); err != nil {
 			log.Error(err, "failed to create infra assessment report directory")
 			return err
 		}
@@ -193,7 +193,7 @@ func (r *NodeCollectorJobController) processCompleteScanJob(ctx context.Context,
 		workloadKind := labels["trivy-operator.resource.kind"]
 		workloadName := labels["trivy-operator.resource.name"]
 		reportPath := filepath.Join(clusterInfraReportDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(reportPath, reportData, 0600)
+		err = os.WriteFile(reportPath, reportData, 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to write compliance report: %w", err)
 		}

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -91,7 +91,8 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 	targetWorkloads = append(targetWorkloads, strings.ToLower(string(kube.KindIngress)))
 	for _, tw := range targetWorkloads {
 		var resource kube.Resource
-		if err = resource.GetWorkloadResource(tw, &v1alpha1.ConfigAuditReport{}, r.ObjectResolver); err != nil {
+		err = resource.GetWorkloadResource(tw, &v1alpha1.ConfigAuditReport{}, r.ObjectResolver)
+		if err != nil {
 			return err
 		}
 		resourceBuilder := r.buildControlMgr(mgr, resource, installModePredicate)

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -305,15 +305,15 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		infraAssessmentDir := filepath.Join(reportDir, "infra_assessment_reports")
 
 		// Ensure the directories exist
-		if err := os.MkdirAll(configAuditDir, 0750); err != nil {
+		if err := os.MkdirAll(configAuditDir, 0o750); err != nil {
 			log.Error(err, "Failed to create configAuditDir")
 			return ctrl.Result{}, err
 		}
-		if err := os.MkdirAll(rbacAssessmentDir, 0750); err != nil {
+		if err := os.MkdirAll(rbacAssessmentDir, 0o750); err != nil {
 			log.Error(err, "Failed to create rbacAssessmentDir")
 			return ctrl.Result{}, err
 		}
-		if err := os.MkdirAll(infraAssessmentDir, 0750); err != nil {
+		if err := os.MkdirAll(infraAssessmentDir, 0o750); err != nil {
 			log.Error(err, "Failed to create infraAssessmentDir")
 			return ctrl.Result{}, err
 		}
@@ -327,7 +327,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 			return ctrl.Result{}, err
 		}
 		configReportPath := filepath.Join(configAuditDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(configReportPath, configReportData, 0600)
+		err = os.WriteFile(configReportPath, configReportData, 0o600)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -339,7 +339,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 			return ctrl.Result{}, err
 		}
 		infraReportPath := filepath.Join(infraAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(infraReportPath, infraReportData, 0600)
+		err = os.WriteFile(infraReportPath, infraReportData, 0o600)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -351,7 +351,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 			return ctrl.Result{}, err
 		}
 		rbacReportPath := filepath.Join(rbacAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(rbacReportPath, rbacReportData, 0600)
+		err = os.WriteFile(rbacReportPath, rbacReportData, 0o600)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/infraassessment/builder.go
+++ b/pkg/infraassessment/builder.go
@@ -186,7 +186,7 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 			// Write the cluster infra assessment report to a file
 			reportDir := b.Config.AltReportDir
 			infraAssessmentDir := filepath.Join(reportDir, "cluster_infra_assessment_reports")
-			if err := os.MkdirAll(infraAssessmentDir, 0750); err != nil {
+			if err := os.MkdirAll(infraAssessmentDir, 0o750); err != nil {
 				return fmt.Errorf("failed to make infraAssessmentDir %s: %w", infraAssessmentDir, err)
 			}
 
@@ -200,7 +200,7 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 			workloadName := report.Labels["trivy-operator.resource.name"]
 
 			reportPath := filepath.Join(infraAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return fmt.Errorf("failed to write cluster infra assessment report: %w", err)
 			}

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -214,7 +214,7 @@ func (r *ClusterController) reconcileClusterComponents(resourceKind kube.Kind) r
 		// Write the sbom report to a file
 		reportDir := r.Config.AltReportDir
 		sbomReportDir := filepath.Join(reportDir, "cluster_sbom_reports")
-		if err := os.MkdirAll(sbomReportDir, 0750); err != nil {
+		if err := os.MkdirAll(sbomReportDir, 0o750); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to make sbomReportDir %s: %w", sbomReportDir, err)
 		}
 
@@ -224,7 +224,7 @@ func (r *ClusterController) reconcileClusterComponents(resourceKind kube.Kind) r
 		}
 
 		reportPath := filepath.Join(sbomReportDir, fmt.Sprintf("%s.json", sbomReport.Name))
-		err = os.WriteFile(reportPath, reportData, 0600)
+		err = os.WriteFile(reportPath, reportData, 0o600)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to write sbom report: %w", err)
 		}

--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	GCPCR_Image_Regex  = `^(us\.|eu\.|asia\.)?gcr\.io.*|^([a-zA-Z0-9-]+)-*-*.docker\.pkg\.dev.*`
-	AWSECR_Image_Regex = "^\\d+\\.dkr\\.ecr\\.(\\w+-\\w+-\\d+)\\.amazonaws\\.com\\/"
+	AWSECR_Image_Regex = `^\d+\.dkr\.ecr\.(\w+-\w+-\d+)\.amazonaws\.com/`
 	// SkipDirsAnnotation annotation  example: trivy-operator.aquasecurity.github.io/skip-dirs: "/tmp,/home"
 	SkipDirsAnnotation = "trivy-operator.aquasecurity.github.io/skip-dirs"
 	// SkipFilesAnnotation example: trivy-operator.aquasecurity.github.io/skip-files: "/src/Gemfile.lock,/examplebinary"

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -398,11 +398,11 @@ func createDataFS(dataPaths []string, k8sVersion string) (fs.FS, []string, error
 
 	// Create a virtual file for Kubernetes scanning
 	if k8sVersion != "" {
-		if err := fsys.MkdirAll("system", 0700); err != nil {
+		if err := fsys.MkdirAll("system", 0o700); err != nil {
 			return nil, nil, err
 		}
 		data := []byte(fmt.Sprintf(`{"k8s": {"version": %q}}`, k8sVersion))
-		if err := fsys.WriteVirtualFile("system/k8s-version.json", data, 0600); err != nil {
+		if err := fsys.WriteVirtualFile("system/k8s-version.json", data, 0o600); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/pkg/rbacassessment/builder.go
+++ b/pkg/rbacassessment/builder.go
@@ -186,7 +186,7 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 			// Write the cluster RBAC assessment report to a file
 			reportDir := b.Config.AltReportDir
 			rbacAssessmentDir := filepath.Join(reportDir, "cluster_rbac_assessment_reports")
-			if err := os.MkdirAll(rbacAssessmentDir, 0750); err != nil {
+			if err := os.MkdirAll(rbacAssessmentDir, 0o750); err != nil {
 				return fmt.Errorf("failed to make rbacAssessmentDir %s: %w", rbacAssessmentDir, err)
 			}
 
@@ -200,7 +200,7 @@ func (b *ReportBuilder) Write(ctx context.Context, writer Writer) error {
 			workloadName := report.Labels["trivy-operator.resource.name"]
 
 			reportPath := filepath.Join(rbacAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return fmt.Errorf("failed to write cluster RBAC assessment report: %w", err)
 			}

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -343,7 +343,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 
 		// Ensure the directories exist
 		for _, dir := range []string{vulnerabilityDir, secretDir, sbomDir, clusterSbomDir, clusterVulnerabilityDir} {
-			if err := os.MkdirAll(dir, 0750); err != nil {
+			if err := os.MkdirAll(dir, 0o750); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to make directory %s: %w", dir, err)
 			}
 		}
@@ -358,7 +358,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal cluster vulnerability report: %w", err)
 			}
 			reportPath := filepath.Join(clusterVulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
@@ -371,7 +371,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal vulnerability report: %w", err)
 			}
 			reportPath := filepath.Join(vulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join vulnerability report: %w", err)
 			}
@@ -384,7 +384,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal exposed secrets report: %w", err)
 			}
 			reportPath := filepath.Join(secretDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join exposed secrets report: %w", err)
 			}
@@ -397,7 +397,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal sbom cluster report: %w", err)
 			}
 			reportPath := filepath.Join(clusterSbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join sbom cluster report: %w", err)
 			}
@@ -410,7 +410,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal sbom report: %w", err)
 			}
 			reportPath := filepath.Join(sbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0600)
+			err = os.WriteFile(reportPath, reportData, 0o600)
 			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join sbom report: %w", err)
 			}


### PR DESCRIPTION
## Description

This enables the following go-critic rules:

* [indexAlloc](https://go-critic.com/overview.html#indexalloc)
* [octalLiteral](https://go-critic.com/overview.html#octalliteral)
* [regexpSimplify](https://go-critic.com/overview.html#regexpsimplify)
* [sloppyReassign](https://go-critic.com/overview.html#sloppyreassign)

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
