### PR TITLE
fix: send webhook reports when altstorage is used

### DIFF
--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -88,11 +88,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 				log.Info("Cluster compliance report written", "path", reportPath)
 
 				// Send webhook notification for compliance report
-				if r.Config.WebhookBroadcastURL != "" {
-					if err := webhook.SendWebhookReport(&report, r.Config); err != nil {
-						log.Error(err, "Failed to send compliance report via webhook")
-					}
-				}
+				webhook.SendWebhookReport(&report, r.Config, log)
 
 				return nil
 			}

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -88,7 +88,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 				log.Info("Cluster compliance report written", "path", reportPath)
 
 				// Send webhook notification for compliance report
-				webhook.SendWebhookReport(&report, r.Config, log)
+				webhook.SendWebhookReport(reportData, r.Config, log)
 
 				return nil
 			}

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
 	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
 	"github.com/aquasecurity/trivy-operator/pkg/utils"
+	"github.com/aquasecurity/trivy-operator/pkg/webhook"
 )
 
 type ClusterComplianceReportReconciler struct {
@@ -85,6 +86,15 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 					return err
 				}
 				log.Info("Cluster compliance report written", "path", reportPath)
+
+				// Send webhook notification for compliance report
+				if r.Config.WebhookBroadcastURL != "" {
+					if err := webhook.SendWebhookReport(&report, r.Config); err != nil {
+						log.Error(err, "Failed to send compliance report via webhook")
+					}
+				}
+
+				return nil
 			}
 			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
 			if err != nil {

--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -88,9 +88,7 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 				log.Info("Cluster compliance report written", "path", reportPath)
 
 				// Send webhook notification for compliance report
-				webhook.SendWebhookReport(reportData, r.Config, log)
-
-				return nil
+				webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 			}
 			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
 			if err != nil {

--- a/pkg/compliance/clustercompliancereport_test.go
+++ b/pkg/compliance/clustercompliancereport_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 

--- a/pkg/compliance/clustercompliancereport_test.go
+++ b/pkg/compliance/clustercompliancereport_test.go
@@ -3,14 +3,21 @@ package compliance
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -149,4 +156,83 @@ func TestClusterComplianceReconciler_generateComplianceReport(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testingLogger(t *testing.T) logr.Logger {
+	return testr.NewWithOptions(t, testr.Options{Verbosity: 1})
+}
+
+type dummyMgr struct{}
+
+func (d dummyMgr) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportSpec) error {
+	// No-op for testing webhook
+	return nil
+}
+
+func TestClusterComplianceReportReconciler_WebhookCalled(t *testing.T) {
+	webhookCalled := false
+	var receivedBody string
+
+	// Mock webhook server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookCalled = true
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	report := &v1alpha1.ClusterComplianceReport{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigAuditReport"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-report"},
+		Spec: v1alpha1.ReportSpec{
+			ReportFormat: "summary",
+			Cron:         "0 */6 * * *",
+			Compliance: v1alpha1.Compliance{
+				ID:    "nsa",
+				Title: "nsa",
+				Controls: []v1alpha1.Control{
+					{
+						ID:          "1.0",
+						Description: "check root permission",
+						Checks: []v1alpha1.SpecCheck{
+							{
+								ID: "AVD-KSV-0001",
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.ReportStatus{
+			UpdateTimestamp: metav1.Time{Time: time.Now()},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(report).Build()
+	timeout := 10 * time.Second
+
+	cfg := etc.Config{
+		AltReportStorageEnabled:     true,
+		AltReportDir:                t.TempDir(),
+		WebhookBroadcastURL:         mockServer.URL,
+		InvokeClusterComplianceOnce: true,
+		WebhookBroadcastTimeout:     &timeout,
+	}
+
+	reconciler := &ClusterComplianceReportReconciler{
+		Client: fakeClient,
+		Config: cfg,
+		Logger: testingLogger(t),
+		Mgr:    dummyMgr{}, // No-op compliance generator
+		Clock:  ext.NewSystemClock(),
+	}
+
+	_, err := reconciler.generateComplianceReport(context.TODO(), types.NamespacedName{Name: "test-report"})
+	require.NoError(t, err)
+
+	assert.True(t, webhookCalled, "Expected webhook to be called")
+	assert.True(t, strings.Contains(receivedBody, "test-report"), "Expected report name in webhook payload")
 }

--- a/pkg/compliance/clustercompliancereport_test.go
+++ b/pkg/compliance/clustercompliancereport_test.go
@@ -164,7 +164,7 @@ func testingLogger(t *testing.T) logr.Logger {
 
 type dummyMgr struct{}
 
-func (d dummyMgr) GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportSpec) error {
+func (d dummyMgr) GenerateComplianceReport(_ context.Context, _ v1alpha1.ReportSpec) error {
 	// No-op for testing webhook
 	return nil
 }
@@ -230,9 +230,9 @@ func TestClusterComplianceReportReconciler_WebhookCalled(t *testing.T) {
 		Clock:  ext.NewSystemClock(),
 	}
 
-	_, err := reconciler.generateComplianceReport(context.TODO(), types.NamespacedName{Name: "test-report"})
+	_, err := reconciler.generateComplianceReport(t.Context(), types.NamespacedName{Name: "test-report"})
 	require.NoError(t, err)
 
 	assert.True(t, webhookCalled, "Expected webhook to be called")
-	assert.True(t, strings.Contains(receivedBody, "test-report"), "Expected report name in webhook payload")
+	assert.Contains(t, receivedBody, "test-report", "Expected report name in webhook payload")
 }

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -336,7 +336,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Config audit report written", "path", configReportPath)
 
 		// Send webhook notification for config audit report
-		webhook.SendWebhookReport(misConfigData.configAuditReportData, r.Config, log)
+		webhook.SendWebhookReport(configReportData, r.Config, log)
 
 		// Write infra assessment report to a file
 		infraReportData, err := json.Marshal(misConfigData.infraAssessmentReportData)
@@ -351,7 +351,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Infra assessment report written", "path", infraReportPath)
 
 		// Send webhook notification for infra assessment report
-		webhook.SendWebhookReport(misConfigData.infraAssessmentReportData, r.Config, log)
+		webhook.SendWebhookReport(infraReportData, r.Config, log)
 
 		// Write RBAC assessment report to a file
 		rbacReportData, err := json.Marshal(misConfigData.rbacAssessmentReportData)
@@ -366,7 +366,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("RBAC assessment report written", "path", rbacReportPath)
 
 		// Send webhook notification for RBAC assessment report
-		webhook.SendWebhookReport(misConfigData.rbacAssessmentReportData, r.Config, log)
+		webhook.SendWebhookReport(rbacReportData, r.Config, log)
 
 	}
 	return ctrl.Result{}, nil

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
+	"github.com/aquasecurity/trivy-operator/pkg/webhook"
 )
 
 // ResourceController watches all Kubernetes kinds and generates
@@ -334,6 +335,13 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		}
 		log.Info("Config audit report written", "path", configReportPath)
 
+		// Send webhook notification for config audit report
+		if r.Config.WebhookBroadcastURL != "" {
+			if err := webhook.SendWebhookReport(misConfigData.configAuditReportData, r.Config); err != nil {
+				log.Error(err, "Failed to send config audit report via webhook")
+			}
+		}
+
 		// Write infra assessment report to a file
 		infraReportData, err := json.Marshal(misConfigData.infraAssessmentReportData)
 		if err != nil {
@@ -346,6 +354,13 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		}
 		log.Info("Infra assessment report written", "path", infraReportPath)
 
+		// Send webhook notification for infra assessment report
+		if r.Config.WebhookBroadcastURL != "" {
+			if err := webhook.SendWebhookReport(misConfigData.infraAssessmentReportData, r.Config); err != nil {
+				log.Error(err, "Failed to send infra assessment report via webhook")
+			}
+		}
+
 		// Write RBAC assessment report to a file
 		rbacReportData, err := json.Marshal(misConfigData.rbacAssessmentReportData)
 		if err != nil {
@@ -357,6 +372,13 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 			return ctrl.Result{}, err
 		}
 		log.Info("RBAC assessment report written", "path", rbacReportPath)
+
+		// Send webhook notification for RBAC assessment report
+		if r.Config.WebhookBroadcastURL != "" {
+			if err := webhook.SendWebhookReport(misConfigData.rbacAssessmentReportData, r.Config); err != nil {
+				log.Error(err, "Failed to send RBAC assessment report via webhook")
+			}
+		}
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -32,8 +32,8 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/policy"
 	"github.com/aquasecurity/trivy-operator/pkg/rbacassessment"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
-	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy-operator/pkg/webhook"
+	"github.com/aquasecurity/trivy/pkg/iac/scan"
 )
 
 // ResourceController watches all Kubernetes kinds and generates

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -336,11 +336,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Config audit report written", "path", configReportPath)
 
 		// Send webhook notification for config audit report
-		if r.Config.WebhookBroadcastURL != "" {
-			if err := webhook.SendWebhookReport(misConfigData.configAuditReportData, r.Config); err != nil {
-				log.Error(err, "Failed to send config audit report via webhook")
-			}
-		}
+		webhook.SendWebhookReport(misConfigData.configAuditReportData, r.Config, log)
 
 		// Write infra assessment report to a file
 		infraReportData, err := json.Marshal(misConfigData.infraAssessmentReportData)
@@ -355,11 +351,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Infra assessment report written", "path", infraReportPath)
 
 		// Send webhook notification for infra assessment report
-		if r.Config.WebhookBroadcastURL != "" {
-			if err := webhook.SendWebhookReport(misConfigData.infraAssessmentReportData, r.Config); err != nil {
-				log.Error(err, "Failed to send infra assessment report via webhook")
-			}
-		}
+		webhook.SendWebhookReport(misConfigData.infraAssessmentReportData, r.Config, log)
 
 		// Write RBAC assessment report to a file
 		rbacReportData, err := json.Marshal(misConfigData.rbacAssessmentReportData)
@@ -374,11 +366,8 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("RBAC assessment report written", "path", rbacReportPath)
 
 		// Send webhook notification for RBAC assessment report
-		if r.Config.WebhookBroadcastURL != "" {
-			if err := webhook.SendWebhookReport(misConfigData.rbacAssessmentReportData, r.Config); err != nil {
-				log.Error(err, "Failed to send RBAC assessment report via webhook")
-			}
-		}
+		webhook.SendWebhookReport(misConfigData.rbacAssessmentReportData, r.Config, log)
+
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -336,7 +336,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Config audit report written", "path", configReportPath)
 
 		// Send webhook notification for config audit report
-		webhook.SendWebhookReport(configReportData, r.Config, log)
+		webhook.SendWebhookReportIfAvailable(configReportData, r.Config, log)
 
 		// Write infra assessment report to a file
 		infraReportData, err := json.Marshal(misConfigData.infraAssessmentReportData)
@@ -351,7 +351,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("Infra assessment report written", "path", infraReportPath)
 
 		// Send webhook notification for infra assessment report
-		webhook.SendWebhookReport(infraReportData, r.Config, log)
+		webhook.SendWebhookReportIfAvailable(infraReportData, r.Config, log)
 
 		// Write RBAC assessment report to a file
 		rbacReportData, err := json.Marshal(misConfigData.rbacAssessmentReportData)
@@ -366,7 +366,7 @@ func (r *ResourceController) writeAlternateReports(resource client.Object, misCo
 		log.Info("RBAC assessment report written", "path", rbacReportPath)
 
 		// Send webhook notification for RBAC assessment report
-		webhook.SendWebhookReport(rbacReportData, r.Config, log)
+		webhook.SendWebhookReportIfAvailable(rbacReportData, r.Config, log)
 
 	}
 	return ctrl.Result{}, nil

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/sbomreport"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
+	"github.com/aquasecurity/trivy-operator/pkg/webhook"
 
 	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 )
@@ -388,6 +389,12 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 			if err := streamReportToFile(vulnerabilityReports.vulnerabilityClusterReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
+			// Send webhook notification for cluster vulnerability report
+			if r.Config.WebhookBroadcastURL != "" {
+				if err := webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityClusterReports, r.Config); err != nil {
+					log.Error(err, "Failed to send cluster vulnerability report via webhook")
+				}
+			}
 		}
 
 		// Write vulnerability reports to a file using streaming
@@ -395,6 +402,12 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 			reportPath := filepath.Join(vulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
 			if err := streamReportToFile(vulnerabilityReports.vulnerabilityNamespaceReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write vulnerability report: %w", err)
+			}
+			// Send webhook notification for vulnerability report
+			if r.Config.WebhookBroadcastURL != "" {
+				if err := webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityNamespaceReports, r.Config); err != nil {
+					log.Error(err, "Failed to send vulnerability report via webhook")
+				}
 			}
 		}
 
@@ -404,6 +417,12 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 			if err := streamReportToFile(secretReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write exposed secrets report: %w", err)
 			}
+			// Send webhook notification for exposed secret reports
+			if r.Config.WebhookBroadcastURL != "" {
+				if err := webhook.SendWebhookReport(secretReports, r.Config); err != nil {
+					log.Error(err, "Failed to send exposed secret reports via webhook")
+				}
+			}
 		}
 
 		// Write SBOM cluster reports to a file using streaming
