### PR TITLE
feat: Vulnerability Report Reconciliation Reduction

### DIFF
--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -237,13 +237,13 @@ func WorkloadPodSpecChangedPredicate() predicate.Predicate {
 			// Only reconcile if podSpec actually changed
 			return oldHash != newHash
 		},
-		CreateFunc: func(e event.CreateEvent) bool {
+		CreateFunc: func(_ event.CreateEvent) bool {
 			return true // Always process new workloads
 		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return true // Always process deletions (for cleanup)
 		},
-		GenericFunc: func(e event.GenericEvent) bool {
+		GenericFunc: func(_ event.GenericEvent) bool {
 			return true // Process generic events
 		},
 	}

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
@@ -32,6 +34,45 @@ import (
 )
 
 const trivyServerUp = "trivy_server_up"
+
+// WorkloadPodSpecChangedPredicate creates a predicate that only triggers reconciliation
+// when the workload's podSpec actually changes, not just metadata updates.
+func WorkloadPodSpecChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true // Always process creation/deletion
+			}
+
+			// Extract podSpecs from both old and new objects
+			oldPodSpec, err := kube.GetPodSpec(e.ObjectOld)
+			if err != nil {
+				return true // If we can't get podSpec, process it
+			}
+
+			newPodSpec, err := kube.GetPodSpec(e.ObjectNew)
+			if err != nil {
+				return true // If we can't get podSpec, process it
+			}
+
+			// Compare podSpec hashes
+			oldHash := kube.ComputeHash(oldPodSpec)
+			newHash := kube.ComputeHash(newPodSpec)
+
+			// Only reconcile if podSpec actually changed
+			return oldHash != newHash
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true // Always process new workloads
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true // Always process deletions
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return true // Process generic events
+		},
+	}
+}
 
 // WorkloadController watches Kubernetes workloads and generates
 // v1alpha1.VulnerabilityReport instances using vulnerability scanner that that
@@ -110,6 +151,7 @@ func (r *WorkloadController) SetupWithManager(mgr ctrl.Manager) error {
 				Not(ManagedByTrivyOperator),
 				Not(IsBeingTerminated),
 				installModePredicate,
+				WorkloadPodSpecChangedPredicate(), // Only reconcile when podSpec changes
 			)).
 			Owns(&v1alpha1.VulnerabilityReport{}).
 			Owns(&v1alpha1.ExposedSecretReport{}).

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -14,8 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
@@ -34,45 +32,6 @@ import (
 )
 
 const trivyServerUp = "trivy_server_up"
-
-// WorkloadPodSpecChangedPredicate creates a predicate that only triggers reconciliation
-// when the workload's podSpec actually changes, not just metadata updates.
-func WorkloadPodSpecChangedPredicate() predicate.Predicate {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectOld == nil || e.ObjectNew == nil {
-				return true // Always process creation/deletion
-			}
-
-			// Extract podSpecs from both old and new objects
-			oldPodSpec, err := kube.GetPodSpec(e.ObjectOld)
-			if err != nil {
-				return true // If we can't get podSpec, process it
-			}
-
-			newPodSpec, err := kube.GetPodSpec(e.ObjectNew)
-			if err != nil {
-				return true // If we can't get podSpec, process it
-			}
-
-			// Compare podSpec hashes
-			oldHash := kube.ComputeHash(oldPodSpec)
-			newHash := kube.ComputeHash(newPodSpec)
-
-			// Only reconcile if podSpec actually changed
-			return oldHash != newHash
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return true // Always process new workloads
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return true // Always process deletions
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return true // Process generic events
-		},
-	}
-}
 
 // WorkloadController watches Kubernetes workloads and generates
 // v1alpha1.VulnerabilityReport instances using vulnerability scanner that that


### PR DESCRIPTION
## Description

This PR implements a predicate-based optimization for the WorkloadController that reduces unnecessary reconciliations by only triggering when the actual container specifications change, rather than on every metadata update.

Currently the WorkloadController is reconciling on every workload update, including trivial metadata changes like labels, annotations, and status updates that don't impact vulnerability related concerns. The proposed predicate extracts podSpecs from both old and new workload versions, computes and compares hashes of the podSpecs using the existing kube.ComputeHash() function, and only allows reconciliation when container specifications actually change. The predicate is integrated into the controller setup alongside existing predicates, ensuring that the controller still processes creation, deletion, and generic events normally while filtering out unnecessary update events. 

Container image updates, new containers being added or removed, environment variable changes affecting container runtime, and volume mount modifications will still trigger reconciliation as expected. However, changes to labels, annotations, replica counts, status updates, and resource limits that don't affect the containers being scanned will no longer cause unnecessary processing.

## Related issues
- N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
