### PR TITLE
feat(clientServer): add support for extraVolumes in trivy-server

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -168,6 +168,7 @@ Keeps security report resources updated
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
 | trivy.sbomSources | string | `""` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
+| trivy.server.extraServerVolumes | object | `{"volumeMounts":[],"volumes":[]}` | volumes set trivy-server volumes |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |

--- a/deploy/helm/templates/trivy-server/statefulset.yaml
+++ b/deploy/helm/templates/trivy-server/statefulset.yaml
@@ -132,6 +132,9 @@ spec:
               name: ssl-cert-dir
               readOnly: true
           {{- end }}
+          {{- with .Values.trivy.server.extraServerVolumes.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.trivy.server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -146,6 +149,9 @@ spec:
         - name: ssl-cert-dir
           hostPath:
             path: {{ . }}
+        {{- end }}
+        {{- with .Values.trivy.server.extraServerVolumes.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -624,6 +624,20 @@ trivy:
     # -- the number of replicas of the trivy-server
     replicas: 1
 
+    # -- volumes set trivy-server volumes
+    extraServerVolumes:
+      # Statefulset volumeMounts
+      volumeMounts: []
+        # - name: trusted-ca
+        #   mountPath: /etc/ssl/trusted-ca
+        #   subPath: trusted-ca.crt
+        #   readOnly: true
+      # Statefulset volumes
+      volumes: []
+        # - name: trusted-ca
+        #   secret:
+        #     secretName: trusted-ca
+
   # -- vaulesFromConfigMap name of a ConfigMap to apply TRIVY_* environment variables. Will override Helm values.
   valuesFromConfigMap: ""
 


### PR DESCRIPTION
Refactors values.yaml to introduce two top-level keys:
- trivy.server.extraVolumes.volumeMounts
- trivy.server.extraVolumes.volumes

This allows mounting additional ConfigMaps or Secrets into the trivy-server Statefulset

## Description
The server needs to get the vulnerability database from docker registry e.g., Artifactory which uses certs

Error:

Failed to verify certificates: x509: certificate signed by unknown authority

Solution

Mounting CAs as a volume solves the issue 

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
