### PR TITLE
ci: bump up KinD to the latest version - v0.29.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -184,8 +184,8 @@ jobs:
           args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
       - name: Install kind and create cluster
         run: >
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION
-          }}/kind-linux-amd64
+          # Using outdated version of kind to test cluster vulnerability reports
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
 
           chmod +x ./kind
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ on:
       - LICENSE
       - NOTICE
 env:
-  KIND_VERSION: v0.24.0
-  KIND_IMAGE: kindest/node:v1.31.2
+  KIND_VERSION: v0.29.0
+  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -185,6 +185,7 @@ jobs:
       - name: Install kind and create cluster
         run: >
           # Using outdated version of kind to test cluster vulnerability reports
+
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
 
           chmod +x ./kind

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,21 +182,13 @@ jobs:
         with:
           version: v2.4.8
           args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
-      - name: Install kind and create cluster
-        run: >
-          # Using outdated version of kind to test cluster vulnerability reports
 
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+      - name: Setup Kubernetes cluster (KIND)
+        uses: engineerd/setup-kind@v0.6.2
+        with:
+          version: ${{ env.KIND_VERSION }}
+          image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865   # Using outdated version of k8s to test the cluster vulnerability reports
 
-          chmod +x ./kind
-
-          sudo mv ./kind /usr/local/bin/kind
-
-          kind create cluster
-
-          curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
-
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: Test connection to Kubernetes cluster
         run: |
           kubectl cluster-info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,7 +279,3 @@ jobs:
           kubectl logs -n trivy-system deployment/trivy-operator
           echo "reports:"
           kubectl get clustervulnerabilityreports.aquasecurity.github.io -A
-
-      - name: Delete kind cluster
-        run: |
-          kind delete cluster

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -186,7 +186,7 @@ jobs:
         run: >
           # Using outdated version of kind to test cluster vulnerability reports
 
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
 
           chmod +x ./kind
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -285,6 +285,8 @@ jobs:
         if: ${{ failure() }}
         run: >
           kubectl logs -n trivy-system deployment/trivy-operator
+          echo "reports:"
+          kubectl get clustervulnerabilityreports.aquasecurity.github.io -A
 
       - name: Delete kind cluster
         run: |

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -12,8 +12,8 @@ on:
     paths:
       - deploy/**
 env:
-  KIND_VERSION: v0.17.0
-  KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+  KIND_VERSION: v0.29.0
+  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -22,8 +22,8 @@ on:
       - LICENSE
       - NOTICE
 env:
-  KIND_VERSION: v0.17.0
-  KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+  KIND_VERSION: v0.29.0
+  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: helm/chart-testing-action@v2.7.0
 
       - name: Setup Kubernetes cluster (KIND)
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.12.0 # v1.5.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_IMAGE }}

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -12,8 +12,8 @@ env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm
-  KIND_VERSION: v0.17.0
-  KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+  KIND_VERSION: v0.29.0
+  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 jobs:
   release:
     # this job will only run if the PR has been merged
@@ -43,7 +43,7 @@ jobs:
         uses: helm/chart-testing-action@v2.7.0
 
       - name: Setup Kubernetes cluster (KIND)
-        uses: helm/kind-action@v1.12.0 # v1.5.0
+        uses: helm/kind-action@v1.12.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_IMAGE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ on:
     tags:
       - "v*"
 env:
-  KIND_VERSION: v0.17.0
-  KIND_IMAGE: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+  KIND_VERSION: v0.29.0
+  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 jobs:
   tests:
     name: Run tests


### PR DESCRIPTION
## Description
This PR bumps up KinD to the latest version and also fixes a warning about using `@sha256`:
```
Please include the @sha256: image digest from the image in the release notes. You can find available image tags on the release page, https://github.com/kubernetes-sigs/kind/releases/tag/v0.24.0

```

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