@@ -412,6 +431,12 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 			if err := streamReportToFile(sbomReports.sbomClusterReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom cluster report: %w", err)
 			}
+			// Send webhook notification for SBOM cluster reports
+			if r.Config.WebhookBroadcastURL != "" {
+				if err := webhook.SendWebhookReport(sbomReports.sbomClusterReports, r.Config); err != nil {
+					log.Error(err, "Failed to send SBOM cluster reports via webhook")
+				}
+			}
 		}
 
 		// Write SBOM reports to a file using streaming
@@ -419,6 +444,12 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 			reportPath := filepath.Join(sbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
 			if err := streamReportToFile(sbomReports.sbomNamespaceReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom report: %w", err)
+			}
+			// Send webhook notification for SBOM reports
+			if r.Config.WebhookBroadcastURL != "" {
+				if err := webhook.SendWebhookReport(sbomReports.sbomNamespaceReports, r.Config); err != nil {
+					log.Error(err, "Failed to send SBOM reports via webhook")
+				}
 			}
 		}
 		// Return empty reports since alternate write method is used

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -390,7 +390,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
 			// Send webhook notification for cluster vulnerability report
-			webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityClusterReports, r.Config, log)
+			webhook.SendWebhookReport(reportData, r.Config, log)
 		}
 
 		// Write vulnerability reports to a file using streaming
