### PR TITLE
ci: add ubi images for vuln pre-release scanning

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -48,6 +48,12 @@ jobs:
           image-ref: 'mirror.gcr.io/aquasec/trivy-operator:${{ github.sha }}-amd64'
           exit-code: '1'
           ignore-unfixed: true
+      - name: Scan Trivy Operator (ubi) image for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'mirror.gcr.io/aquasec/trivy-operator:${{ github.sha }}-ubi9-amd64'
+          exit-code: '1'
+          ignore-unfixed: true
       - name: Notify dedicated teams channel
         uses: jdcargile/ms-teams-notification@v1.4
         if: failure()


### PR DESCRIPTION
## Description
This pull request adds a new step to the release snapshot workflow to enhance security by scanning an additional image for vulnerabilities.

Workflow enhancements:

* [`.github/workflows/release-snapshot.yaml`](diffhunk://#diff-237e89a82f696b00a56feb5feabd760fa7ff2baf5c7678b7b86a47364e8e6605R51-R56): Added a step to scan the `mirror.gcr.io/aquasec/trivy-operator:${{ github.sha }}-ubi9-amd64` image for vulnerabilities using the `aquasecurity/trivy-action` GitHub Action.


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
