### PR TITLE
fix(helm): always attempt to create ServiceMonitor when it is enabled

### DIFF
--- a/deploy/helm/templates/monitor/servicemonitor.yaml
+++ b/deploy/helm/templates/monitor/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.serviceMonitor.enabled true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -231,7 +231,7 @@ service:
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will
-# have no effect.
+# produce an error.
 serviceMonitor:
   # -- enabled determines whether a serviceMonitor should be deployed
   enabled: false


### PR DESCRIPTION
## Description

The ServiceMonitor resource is not always created due to the check for the `"monitoring.coreos.com/v1"` API. This is due to the helm's `.Capabilities` object not always being present depending on the method of deployment chosen (eg. `helm template`, using `kustomize`, using ArgoCD).

This change removes the check from the template so that the `ServiceMonitor` resource will always be created if the ServiceMonitor is enabled.

Before:
```
$ helm template deploy/helm/ --set serviceMonitor.enabled=true | yq 'select(.kind == "ServiceMonitor")'
$ 
```

After:
```
$ helm template deploy/helm/ --set serviceMonitor.enabled=true | yq 'select(.kind == "ServiceMonitor")'
# Source: trivy-operator/templates/monitor/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-trivy-operator
  namespace: default
  labels:
    helm.sh/chart: trivy-operator-0.30.0
    app.kubernetes.io/name: trivy-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.28.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: trivy-operator
      app.kubernetes.io/instance: release-name
  endpoints:
    - honorLabels: true
      port: metrics
      scheme: http
$
```

## Related issues
- #1312 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
