### PR TITLE
fix: add ubi9 images for nightly testing

### DIFF
--- a/goreleaser-e2e.yaml
+++ b/goreleaser-e2e.yaml
@@ -57,7 +57,28 @@ dockers:
       - --label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{
         .Version }}/
       - --platform=linux/amd64
+  - image_templates:
+      - "mirror.gcr.io/aquasec/trivy-operator:{{ .Version }}-ubi9-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/trivy-operator/Dockerfile.ubi9
+    goarch: amd64
+    ids:
+      - trivy-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=trivy-operator"
+      - "--label=org.opencontainers.image.description=Keeps trivy-operator resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy-operator"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy-operator/v{{ .Version }}/"
+      - "--platform=linux/amd64"
 docker_manifests:
   - name_template: mirror.gcr.io/aquasec/trivy-operator:{{ .Version }}
     image_templates:
       - mirror.gcr.io/aquasec/trivy-operator:{{ .Version }}-amd64
+  - name_template: "mirror.gcr.io/aquasec/trivy-operator:{{ .Version }}-ubi9"
+    image_templates:
+      - "mirror.gcr.io/aquasec/trivy-operator:{{ .Version }}-ubi9-amd64"


### PR DESCRIPTION
## Description

fix: add ubi9 images for nightly testing

 
## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
