### PR TITLE
fix: correct predicate logic to allow whitelisted ConfigMaps

### DIFF
--- a/pkg/configauditreport/controller/checks.go
+++ b/pkg/configauditreport/controller/checks.go
@@ -102,7 +102,7 @@ var allowedConfigMaps = set.New(
 var configPredicate = func(namespace string) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if allowedConfigMaps.Contains(obj.GetName()) {
-			return false
+			return true
 		}
 		return obj.GetNamespace() == namespace
 	})


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy-operator/issues/2629

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
