### PR TITLE
fix: add missing permission to get namespaces

### DIFF
--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -23,6 +23,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -3227,6 +3227,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -329,6 +329,8 @@ func (r *ClusterController) numOfCoreComponentPodsAndNodes(ctx context.Context) 
 	return corePodsCount + len(addonPods.Items), len(nodes.Items), nil
 }
 
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+
 func (r *ClusterController) isOpenShift(ctx context.Context) bool {
 	_, err := r.clientset.CoreV1().Namespaces().Get(ctx, "openshift-kube-apiserver", metav1.GetOptions{})
 	return !k8sapierror.IsNotFound(err)


### PR DESCRIPTION
## Description

trivy-operator is doing:

`_, err := r.clientset.CoreV1().Namespaces().Get(ctx, "openshift-kube-apiserver", metav1.GetOptions{})`

to check if it's running on OpenShift.

Because the operator is missing the necessary permission to get namespaces, our logs are filled with errors like the one below:

`namespaces "openshift-kube-apiserver" is forbidden: User "system:serviceaccount:trivy:trivy" cannot get resource "namespaces" in API group "" in the namespace "openshift-kube-apiserver"`

## Checklist
- [x ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ x] I've added tests that prove my fix is effective or that my feature works.
- [ x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ x] I've added usage information (if the PR introduces new options)
- [ x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