@@ -400,7 +400,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write vulnerability report: %w", err)
 			}
 			// Send webhook notification for vulnerability report
-			webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityNamespaceReports, r.Config, log)
+			webhook.SendWebhookReport(reportData, r.Config, log)
 		}
 
 		// Write secret reports to a file using streaming
@@ -410,7 +410,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write exposed secrets report: %w", err)
 			}
 			// Send webhook notification for exposed secret reports
-			webhook.SendWebhookReport(secretReports, r.Config, log)
+			webhook.SendWebhookReport(reportData, r.Config, log)
 		}
 
 		// Write SBOM cluster reports to a file using streaming
@@ -420,7 +420,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom cluster report: %w", err)
 			}
 			// Send webhook notification for SBOM cluster reports
-			webhook.SendWebhookReport(sbomReports.sbomClusterReports, r.Config, log)
+			webhook.SendWebhookReport(reportData, r.Config, log)
 		}
 
 		// Write SBOM reports to a file using streaming
@@ -430,7 +430,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom report: %w", err)
 			}
 			// Send webhook notification for SBOM reports
-			webhook.SendWebhookReport(sbomReports.sbomNamespaceReports, r.Config, log)
+			webhook.SendWebhookReport(reportData, r.Config, log)
 		}
 		// Return empty reports since alternate write method is used
 		return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, nil

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -31,22 +31,20 @@ import (
 	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 )
 
