### PR TITLE
chore: use ids instead of builds and remove unused format_overrides in goreleaser archives

### DIFF
--- a/goreleaser-e2e.yaml
+++ b/goreleaser-e2e.yaml
@@ -20,11 +20,8 @@ builds:
       - amd64
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - trivy-operator
-    format_overrides:
-      - goos: windows
-        format: zip
 checksum:
   name_template: checksums.txt
 snapshot:


### PR DESCRIPTION
## Description

Update goreleaser-e2e.yaml to fix archives section:  
- replaced `builds` with `ids` . See https://goreleaser.com/deprecations/#archivesbuilds
- removed unused `format_overrides` since Windows builds are not produced 

Before:
```bash
❯ goreleaser check goreleaser-e2e.yaml
  • checking                                 path=goreleaser-e2e.yaml
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.builds  should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
  • goreleaser-e2e.yaml                              error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:
```bash
❯ goreleaser check goreleaser-e2e.yaml
  • checking                                 path=goreleaser-e2e.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
