### PR TITLE
fix(ci): clean up space for e2e tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -167,6 +167,18 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: enabled
       GOEXPERIMENT: jsonv2
     steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-large-packages: 'true'
+          remove-cached-tools: 'true'
+          remove-swapfile: 'true'
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Description

Recently, the GitHub workflow started failing during the database download step with the error message:
no space left on device. As a result, the E2E tests could no longer complete successfully.

This PR introduces an additional cleanup step in the E2E test workflow using a well-known GitHub Action that removes unused packages and frees up disk space.

https://github.com/aquasecurity/trivy-operator/actions/runs/18338935104/job/52231648448
```sh
{"level":"error","ts":"2025-10-08T09:19:48Z","logger":"reconciler.scan job","msg":"Scan job container","job":"trivy-system/scan-vulnerabilityreport-75b94bc5cc","container":"c4508e4f-8d47-4b6f-85b3-6d3950607504","status.reason":"Error","status.message":"--------------------->] 100.00% 8.00 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 8.00 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.49 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.49 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.49 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.00 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.00 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 7.00 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.55 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.55 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.55 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.13 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.13 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 6.13 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 5.73 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [----------------------------------------------->] 100.00% 5.73 MiB p/s ETA 0s72.33 MiB / 72.33 MiB [---------------------------------------------------] 100.00% 3.50 MiB p/s 21s2025-10-08T09:19:45Z\tFATAL\tFatal error\trun error: init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2: oci download error: download error: failed to download /tmp/trivy-1/oci-download-3556752482/db.tar.gz: write /tmp/trivy/.cache/db/trivy.db: no space left on device\n","stacktrace":"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport/controller.(*ScanJobController).completedContainers\n\t/home/runner/work/trivy-operator/trivy-operator/pkg/vulnerabilityreport/controller/scanjob.go:441\ngithub.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport/controller.(*ScanJobController).SetupWithManager.(*ScanJobController).reconcileJobs.func1\n\t/home/runner/work/trivy-operator/trivy-operator/pkg/vulnerabilityreport/controller/scanjob.go:103\nsigs.k8s.io/controller-runtime/pkg/reconcile.TypedFunc[...].Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/reconcile/reconcile.go:134\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296"}
```
## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
