### PR TITLE
feat: Added support for dual-stack for metric service

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.1
+version: 0.29.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -114,6 +114,8 @@ Keeps security report resources updated
 | service.metricsPort | int | `80` | port exposed by the Service |
 | service.nodePort | string | `nil` | the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one. |
 | service.type | string | `"ClusterIP"` | the Service type |
+| service.ipFamilyPolicy | string | `""` | The IP family policy used for the service |
+| service.ipFamilies | list | `[]` | List of IP families for the service. Can be "IPv4" and/or "IPv6" |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |

--- a/deploy/helm/templates/monitor/service.yaml
+++ b/deploy/helm/templates/monitor/service.yaml
@@ -11,6 +11,12 @@ spec:
   {{- if and (.Values.service.headless) (eq .Values.service.type "ClusterIP") }}
   clusterIP: None
   {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -225,6 +225,11 @@ service:
   type: ClusterIP
   # -- the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one.
   nodePort:
+  # -- the IP family policy for the Service to be able to configure dual-stack; see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+  ipFamilyPolicy: ""
+  # -- a list of IP families for the Service that should be supported, in the order in which they should be applied to ClusterIP. Can be "IPv4" and/or "IPv6".
+  ipFamilies: []
+
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will


### PR DESCRIPTION
## Description

Small change to add support to configure dual-stack for the monitoring service.
The default behavior shouldn't change with this.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
