### PR TITLE
perf: use protobuf for k8s api

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,6 +131,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 
 	kubeConfig, err := ctrl.GetConfig()
 	kubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
+	kubeConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 
 	if err != nil {
 		return fmt.Errorf("getting kube client config: %w", err)


### PR DESCRIPTION
## Description

perf: use protobuf for k8s api

## Related issues
- Address  https://github.com/aquasecurity/trivy-operator/issues/2541

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