-// streamReportToFile writes a report directly to file using streaming JSON encoding
-// This reduces memory usage by avoiding intermediate marshaling to byte arrays
-func streamReportToFile(report any, filePath string) error {
-	file, err := os.Create(filePath)
+// streamReportToFile marshals the report, writes it to filePath and returns the
+// encoded bytes so the exact same payload can be forwarded to a webhook.
+func streamReportToFile(report any, filePath string) ([]byte, error) {
+	data, err := json.MarshalIndent(report, "", "  ") // Pretty print for readability
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to encode report: %w", err)
 	}
-	defer file.Close()
+	data = append(data, '\n')
 
-	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "  ") // Pretty print for readability
-	if err := encoder.Encode(report); err != nil {
-		return fmt.Errorf("failed to encode report: %w", err)
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to create file %s: %w", filePath, err)
 	}
 
-	return nil
+	return data, nil
 }
 
 // ScanJobController watches Kubernetes workloads and generates
@@ -386,51 +384,56 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 		// Write cluster vulnerability reports to a file using streaming
 		if vulnerabilityReports.vulnerabilityClusterReports != nil {
 			reportPath := filepath.Join(clusterVulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			if err := streamReportToFile(vulnerabilityReports.vulnerabilityClusterReports, reportPath); err != nil {
+			reportData, err := streamReportToFile(vulnerabilityReports.vulnerabilityClusterReports, reportPath)
+			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
 			// Send webhook notification for cluster vulnerability report
-			webhook.SendWebhookReport(reportData, r.Config, log)
+			webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 		}
 
 		// Write vulnerability reports to a file using streaming
 		if vulnerabilityReports.vulnerabilityNamespaceReports != nil {
 			reportPath := filepath.Join(vulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			if err := streamReportToFile(vulnerabilityReports.vulnerabilityNamespaceReports, reportPath); err != nil {
+			reportData, err := streamReportToFile(vulnerabilityReports.vulnerabilityNamespaceReports, reportPath)
+			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write vulnerability report: %w", err)
 			}
 			// Send webhook notification for vulnerability report
-			webhook.SendWebhookReport(reportData, r.Config, log)
+			webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 		}
 
 		// Write secret reports to a file using streaming
 		if len(secretReports) > 0 {
 			reportPath := filepath.Join(secretDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			if err := streamReportToFile(secretReports, reportPath); err != nil {
+			reportData, err := streamReportToFile(secretReports, reportPath)
+			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write exposed secrets report: %w", err)
 			}
 			// Send webhook notification for exposed secret reports
-			webhook.SendWebhookReport(reportData, r.Config, log)
+			webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 		}
 
 		// Write SBOM cluster reports to a file using streaming
 		if len(sbomReports.sbomClusterReports) > 0 {
 			reportPath := filepath.Join(clusterSbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			if err := streamReportToFile(sbomReports.sbomClusterReports, reportPath); err != nil {
+			reportData, err := streamReportToFile(sbomReports.sbomClusterReports, reportPath)
+			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom cluster report: %w", err)
 			}
 			// Send webhook notification for SBOM cluster reports
-			webhook.SendWebhookReport(reportData, r.Config, log)
+			webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 		}
 
 		// Write SBOM reports to a file using streaming
 		if len(sbomReports.sbomNamespaceReports) > 0 {
 			reportPath := filepath.Join(sbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			if err := streamReportToFile(sbomReports.sbomNamespaceReports, reportPath); err != nil {
+			reportData, err := streamReportToFile(sbomReports.sbomNamespaceReports, reportPath)
+			if err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom report: %w", err)
 			}
 			// Send webhook notification for SBOM reports
-			webhook.SendWebhookReport(reportData, r.Config, log)
+			webhook.SendWebhookReportIfAvailable(reportData, r.Config, log)
 		}
 		// Return empty reports since alternate write method is used
 		return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, nil

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -390,11 +390,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
 			// Send webhook notification for cluster vulnerability report
-			if r.Config.WebhookBroadcastURL != "" {
-				if err := webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityClusterReports, r.Config); err != nil {
-					log.Error(err, "Failed to send cluster vulnerability report via webhook")
-				}
-			}
+			webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityClusterReports, r.Config, log)
 		}
 
 		// Write vulnerability reports to a file using streaming
@@ -404,11 +400,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write vulnerability report: %w", err)
 			}
 			// Send webhook notification for vulnerability report
-			if r.Config.WebhookBroadcastURL != "" {
-				if err := webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityNamespaceReports, r.Config); err != nil {
-					log.Error(err, "Failed to send vulnerability report via webhook")
-				}
-			}
+			webhook.SendWebhookReport(vulnerabilityReports.vulnerabilityNamespaceReports, r.Config, log)
 		}
 
 		// Write secret reports to a file using streaming
