### PR TITLE
chore: bump up UBI 9 version to 9.6-1752587672

### DIFF
--- a/build/trivy-operator/Dockerfile.ubi9
+++ b/build/trivy-operator/Dockerfile.ubi9
@@ -1,7 +1,7 @@
 # If you need to update the base image, please refer to the following link:
 # https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti&gti-tabs=unauthenticated
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:11db23b63f9476e721f8d0b8a2de5c858571f76d5a0dae2ec28adf08cbaf3652
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:6d5a6576c83816edcc0da7ed62ba69df8f6ad3cbe659adde2891bfbec4dbf187
 
 RUN microdnf install shadow-utils
 RUN useradd -u 10000 trivyoperator


### PR DESCRIPTION
## Description

This PR bumps up UBI9 version to 9.6-1752587672.

Before:
```sh
trivy i --cache-backend=memory --ignore-unfixed docker.io/aquasecurity/trivy-operator:dev-ubi9 -q

Report Summary

┌─────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                           Target                            │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6) │  redhat  │        2        │    -    │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                                │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


docker.io/aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │   Fixed Version   │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────────┼───────────────────────────────────────────────────────────┤
│ glib2   │ CVE-2024-52533 │ MEDIUM   │ fixed  │ 2.68.4-16.el9     │ 2.68.4-16.el9_6.2 │ glib: buffer overflow in set_connect_msg()                │
│         │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2024-52533                │
│         ├────────────────┤          │        │                   │                   ├───────────────────────────────────────────────────────────┤
│         │ CVE-2025-4373  │          │        │                   │                   │ glib: Buffer Underflow on GLib through glib/gstring.c via │
│         │                │          │        │                   │                   │ function g_string_insert_unichar                          │
│         │                │          │        │                   │                   │ https://avd.aquasec.com/nvd/cve-2025-4373                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────────┴───────────────────────────────────────────────────────────┘
```
After:
```sh
trivy i --cache-backend=memory --ignore-unfixed docker.io/aquasecurity/trivy-operator:dev-ubi9 -q

Report Summary

┌─────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                           Target                            │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/aquasecurity/trivy-operator:dev-ubi9 (redhat 9.6) │  redhat  │        0        │    -    │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                                │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
