### PR TITLE
chore: use a correct default repo for node-collector

### DIFF
--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -120,7 +120,7 @@ func GetDefaultConfig() ConfigData {
 		KeyScanJobcompressLogs:          "true",
 		keyComplianceFailEntriesLimit:   "10",
 		KeyReportRecordFailedChecksOnly: "true",
-		KeyNodeCollectorImageRef:        "gcr.io/aquasecurity/node-collector:0.3.1",
+		KeyNodeCollectorImageRef:        "ghcr.io/aquasecurity/node-collector:0.3.1",
 		KeyPoliciesBundleOciRef:         "mirror.gcr.io/aquasec/trivy-checks:1",
 	}
 }


### PR DESCRIPTION
## Description

This PR sets a correct default value for a node-collector repo.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
