### PR TITLE
docs: fix typo in RELEASING.md for Helm chart file name

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@
       2. Update the `appVersion` property
    2. Update the `app.kubernetes.io/version` labels in the following files:
       1. [`deploy/static/namespace.yaml`]
-      2. [`deploy/helm/templates/specs/nsa-1.0.yaml`]
+      2. [`deploy/helm/templates/specs/k8s-nsa-1.0.yaml`]
    3. Update static resources from Helm chart by running the mage target:
 
       ```sh


### PR DESCRIPTION
## Description

This PR fixes a typo in the `RELEASING.md` documentation by updating the Helm chart file name from `nsa-1.0.yaml` to `k8s-nsa-1.0.yaml`

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
