### PR TITLE
perf: strip data fields from all ConfigMaps except operator configs

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -72,7 +72,6 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 				DisableFor: []client.Object{
 					&corev1.Secret{},
 					&corev1.ServiceAccount{},
-					&corev1.ConfigMap{},
 				},
 			},
 		},
@@ -90,6 +89,13 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 					}
 				}
 
+				if cm, ok := obj.(*corev1.ConfigMap); ok {
+					// Strip data from ALL ConfigMaps except the two operator ConfigMaps
+					if cm.Name != trivyoperator.PoliciesConfigMapName && cm.Name != trivyoperator.TrivyConfigMapName {
+						cm.Data = nil
+						cm.BinaryData = nil
+					}
+				}
 				return obj, nil
 			},
 		},


### PR DESCRIPTION
To reduce memory usage and avoid operator restarts due to large ConfigMap objects, this change disables caching of `data` and `binaryData` fields for all ConfigMaps except `trivy-operator-policies-config` and `trivy-operator-trivy-config`.