### PR TITLE
fix: login private registry instead of download JavaDB

### DIFF
--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -51,22 +51,6 @@ type PodSpecMgr interface {
 func NewPodSpecMgr(config Config) PodSpecMgr {
 	mode := config.GetMode()
 	command := config.GetCommand()
-	if command == Image {
-		switch mode {
-		case Standalone:
-			return &ImageJobSpecMgr{
-				getPodSpecFunc: GetPodSpecForStandaloneMode,
-			}
-		case ClientServer:
-			return &ImageJobSpecMgr{
-				getPodSpecFunc: GetPodSpecForClientServerMode,
-			}
-		default:
-			return &ImageJobSpecMgr{
-				getPodSpecFunc: GetPodSpecForStandaloneMode,
-			}
-		}
-	}
 
 	if command == Filesystem || command == Rootfs {
 		switch mode {
@@ -85,7 +69,7 @@ func NewPodSpecMgr(config Config) PodSpecMgr {
 		}
 	}
 	return &ImageJobSpecMgr{
-		getPodSpecFunc: GetPodSpecForStandaloneMode,
+		getPodSpecFunc: GetPodSpecForImageScan,
 	}
 }
 

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -113,6 +113,7 @@ func (p *plugin) GetScanJobSpec(ctx trivyoperator.PluginContext, workload client
 
 const (
 	tmpVolumeName               = "tmp"
+	dockerConfigVolumeName      = "dockerconfig"
 	ignoreFileVolumeName        = "ignorefile"
 	configFileVolumeName        = "configfile"
 	sslCertDirVolumeName        = "ssl-cert-dir"

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7381,6 +7381,19 @@ func TestGetInitContainers(t *testing.T) {
 				"trivy.command":          string(trivy.Image),
 			},
 		},
+		{
+			name: "Client-server mode with image command java-db from private registry",
+			configData: map[string]string{
+				"trivy.dbRepository":     trivy.DefaultDBRepository,
+				"trivy.javaDbRepository": "my-private-registry.io/aquasec/trivy-java-db",
+				"trivy.skipJavaDBUpdate": "false",
+				"trivy.repository":       "gcr.io/aquasec/trivy",
+				"trivy.tag":              "0.35.0",
+				"trivy.mode":             string(trivy.ClientServer),
+				"trivy.serverURL":        "http://trivy.trivy:4954",
+				"trivy.command":          string(trivy.Image),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6199,11 +6199,11 @@ default ignore = false`,
 							"--cache-dir",
 							"/tmp/trivy/.cache",
 							"image",
+							"--config",
+							"/etc/trivy/trivy-config.yaml",
 							"--download-db-only",
 							"--db-repository",
 							trivy.DefaultDBRepository,
-							"--config",
-							"/etc/trivy/trivy-config.yaml",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7454,7 +7454,7 @@ func TestGetInitContainers(t *testing.T) {
 
 			assert.Len(t, jobSpec.InitContainers, numInitContainers)
 
-			trivyDbInitContainer := jobSpec.InitContainers[0]
+			trivyDbInitContainer := jobSpec.InitContainers[numInitContainers-1]
 			if tc.configData["trivy.mode"] == string(trivy.Standalone) {
 				// Assert first init container to download trivy-db from private registry
 				containsDownloadDBOnly := false
@@ -7464,7 +7464,7 @@ func TestGetInitContainers(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, containsDownloadDBOnly, "Expected first init container to only download try-db")
+				assert.True(t, containsDownloadDBOnly, "Expected second init container to only download try-db")
 			}
 
 			hasTrivyUsername := false
@@ -7480,11 +7480,11 @@ func TestGetInitContainers(t *testing.T) {
 			assert.True(t, hasTrivyUsername, "Expected init container to have username env var for private trivy-db registry")
 			assert.True(t, hasTrivyPassword, "Expected init container to have password env var for private trivy-db registry")
 
-			javaDbInitContainer := jobSpec.InitContainers[numInitContainers-1]
+			loginInitContainer := jobSpec.InitContainers[0]
 
 			containsDownloadJavaDBOnly := false
-			for _, arg := range javaDbInitContainer.Args {
-				if arg == "--download-java-db-only" {
+			for _, arg := range loginInitContainer.Args {
+				if arg == "login" {
 					containsDownloadJavaDBOnly = true
 					break
 				}
@@ -7493,7 +7493,7 @@ func TestGetInitContainers(t *testing.T) {
 
 			hasTrivyUsername = false
 			hasTrivyPassword = false
-			for _, envVar := range javaDbInitContainer.Env {
+			for _, envVar := range loginInitContainer.Env {
 				if envVar.Name == "TRIVY_USERNAME" {
 					hasTrivyUsername = true
 				}

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -2201,42 +2201,6 @@ default ignore = false`,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
 							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -2310,6 +2274,42 @@ default ignore = false`,
 								},
 							},
 							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
 								Name: "TRIVY_TOKEN_HEADER",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -2374,6 +2374,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -2430,42 +2431,6 @@ default ignore = false`,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
 							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -2539,6 +2504,42 @@ default ignore = false`,
 								},
 							},
 							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
 								Name: "TRIVY_TOKEN_HEADER",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -2603,6 +2604,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -2660,42 +2662,6 @@ default ignore = false`,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
 							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -2764,6 +2730,42 @@ default ignore = false`,
 											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
 										Optional: ptr.To[bool](true),
 									},
 								},
@@ -2837,6 +2839,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -2893,42 +2896,6 @@ default ignore = false`,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
-							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
 							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
@@ -3003,6 +2970,42 @@ default ignore = false`,
 								},
 							},
 							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
 								Name: "TRIVY_TOKEN_HEADER",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -3071,6 +3074,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -3148,42 +3152,6 @@ CVE-2019-1543`,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
 							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -3252,6 +3220,42 @@ CVE-2019-1543`,
 											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
 										Optional: ptr.To[bool](true),
 									},
 								},
@@ -3331,6 +3335,7 @@ CVE-2019-1543`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -3408,42 +3413,6 @@ default ignore = false`,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
 							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -3512,6 +3481,42 @@ default ignore = false`,
 											Name: "trivy-operator-trivy-config",
 										},
 										Key:      "trivy.skipDirs",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
 										Optional: ptr.To[bool](true),
 									},
 								},
@@ -3591,6 +3596,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{
@@ -3646,42 +3652,6 @@ default ignore = false`,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
-							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
 							{
 								Name: "TRIVY_SEVERITY",
 								ValueFrom: &corev1.EnvVarSource{
@@ -3756,6 +3726,42 @@ default ignore = false`,
 								},
 							},
 							{
+								Name: "HTTP_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "HTTPS_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.httpsProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
+								Name: "NO_PROXY",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "trivy-operator-trivy-config",
+										},
+										Key:      "trivy.noProxy",
+										Optional: ptr.To[bool](true),
+									},
+								},
+							},
+							{
 								Name: "TRIVY_TOKEN_HEADER",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -3820,6 +3826,7 @@ default ignore = false`,
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{},
 			},
 		},
 		{

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -7464,7 +7464,7 @@ func TestGetInitContainers(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, containsDownloadDBOnly, "Expected second init container to only download try-db")
+				assert.True(t, containsDownloadDBOnly, "Expected second init container to only download trivy-db")
 			}
 
 			hasTrivyUsername := false
@@ -7482,14 +7482,14 @@ func TestGetInitContainers(t *testing.T) {
 
 			loginInitContainer := jobSpec.InitContainers[0]
 
-			containsDownloadJavaDBOnly := false
+			containsLoginContainer := false
 			for _, arg := range loginInitContainer.Args {
 				if arg == "login" {
-					containsDownloadJavaDBOnly = true
+					containsLoginContainer = true
 					break
 				}
 			}
-			assert.True(t, containsDownloadJavaDBOnly, "Expected second init container to only download java-db")
+			assert.True(t, containsLoginContainer, "Expected a login init container")
 
 			hasTrivyUsername = false
 			hasTrivyPassword = false


### PR DESCRIPTION
## Description
This PR updates the authorization method for accessing the private repository containing JavaDB.

The initContainer no longer downloads the JavaDB database. Instead, it now performs authentication against the private registry.

This change eliminates unnecessary downloads of the heavy JavaDB image in scenarios where it is not needed, improving efficiency and reducing overhead.

It fixes next similar bugs for `ClientServer` modes, which were updated for `Standalone`:
- #2353
- #2073 

## Related issues
- Close #2510 
- Close #1836 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
