### PR TITLE
fix: bump ubi9 image to latest release

### DIFF
--- a/build/trivy-operator/Dockerfile.ubi9
+++ b/build/trivy-operator/Dockerfile.ubi9
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:383329bf9c4f968e87e85d30ba3a5cb988a3bbde28b8e4932dcd3a025fd9c98c
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:aa891eebbcaf8a9e9a3ba6f5797b5b03f3f3d38578f822ef07368bf5e010d79
 
 RUN microdnf install shadow-utils
 RUN useradd -u 10000 trivyoperator


### PR DESCRIPTION
## Description

fix: bump ubi9 image to latest release

## Related issues
- Resolve https://github.com/aquasecurity/trivy-operator/actions/runs/16208559040/job/45764118008


## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
