### PR TITLE
perf: optimize report processing

### DIFF
--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -30,6 +30,24 @@ import (
 	. "github.com/aquasecurity/trivy-operator/pkg/operator/predicate"
 )
 
+// streamReportToFile writes a report directly to file using streaming JSON encoding
+// This reduces memory usage by avoiding intermediate marshaling to byte arrays
+func streamReportToFile(report interface{}, filePath string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ") // Pretty print for readability
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("failed to encode report to file %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
 // ScanJobController watches Kubernetes workloads and generates
 // v1alpha1.VulnerabilityReport instances using vulnerability scanner that that
 // implements the Plugin interface.
@@ -351,68 +369,43 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 		// Get workload kind and name
 		workloadKind := owner.GetObjectKind().GroupVersionKind().Kind
 		workloadName := owner.GetName()
-		// Write cluster vulnerability reports to a file
+		// Write cluster vulnerability reports to a file using streaming
 		if vulnerabilityReports.vulnerabilityClusterReports != nil {
-			reportData, err := json.Marshal(vulnerabilityReports.vulnerabilityClusterReports)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal cluster vulnerability report: %w", err)
-			}
 			reportPath := filepath.Join(clusterVulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0o600)
-			if err != nil {
+			if err := streamReportToFile(vulnerabilityReports.vulnerabilityClusterReports, reportPath); err != nil {
 				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write cluster vulnerability report: %w", err)
 			}
 		}
 
-		// Write vulnerability reports to a file
+		// Write vulnerability reports to a file using streaming
 		if vulnerabilityReports.vulnerabilityNamespaceReports != nil {
-			reportData, err := json.Marshal(vulnerabilityReports.vulnerabilityNamespaceReports)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal vulnerability report: %w", err)
-			}
 			reportPath := filepath.Join(vulnerabilityDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0o600)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join vulnerability report: %w", err)
+			if err := streamReportToFile(vulnerabilityReports.vulnerabilityNamespaceReports, reportPath); err != nil {
+				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write vulnerability report: %w", err)
 			}
 		}
 
-		// Write secret reports to a file
+		// Write secret reports to a file using streaming
 		if len(secretReports) > 0 {
-			reportData, err := json.Marshal(secretReports)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal exposed secrets report: %w", err)
-			}
 			reportPath := filepath.Join(secretDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0o600)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join exposed secrets report: %w", err)
+			if err := streamReportToFile(secretReports, reportPath); err != nil {
+				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write exposed secrets report: %w", err)
 			}
 		}
 
-		// Write SBOM cluster reports to a file
+		// Write SBOM cluster reports to a file using streaming
 		if len(sbomReports.sbomClusterReports) > 0 {
-			reportData, err := json.Marshal(sbomReports.sbomClusterReports)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal sbom cluster report: %w", err)
-			}
 			reportPath := filepath.Join(clusterSbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0o600)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join sbom cluster report: %w", err)
+			if err := streamReportToFile(sbomReports.sbomClusterReports, reportPath); err != nil {
+				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom cluster report: %w", err)
 			}
 		}
 
-		// Write SBOM reports to a file
+		// Write SBOM reports to a file using streaming
 		if len(sbomReports.sbomNamespaceReports) > 0 {
-			reportData, err := json.Marshal(sbomReports.sbomNamespaceReports)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to marshal sbom report: %w", err)
-			}
 			reportPath := filepath.Join(sbomDir, fmt.Sprintf("%s-%s-%s.json", workloadKind, workloadName, containerName))
