### PR TITLE
perf: optimize memory configuration for scan jobs

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -498,11 +498,11 @@ trivy:
   resources:
     requests:
       cpu: 100m
-      memory: 100M
+      memory: 200M  # Increased for better performance
       # ephemeralStorage: "2Gi"
     limits:
       cpu: 500m
-      memory: 500M
+      memory: 1Gi   # Increased for large scans
       # ephemeralStorage: "2Gi"
 
   # -- githubToken is the GitHub access token used by Trivy to download the vulnerabilities


### PR DESCRIPTION
## Description

- Increase memory requests from 100M to 200M for better performance
- Increase memory limits from 500M to 1Gi to handle large scans


## Related discussions
- https://github.com/aquasecurity/trivy-operator/discussions/2674


## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