@@ -418,11 +410,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write exposed secrets report: %w", err)
 			}
 			// Send webhook notification for exposed secret reports
-			if r.Config.WebhookBroadcastURL != "" {
-				if err := webhook.SendWebhookReport(secretReports, r.Config); err != nil {
-					log.Error(err, "Failed to send exposed secret reports via webhook")
-				}
-			}
+			webhook.SendWebhookReport(secretReports, r.Config, log)
 		}
 
 		// Write SBOM cluster reports to a file using streaming
@@ -432,11 +420,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom cluster report: %w", err)
 			}
 			// Send webhook notification for SBOM cluster reports
-			if r.Config.WebhookBroadcastURL != "" {
-				if err := webhook.SendWebhookReport(sbomReports.sbomClusterReports, r.Config); err != nil {
-					log.Error(err, "Failed to send SBOM cluster reports via webhook")
-				}
-			}
+			webhook.SendWebhookReport(sbomReports.sbomClusterReports, r.Config, log)
 		}
 
 		// Write SBOM reports to a file using streaming
@@ -446,11 +430,7 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom report: %w", err)
 			}
 			// Send webhook notification for SBOM reports
-			if r.Config.WebhookBroadcastURL != "" {
-				if err := webhook.SendWebhookReport(sbomReports.sbomNamespaceReports, r.Config); err != nil {
-					log.Error(err, "Failed to send SBOM reports via webhook")
-				}
-			}
+			webhook.SendWebhookReport(sbomReports.sbomNamespaceReports, r.Config, log)
 		}
 		// Return empty reports since alternate write method is used
 		return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, nil