-			err = os.WriteFile(reportPath, reportData, 0o600)
-			if err != nil {
-				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to join sbom report: %w", err)
+			if err := streamReportToFile(sbomReports.sbomNamespaceReports, reportPath); err != nil {
+				return VulnerabilityReports{}, []v1alpha1.ExposedSecretReport{}, &SbomReports{}, fmt.Errorf("failed to write sbom report: %w", err)
 			}
 		}
 		// Return empty reports since alternate write method is used

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -32,7 +32,7 @@ import (
 
 // streamReportToFile writes a report directly to file using streaming JSON encoding
 // This reduces memory usage by avoiding intermediate marshaling to byte arrays
-func streamReportToFile(report interface{}, filePath string) error {
+func streamReportToFile(report any, filePath string) error {
 	file, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", filePath, err)

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -42,7 +42,7 @@ func streamReportToFile(report interface{}, filePath string) error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ") // Pretty print for readability
 	if err := encoder.Encode(report); err != nil {
-		return fmt.Errorf("failed to encode report to file %s: %w", filePath, err)
+		return fmt.Errorf("failed to encode report: %w", err)
 	}
 
 	return nil

--- a/pkg/vulnerabilityreport/controller/scanjob_test.go
+++ b/pkg/vulnerabilityreport/controller/scanjob_test.go
@@ -168,10 +168,10 @@ func TestDeletionOfCompletedScanJobs(t *testing.T) {
 
 // Test data structures for streamReportToFile tests
 type TestVulnerabilityReport struct {
-	APIVersion string                 `json:"apiVersion"`
-	Kind       string                 `json:"kind"`
-	Metadata   TestReportMetadata     `json:"metadata"`
-	Report     TestVulnerabilityData  `json:"report"`
+	APIVersion string                `json:"apiVersion"`
+	Kind       string                `json:"kind"`
+	Metadata   TestReportMetadata    `json:"metadata"`
+	Report     TestVulnerabilityData `json:"report"`
 }
 
 type TestReportMetadata struct {
@@ -181,8 +181,8 @@ type TestReportMetadata struct {
 }
 
 type TestVulnerabilityData struct {
-	Scanner      TestScanner        `json:"scanner"`
-	Summary      TestSummary        `json:"summary"`
+	Scanner         TestScanner         `json:"scanner"`
+	Summary         TestSummary         `json:"summary"`
 	Vulnerabilities []TestVulnerability `json:"vulnerabilities"`
 }
 
@@ -211,9 +211,9 @@ type TestVulnerability struct {
 func TestStreamReportToFile(t *testing.T) {
 	tests := []struct {
 		name           string
-		report         interface{}
+		report         any
 		setupFile      func(t *testing.T) string
-		validateResult func(t *testing.T, filePath string, originalReport interface{})
+		validateResult func(t *testing.T, filePath string, originalReport any)
 		expectError    bool
 		errorContains  string
 	}{
@@ -226,7 +226,7 @@ func TestStreamReportToFile(t *testing.T) {
 					Name:      "test-vulnerability-report",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.kubernetes.io/name": "test-app",
+						"app.kubernetes.io/name":  "test-app",
 						"trivy-operator.resource": "test",
 					},
 				},
@@ -266,19 +266,19 @@ func TestStreamReportToFile(t *testing.T) {
 				tmpDir := t.TempDir()
 				return filepath.Join(tmpDir, "vulnerability-report.json")
 			},
-			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+			validateResult: func(t *testing.T, filePath string, originalReport any) {
 				// Check file exists
 				assert.FileExists(t, filePath)
-				
+
 				// Read file content
 				content, err := os.ReadFile(filePath)
 				require.NoError(t, err)
-				
+
 				// Validate JSON structure
 				var decodedReport TestVulnerabilityReport
 				err = json.Unmarshal(content, &decodedReport)
 				require.NoError(t, err)
-				
+
 				// Validate content matches original
 				original := originalReport.(TestVulnerabilityReport)
 				assert.Equal(t, original.APIVersion, decodedReport.APIVersion)
@@ -287,7 +287,7 @@ func TestStreamReportToFile(t *testing.T) {
 				assert.Equal(t, original.Report.Scanner.Name, decodedReport.Report.Scanner.Name)
 				assert.Equal(t, original.Report.Summary.CriticalCount, decodedReport.Report.Summary.CriticalCount)
 				assert.Len(t, decodedReport.Report.Vulnerabilities, 2)
-				
+
 				// Validate pretty printing (indentation)
 				assert.Contains(t, string(content), "  \"apiVersion\":")
 				assert.Contains(t, string(content), "    \"name\":")
@@ -297,10 +297,10 @@ func TestStreamReportToFile(t *testing.T) {
 		{
 			name:   "failure due to invalid directory path",
 			report: map[string]string{"test": "data"},
-			setupFile: func(t *testing.T) string {
+			setupFile: func(_ *testing.T) string {
 				return "/nonexistent/directory/report.json"
 			},
-			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+			validateResult: func(t *testing.T, filePath string, _ any) {
 				// File should not exist
 				assert.NoFileExists(t, filePath)
 			},
@@ -309,7 +309,7 @@ func TestStreamReportToFile(t *testing.T) {
 		},
 		{
 			name: "failure due to non-serializable data",
-			report: map[string]interface{}{
+			report: map[string]any{
 				"valid":   "data",
 				"invalid": make(chan int), // Channels cannot be JSON marshaled
 			},
@@ -317,7 +317,7 @@ func TestStreamReportToFile(t *testing.T) {
 				tmpDir := t.TempDir()
 				return filepath.Join(tmpDir, "invalid-report.json")
 			},
-			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+			validateResult: func(t *testing.T, filePath string, _ any) {
 				// File may be created but content will be invalid
 				info, err := os.Stat(filePath)
 				if err == nil {
@@ -333,20 +333,20 @@ func TestStreamReportToFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filePath := tt.setupFile(t)
-			
+
 			// Execute the function under test
 			err := streamReportToFile(tt.report, filePath)
-			
+
 			// Validate error expectations
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
-			
+
 			// Validate results
 			tt.validateResult(t, filePath, tt.report)
 		})
@@ -356,22 +356,22 @@ func TestStreamReportToFile(t *testing.T) {
 func TestStreamReportToFilePermissions(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "permissions-test.json")
-	
+
 	report := map[string]string{
 		"test": "data for permissions test",
 	}
-	
+
 	err := streamReportToFile(report, filePath)
 	require.NoError(t, err)
-	
+
 	// Check file permissions
 	info, err := os.Stat(filePath)
 	require.NoError(t, err)
-	
+
 	// File should be readable and writable by owner
 	mode := info.Mode()
 	assert.True(t, mode.IsRegular())
-	
+
 	// Verify file can be read
 	content, err := os.ReadFile(filePath)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestStreamReportToFilePermissions(t *testing.T) {
 // Benchmark tests to measure memory efficiency of streaming approach
 func BenchmarkStreamReportToFile(b *testing.B) {
 	tmpDir := b.TempDir()
-	
+
 	// Create a moderately sized report
 	vulnerabilities := make([]TestVulnerability, 100)
 	for i := 0; i < 100; i++ {
@@ -394,7 +394,7 @@ func BenchmarkStreamReportToFile(b *testing.B) {
 			Links:           []string{fmt.Sprintf("https://example.com/cve-%d", i)},
 		}
 	}
-	
+
 	report := TestVulnerabilityReport{
 		APIVersion: "aquasecurity.github.io/v1alpha1",
 		Kind:       "VulnerabilityReport",
@@ -414,7 +414,7 @@ func BenchmarkStreamReportToFile(b *testing.B) {
 			Vulnerabilities: vulnerabilities,
 		},
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		filePath := filepath.Join(tmpDir, fmt.Sprintf("benchmark-report-%d.json", i))

--- a/pkg/vulnerabilityreport/controller/scanjob_test.go
+++ b/pkg/vulnerabilityreport/controller/scanjob_test.go
@@ -1,8 +1,13 @@
 package controller
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -158,5 +163,264 @@ func TestDeletionOfCompletedScanJobs(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, jobAfterCompletion)
 		})
+	}
+}
+
+// Test data structures for streamReportToFile tests
+type TestVulnerabilityReport struct {
+	APIVersion string                 `json:"apiVersion"`
+	Kind       string                 `json:"kind"`
+	Metadata   TestReportMetadata     `json:"metadata"`
+	Report     TestVulnerabilityData  `json:"report"`
+}
+
+type TestReportMetadata struct {
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+type TestVulnerabilityData struct {
+	Scanner      TestScanner        `json:"scanner"`
+	Summary      TestSummary        `json:"summary"`
+	Vulnerabilities []TestVulnerability `json:"vulnerabilities"`
+}
+
+type TestScanner struct {
+	Name    string `json:"name"`
+	Vendor  string `json:"vendor"`
+	Version string `json:"version"`
+}
+
+type TestSummary struct {
+	CriticalCount int `json:"criticalCount"`
+	HighCount     int `json:"highCount"`
+	MediumCount   int `json:"mediumCount"`
+	LowCount      int `json:"lowCount"`
+}
+
+type TestVulnerability struct {
+	VulnerabilityID string   `json:"vulnerabilityID"`
+	Severity        string   `json:"severity"`
+	Title           string   `json:"title"`
+	Description     string   `json:"description"`
+	FixedVersion    string   `json:"fixedVersion,omitempty"`
+	Links           []string `json:"links,omitempty"`
+}
+
+func TestStreamReportToFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		report         interface{}
+		setupFile      func(t *testing.T) string
+		validateResult func(t *testing.T, filePath string, originalReport interface{})
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "successful streaming of vulnerability report",
+			report: TestVulnerabilityReport{
+				APIVersion: "aquasecurity.github.io/v1alpha1",
+				Kind:       "VulnerabilityReport",
+				Metadata: TestReportMetadata{
+					Name:      "test-vulnerability-report",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "test-app",
+						"trivy-operator.resource": "test",
+					},
+				},
+				Report: TestVulnerabilityData{
+					Scanner: TestScanner{
+						Name:    "Trivy",
+						Vendor:  "Aqua Security",
+						Version: "v0.65.0",
+					},
+					Summary: TestSummary{
+						CriticalCount: 2,
+						HighCount:     5,
+						MediumCount:   3,
+						LowCount:      1,
+					},
+					Vulnerabilities: []TestVulnerability{
+						{
+							VulnerabilityID: "CVE-2023-1234",
+							Severity:        "CRITICAL",
+							Title:           "Test Critical Vulnerability",
+							Description:     "A test critical vulnerability for unit testing",
+							FixedVersion:    "1.2.3",
+							Links:           []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1234"},
+						},
+						{
+							VulnerabilityID: "CVE-2023-5678",
+							Severity:        "HIGH",
+							Title:           "Test High Vulnerability",
+							Description:     "A test high vulnerability for unit testing",
+							FixedVersion:    "1.2.4",
+							Links:           []string{"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-5678"},
+						},
+					},
+				},
+			},
+			setupFile: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				return filepath.Join(tmpDir, "vulnerability-report.json")
+			},
+			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+				// Check file exists
+				assert.FileExists(t, filePath)
+				
+				// Read file content
+				content, err := os.ReadFile(filePath)
+				require.NoError(t, err)
+				
+				// Validate JSON structure
+				var decodedReport TestVulnerabilityReport
+				err = json.Unmarshal(content, &decodedReport)
+				require.NoError(t, err)
+				
+				// Validate content matches original
+				original := originalReport.(TestVulnerabilityReport)
+				assert.Equal(t, original.APIVersion, decodedReport.APIVersion)
+				assert.Equal(t, original.Kind, decodedReport.Kind)
+				assert.Equal(t, original.Metadata.Name, decodedReport.Metadata.Name)
+				assert.Equal(t, original.Report.Scanner.Name, decodedReport.Report.Scanner.Name)
+				assert.Equal(t, original.Report.Summary.CriticalCount, decodedReport.Report.Summary.CriticalCount)
+				assert.Len(t, decodedReport.Report.Vulnerabilities, 2)
+				
+				// Validate pretty printing (indentation)
+				assert.Contains(t, string(content), "  \"apiVersion\":")
+				assert.Contains(t, string(content), "    \"name\":")
+			},
+			expectError: false,
+		},
+		{
+			name:   "failure due to invalid directory path",
+			report: map[string]string{"test": "data"},
+			setupFile: func(t *testing.T) string {
+				return "/nonexistent/directory/report.json"
+			},
+			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+				// File should not exist
+				assert.NoFileExists(t, filePath)
+			},
+			expectError:   true,
+			errorContains: "failed to create file",
+		},
+		{
+			name: "failure due to non-serializable data",
+			report: map[string]interface{}{
+				"valid":   "data",
+				"invalid": make(chan int), // Channels cannot be JSON marshaled
+			},
+			setupFile: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				return filepath.Join(tmpDir, "invalid-report.json")
+			},
+			validateResult: func(t *testing.T, filePath string, originalReport interface{}) {
+				// File may be created but content will be invalid
+				info, err := os.Stat(filePath)
+				if err == nil {
+					// If file exists, it should be empty or contain invalid JSON
+					assert.Equal(t, int64(0), info.Size())
+				}
+			},
+			expectError:   true,
+			errorContains: "failed to encode report",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := tt.setupFile(t)
+			
+			// Execute the function under test
+			err := streamReportToFile(tt.report, filePath)
+			
+			// Validate error expectations
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			
+			// Validate results
+			tt.validateResult(t, filePath, tt.report)
+		})
+	}
+}
+
+func TestStreamReportToFilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "permissions-test.json")
+	
+	report := map[string]string{
+		"test": "data for permissions test",
+	}
+	
+	err := streamReportToFile(report, filePath)
+	require.NoError(t, err)
+	
+	// Check file permissions
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	
+	// File should be readable and writable by owner
+	mode := info.Mode()
+	assert.True(t, mode.IsRegular())
+	
+	// Verify file can be read
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "permissions test")
+}
+
+// Benchmark tests to measure memory efficiency of streaming approach
+func BenchmarkStreamReportToFile(b *testing.B) {
+	tmpDir := b.TempDir()
+	
+	// Create a moderately sized report
+	vulnerabilities := make([]TestVulnerability, 100)
+	for i := 0; i < 100; i++ {
+		vulnerabilities[i] = TestVulnerability{
+			VulnerabilityID: fmt.Sprintf("CVE-2023-%04d", i),
+			Severity:        "MEDIUM",
+			Title:           fmt.Sprintf("Benchmark Vulnerability %d", i),
+			Description:     fmt.Sprintf("A benchmark vulnerability number %d for performance testing", i),
+			FixedVersion:    "1.0.0",
+			Links:           []string{fmt.Sprintf("https://example.com/cve-%d", i)},
+		}
+	}
+	
+	report := TestVulnerabilityReport{
+		APIVersion: "aquasecurity.github.io/v1alpha1",
+		Kind:       "VulnerabilityReport",
+		Metadata: TestReportMetadata{
+			Name:      "benchmark-vulnerability-report",
+			Namespace: "default",
+		},
+		Report: TestVulnerabilityData{
+			Scanner: TestScanner{
+				Name:    "Trivy",
+				Vendor:  "Aqua Security",
+				Version: "v0.65.0",
+			},
+			Summary: TestSummary{
+				MediumCount: 100,
+			},
+			Vulnerabilities: vulnerabilities,
+		},
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		filePath := filepath.Join(tmpDir, fmt.Sprintf("benchmark-report-%d.json", i))
+		err := streamReportToFile(report, filePath)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Description
```
New
Performance: ~277ms/op
Memory: 155KB/op
Allocations: 27 allocs/op

Old
Performance: ~371ms/op
Memory: 75KB/op
Allocations: 9 allocs/op
```

## Related discussions
- https://github.com/aquasecurity/trivy-operator/discussions/2674


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
