### PR TITLE
ci: use kind action instead of install kind script

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -44,14 +44,12 @@ jobs:
           version: v2.4.8
           args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
 
-      - name: Install kind and create cluster
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          kind create cluster
-          curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+      - name: Setup Kubernetes cluster (KIND)
+        uses: engineerd/setup-kind@v0.6.2
+        with:
+          version: ${{ env.KIND_VERSION }}
+          image: ${{ env.KIND_IMAGE }}
+
       - name: Test connection to Kubernetes cluster
         run: |
           kubectl cluster-info

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -53,20 +53,13 @@ jobs:
         with:
           version: v2.4.8
           args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
-      - name: Install kind and create cluster
-        run: >
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION
-          }}/kind-linux-amd64
 
-          chmod +x ./kind
+      - name: Setup Kubernetes cluster (KIND)
+        uses: engineerd/setup-kind@v0.6.2
+        with:
+          version: ${{ env.KIND_VERSION }}
+          image: ${{ env.KIND_IMAGE }}
 
-          sudo mv ./kind /usr/local/bin/kind
-
-          kind create cluster
-
-          curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
-
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: Test connection to Kubernetes cluster
         run: |
           kubectl cluster-info


### PR DESCRIPTION
## Description
This PR uses kind action instead of install kind script for github workflows.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
