### PR TITLE
chore: bump up UBI version to 9.6-1751445649

### DIFF
--- a/build/trivy-operator/Dockerfile.ubi9
+++ b/build/trivy-operator/Dockerfile.ubi9
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:e12131db2e2b6572613589a94b7f615d4ac89d94f859dad05908aeb478fb090f
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:383329bf9c4f968e87e85d30ba3a5cb988a3bbde28b8e4932dcd3a025fd9c98c
 
 RUN microdnf install shadow-utils
 RUN useradd -u 10000 trivyoperator


### PR DESCRIPTION
## Description

This PR bumps up UBI to the latest version that was released July 02, 2025.

```sh
$ mage build:binary
Building trivy-operator binary...
$ mage build:dockerUbi9
...
$ trivy i docker.io/aquasecurity/trivy-operator:dev-ubi9 --cache-backend memory
```

<details>
<summary>the scan result</summary>

```sh
Report Summary

┌─────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                           Target                            │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6) │  redhat  │       44        │    -    │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                                │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


docker.io/aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6)

Total: 44 (UNKNOWN: 0, LOW: 33, MEDIUM: 9, HIGH: 2, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬──────────────┬─────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │    Status    │  Installed Version  │ Fixed Version │                            Title                             │
├──────────────────┼────────────────┼──────────┼──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ coreutils-single │ CVE-2025-5278  │ MEDIUM   │ affected     │ 8.32-39.el9         │               │ coreutils: Heap Buffer Under-Read in GNU Coreutils sort via  │
│                  │                │          │              │                     │               │ Key Specification                                            │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5278                    │
├──────────────────┼────────────────┼──────────┤              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ curl-minimal     │ CVE-2024-11053 │ LOW      │              │ 7.76.1-31.el9       │               │ curl: curl netrc password leak                               │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-11053                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-7264  │          │              │                     │               │ curl: libcurl: ASN.1 date parser overread                    │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-7264                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-9681  │          │              │                     │               │ curl: HSTS subdomain overwrites parent cache entry           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-9681                    │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ gawk             │ CVE-2023-4156  │          │              │ 5.1.0-6.el9         │               │ gawk: heap out of bound read in builtin.c                    │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-4156                    │
├──────────────────┼────────────────┼──────────┼──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ glib2            │ CVE-2024-52533 │ MEDIUM   │ will_not_fix │ 2.68.4-16.el9       │               │ glib: buffer overflow in set_connect_msg()                   │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-52533                   │
│                  ├────────────────┤          ├──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-4373  │          │ affected     │                     │               │ glib: Buffer Underflow on GLib through glib/gstring.c via    │
│                  │                │          │              │                     │               │ function g_string_insert_unichar                             │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-4373                    │
│                  ├────────────────┼──────────┤              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-32636 │ LOW      │              │                     │               │ glib: Timeout in fuzz_variant_text                           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-32636                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-3360  │          │              │                     │               │ glibc: GLib prior to 2.82.5 is vulnerable to integer         │
│                  │                │          │              │                     │               │ overflow and...                                              │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-3360                    │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ gnupg2           │ CVE-2022-3219  │          │              │ 2.3.3-4.el9         │               │ gnupg: denial of service issue (resource consumption) using  │
│                  │                │          │              │                     │               │ compressed packets                                           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-3219                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-30258 │          │              │                     │               │ gnupg: verification DoS due to a malicious subkey in the     │
│                  │                │          │              │                     │               │ keyring                                                      │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-30258                   │
├──────────────────┼────────────────┼──────────┼──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libarchive       │ CVE-2023-30571 │ MEDIUM   │ will_not_fix │ 3.5.3-5.el9_6       │               │ libarchive: Race condition in multi-threaded use of          │
│                  │                │          │              │                     │               │ archive_write_disk_header() on posix based systems...        │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-30571                   │
│                  ├────────────────┼──────────┼──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-1632  │ LOW      │ affected     │                     │               │ libarchive: null pointer dereference in bsdunzip.c           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-1632                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-5914  │          │              │                     │               │ libarchive: Double free at                                   │
│                  │                │          │              │                     │               │ archive_read_format_rar_seek_data() in                       │
│                  │                │          │              │                     │               │ archive_read_support_format_rar.c                            │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5914                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-5915  │          │              │                     │               │ libarchive: Heap buffer over read in copy_from_lzss_window() │
│                  │                │          │              │                     │               │ at archive_read_support_format_rar.c                         │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5915                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-5916  │          │              │                     │               │ libarchive: Integer overflow while reading warc files at     │
│                  │                │          │              │                     │               │ archive_read_support_format_warc.c                           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5916                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-5917  │          │              │                     │               │ libarchive: Off by one error in build_ustar_entry_name() at  │
│                  │                │          │              │                     │               │ archive_write_set_format_pax.c                               │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5917                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-5918  │          │              │                     │               │ libarchive: Reading past EOF may be triggered for piped file │
│                  │                │          │              │                     │               │ streams                                                      │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5918                    │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libatomic        │ CVE-2022-27943 │          │              │ 11.5.0-5.el9_5      │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                │          │              │                     │               │ stack exhaustion in demangle_const                           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcurl-minimal  │ CVE-2024-11053 │          │              │ 7.76.1-31.el9       │               │ curl: curl netrc password leak                               │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-11053                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-7264  │          │              │                     │               │ curl: libcurl: ASN.1 date parser overread                    │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-7264                    │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-9681  │          │              │                     │               │ curl: HSTS subdomain overwrites parent cache entry           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-9681                    │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgcc           │ CVE-2022-27943 │          │              │ 11.5.0-5.el9_5      │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                │          │              │                     │               │ stack exhaustion in demangle_const                           │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┤                │          │              │                     ├───────────────┤                                                              │
│ libstdc++        │                │          │              │                     │               │                                                              │
│                  │                │          │              │                     │               │                                                              │
│                  │                │          │              │                     │               │                                                              │
├──────────────────┼────────────────┼──────────┤              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2          │ CVE-2025-49794 │ HIGH     │              │ 2.9.13-9.el9_6      │               │ libxml: Heap use after free (UAF) leads to Denial of service │
│                  │                │          │              │                     │               │ (DoS)...                                                     │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-49794                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-49796 │          │              │                     │               │ libxml: Type confusion leads to Denial of service (DoS)      │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-49796                   │
│                  ├────────────────┼──────────┤              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-32414 │ MEDIUM   │              │                     │               │ libxml2: Out-of-Bounds Read in libxml2                       │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-32414                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-32415 │          │              │                     │               │ libxml2: Out-of-bounds Read in xmlSchemaIDCFillNodeTables    │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-32415                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-6021  │          │              │                     │               │ libxml2: Integer Overflow in xmlBuildQName() Leads to Stack  │
│                  │                │          │              │                     │               │ Buffer Overflow in libxml2...                                │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-6021                    │
│                  ├────────────────┼──────────┼──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-45322 │ LOW      │ will_not_fix │                     │               │ libxml2: use-after-free in xmlUnlinkNode() in tree.c         │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-45322                   │
│                  ├────────────────┤          ├──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-34459 │          │ affected     │                     │               │ libxml2: buffer over-read in xmlHTMLPrintFileContext in      │
│                  │                │          │              │                     │               │ xmllint.c                                                    │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-34459                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-27113 │          │              │                     │               │ libxml2: NULL Pointer Dereference in libxml2 xmlPatMatch     │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-27113                   │
│                  ├────────────────┤          │              │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-6170  │          │              │                     │               │ libxml2: Stack Buffer Overflow in xmllint Interactive Shell  │
│                  │                │          │              │                     │               │ Command Handling                                             │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-6170                    │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ ncurses-base     │ CVE-2022-29458 │          │              │ 6.2-10.20210508.el9 │               │ ncurses: segfaulting OOB read                                │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-29458                   │
│                  ├────────────────┤          ├──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-50495 │          │ will_not_fix │                     │               │ ncurses: segmentation fault via _nc_wrap_entry()             │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-50495                   │
├──────────────────┼────────────────┤          ├──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│ ncurses-libs     │ CVE-2022-29458 │          │ affected     │                     │               │ ncurses: segfaulting OOB read                                │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-29458                   │
│                  ├────────────────┤          ├──────────────┤                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-50495 │          │ will_not_fix │                     │               │ ncurses: segmentation fault via _nc_wrap_entry()             │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-50495                   │
├──────────────────┼────────────────┤          ├──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ openldap         │ CVE-2023-2953  │          │ affected     │ 2.6.8-4.el9         │               │ openldap: null pointer dereference in ber_memalloc_x         │
│                  │                │          │              │                     │               │ function                                                     │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2023-2953                    │
├──────────────────┼────────────────┤          ├──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ openssl-libs     │ CVE-2024-41996 │          │ will_not_fix │ 1:3.2.2-6.el9_5.1   │               │ openssl: remote attackers (from the client side) to trigger  │
│                  │                │          │              │                     │               │ unnecessarily expensive server-side...                       │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-41996                   │
├──────────────────┼────────────────┤          │              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ pcre2            │ CVE-2022-41409 │          │              │ 10.40-6.el9         │               │ pcre2: negative repeat value in a pcre2test subject line     │
│                  │                │          │              │                     │               │ leads to inifinite...                                        │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2022-41409                   │
├──────────────────┤                │          │              │                     ├───────────────┤                                                              │
│ pcre2-syntax     │                │          │              │                     │               │                                                              │
│                  │                │          │              │                     │               │                                                              │
│                  │                │          │              │                     │               │                                                              │
├──────────────────┼────────────────┼──────────┼──────────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ shadow-utils     │ CVE-2024-56433 │ MEDIUM   │ affected     │ 2:4.9-12.el9        │               │ shadow-utils: Default subordinate ID configuration in        │
│                  │                │          │              │                     │               │ /etc/login.defs could lead to compromise                     │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-56433                   │
├──────────────────┼────────────────┼──────────┤              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ sqlite-libs      │ CVE-2024-0232  │ LOW      │              │ 3.34.1-7.el9_3      │               │ sqlite: use-after-free bug in jsonParseAddNodeArray          │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2024-0232                    │
├──────────────────┼────────────────┼──────────┤              ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ systemd-libs     │ CVE-2025-4598  │ MEDIUM   │              │ 252-51.el9_6.1      │               │ systemd-coredump: race condition that allows a local         │
│                  │                │          │              │                     │               │ attacker to crash a SUID...                                  │
│                  │                │          │              │                     │               │ https://avd.aquasec.com/nvd/cve-2025-4598                    │
└──────────────────┴────────────────┴──────────┴──────────────┴─────────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```
</details>

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
