### PR TITLE
ci: remove kind deletion

### DIFF
--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -104,6 +104,3 @@ jobs:
           ./bin/kuttl test --start-kind=false --config tests/e2e/config/image-private-registries-sa.yaml
 
           ./tests/resources-cleanup-private.sh > /dev/null 2>&1
-      - name: Delete kind cluster
-        run: |
-          kind delete cluster


### PR DESCRIPTION
## Description

setup-kind auto deletes the cluster post usage https://github.com/engineerd/setup-kind/pull/49

Currently the CI jobs fail to delete the missing cluster


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