--- a/pkg/vulnerabilityreport/controller/scanjob_test.go
+++ b/pkg/vulnerabilityreport/controller/scanjob_test.go
@@ -335,7 +335,7 @@ func TestStreamReportToFile(t *testing.T) {
 			filePath := tt.setupFile(t)
 
 			// Execute the function under test
-			err := streamReportToFile(tt.report, filePath)
+			_, err := streamReportToFile(tt.report, filePath)
 
 			// Validate error expectations
 			if tt.expectError {
@@ -361,7 +361,7 @@ func TestStreamReportToFilePermissions(t *testing.T) {
 		"test": "data for permissions test",
 	}
 
-	err := streamReportToFile(report, filePath)
+	_, err := streamReportToFile(report, filePath)
 	require.NoError(t, err)
 
 	// Check file permissions
@@ -418,7 +418,7 @@ func BenchmarkStreamReportToFile(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		filePath := filepath.Join(tmpDir, fmt.Sprintf("benchmark-report-%d.json", i))
-		err := streamReportToFile(report, filePath)
+		_, err := streamReportToFile(report, filePath)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/webhook/webhookreporter.go
+++ b/pkg/webhook/webhookreporter.go
@@ -74,13 +74,16 @@ func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // SendWebhookReport sends a report directly via webhook without going through CRD reconciliation
 // This is used when AltReportStorageEnabled is true and reports are written to filesystem
-func SendWebhookReport(reportObj any, config etc.Config) error {
+func SendWebhookReport(reportObj any, config etc.Config, log logr.Logger) {
 	if config.WebhookBroadcastURL == "" {
-		return nil // No webhook URL configured
+		return // No webhook URL configured
 	}
 
 	webhookBroadcastCustomHeaders := config.GetWebhookBroadcastCustomHeaders()
-	return sendReport(reportObj, config.WebhookBroadcastURL, *config.WebhookBroadcastTimeout, webhookBroadcastCustomHeaders)
+	err := sendReport(reportObj, config.WebhookBroadcastURL, *config.WebhookBroadcastTimeout, webhookBroadcastCustomHeaders)
+	if err != nil {
+		log.Error(err, "Failed to call webhook")
+	}
 }
 
 func (r *WebhookReconciler) reconcileReport(reportType client.Object) reconcile.Func {

--- a/pkg/webhook/webhookreporter.go
+++ b/pkg/webhook/webhookreporter.go
@@ -74,7 +74,7 @@ func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // SendWebhookReport sends a report directly via webhook without going through CRD reconciliation
 // This is used when AltReportStorageEnabled is true and reports are written to filesystem
-func SendWebhookReport(reportObj interface{}, config etc.Config) error {
+func SendWebhookReport(reportObj any, config etc.Config) error {
 	if config.WebhookBroadcastURL == "" {
 		return nil // No webhook URL configured
 	}

--- a/pkg/webhook/webhookreporter.go
+++ b/pkg/webhook/webhookreporter.go
@@ -68,7 +68,19 @@ func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 
 	}
+
 	return nil
+}
+
+// SendWebhookReport sends a report directly via webhook without going through CRD reconciliation
+// This is used when AltReportStorageEnabled is true and reports are written to filesystem
+func SendWebhookReport(reportObj interface{}, config etc.Config) error {
+	if config.WebhookBroadcastURL == "" {
+		return nil // No webhook URL configured
+	}
+
+	webhookBroadcastCustomHeaders := config.GetWebhookBroadcastCustomHeaders()
+	return sendReport(reportObj, config.WebhookBroadcastURL, *config.WebhookBroadcastTimeout, webhookBroadcastCustomHeaders)
 }
 
 func (r *WebhookReconciler) reconcileReport(reportType client.Object) reconcile.Func {

--- a/pkg/webhook/webhookreporter.go
+++ b/pkg/webhook/webhookreporter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -72,9 +73,10 @@ func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// SendWebhookReport sends a report directly via webhook without going through CRD reconciliation
-// This is used when AltReportStorageEnabled is true and reports are written to filesystem
-func SendWebhookReport(reportData []byte, config etc.Config, log logr.Logger) {
+// SendWebhookReportIfAvailable sends a report directly via webhook without going through CRD reconciliation
+// This is used when AltReportStorageEnabled is true and reports are written to filesystem.
+// It is a no-op when no webhook URL is configured.
+func SendWebhookReportIfAvailable(reportData []byte, config etc.Config, log logr.Logger) {
 	if config.WebhookBroadcastURL == "" {
 		return // No webhook URL configured
 	}
@@ -132,13 +134,14 @@ func sendEncodedReport(data []byte, endpoint string, timeout time.Duration, head
 	req.Header = headerValues
 
 	resp, err := hc.Do(req)
-	defer func() {
-		if resp != nil {
-			_ = resp.Body.Close()
-		}
-	}()
 	if err != nil {
 		return fmt.Errorf("failed to send reports to endpoint: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("webhook endpoint returned %s: %s", resp.Status, bytes.TrimSpace(body))
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

## Related issues
- Close #2682

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
