### PR TITLE
feat: allow to deploy sidecars in the operator pod

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -55,6 +55,7 @@ Keeps security report resources updated
 | operator.configAuditScannerScanOnlyCurrentRevisions | bool | `true` | configAuditScannerScanOnlyCurrentRevisions the flag to only create config audit scans on the current revision of a deployment. |
 | operator.controllerCacheSyncTimeout | string | `"5m"` | controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m). |
 | operator.exposedSecretScannerEnabled | bool | `true` | exposedSecretScannerEnabled the flag to enable exposed secret scanner |
+| operator.extraContainers | list | `[]` | Additional containers to be added to the operator pod. See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example. |
 | operator.httpProxy | string | `nil` | httpProxy is the HTTP proxy used by Trivy operator to download the default policies from GitHub. |
 | operator.httpsProxy | string | `nil` | httpsProxy is the HTTPS proxy used by Trivy operator to download the default policies from GitHub. |
 | operator.infraAssessmentScannerEnabled | bool | `true` | infraAssessmentScannerEnabled the flag to enable infra assessment scanner |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -111,6 +111,9 @@ spec:
             - name: {{ .Values.alternateReportStorage.volumeName }}
               mountPath: {{ .Values.alternateReportStorage.mountPath }}
           {{- end }}
+      {{- if .Values.operator.extraContainers }}
+        {{- toYaml .Values.operator.extraContainers | nindent 8 }}
+      {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -64,6 +64,30 @@ operator:
   # -- additional labels for the operator pod
   podLabels: {}
 
+  # -- Additional containers to be added to the operator pod.
+  # See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
+  extraContainers: []
+  #  - name: my-sidecar
+  #    image: nginx:latest
+  #  - name: lemonldap-ng-controller
+  #    image: lemonldapng/lemonldap-ng-controller:0.2.0
+  #    args:
+  #      - /lemonldap-ng-controller
+  #      - --alsologtostderr
+  #      - --configmap=$(POD_NAMESPACE)/lemonldap-ng-configuration
+  #    env:
+  #      - name: POD_NAME
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.name
+  #      - name: POD_NAMESPACE
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.namespace
+  #    volumeMounts:
+  #    - name: copy-portal-skins
+  #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
+
   # -- leaderElectionId determines the name of the resource that leader election
   # will use for holding the leader lock.
   leaderElectionId: "trivyoperator-lock"


### PR DESCRIPTION
## Description
As workaround for #2682, I've added a container to send the reports somewhere else. Please allow to add sidecars to the operator pod.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
