### PR TITLE
fix: add credentials for downloading in client-server mode

### DIFF
--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7381,6 +7381,19 @@ func TestGetInitContainers(t *testing.T) {
 				"trivy.command":          string(trivy.Image),
 			},
 		},
+		{
+			name: "Client-server mode with image command java-db from private registry",
+			configData: map[string]string{
+				"trivy.dbRepository":     trivy.DefaultDBRepository,
+				"trivy.javaDbRepository": "my-private-registry.io/aquasec/trivy-java-db",
+				"trivy.skipJavaDBUpdate": "false",
+				"trivy.repository":       "gcr.io/aquasec/trivy",
+				"trivy.tag":              "0.35.0",
+				"trivy.mode":             string(trivy.ClientServer),
+				"trivy.serverURL":        "http://trivy.trivy:4954",
+				"trivy.command":          string(trivy.Image),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

## Related issues
- Close #2510 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
