### PR TITLE
fix(ci): use multiline syntax to print logs on failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -275,7 +275,7 @@ jobs:
 
       - name: The job has failed - print the logs
         if: ${{ failure() }}
-        run: >
+        run: |
           kubectl logs -n trivy-system deployment/trivy-operator
           echo "reports:"
           kubectl get clustervulnerabilityreports.aquasecurity.github.io -A


### PR DESCRIPTION
## Description

Fixes an error where multiple commands were joined into one, causing `kubectl` to misinterpret flags.

```bash
Run kubectl logs -n trivy-system deployment/trivy-operator echo "reports:" kubectl get clustervulnerabilityreports.aquasecurity.github.io -A
  kubectl logs -n trivy-system deployment/trivy-operator echo "reports:" kubectl get clustervulnerabilityreports.aquasecurity.github.io -A
  shell: /usr/bin/bash -e {0}
  env:
    KIND_VERSION: v0.[2](https://github.com/aquasecurity/trivy-operator/actions/runs/16005323687/job/45151546248?pr=2631#step:20:2)9.0
    KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
    DOCKER_CLI_EXPERIMENTAL: enabled
error: unknown shorthand flag: 'A' in -A
See 'kubectl logs --help' for usage.
```

- https://github.com/aquasecurity/trivy-operator/actions/runs/16005323687/job/45151546248?pr=2631

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
