### PR TITLE
chore: bump up KinD and K8s versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ on:
       - LICENSE
       - NOTICE
 env:
-  KIND_VERSION: v0.29.0
-  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+  KIND_VERSION: v0.30.0
+  KIND_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -12,8 +12,8 @@ on:
     paths:
       - deploy/**
 env:
-  KIND_VERSION: v0.29.0
-  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+  KIND_VERSION: v0.30.0
+  KIND_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -22,8 +22,8 @@ on:
       - LICENSE
       - NOTICE
 env:
-  KIND_VERSION: v0.29.0
-  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+  KIND_VERSION: v0.30.0
+  KIND_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -12,8 +12,8 @@ env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm
-  KIND_VERSION: v0.29.0
-  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+  KIND_VERSION: v0.30.0
+  KIND_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 jobs:
   release:
     # this job will only run if the PR has been merged

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ on:
     tags:
       - "v*"
 env:
-  KIND_VERSION: v0.29.0
-  KIND_IMAGE: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
+  KIND_VERSION: v0.30.0
+  KIND_IMAGE: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 jobs:
   tests:
     name: Run tests


### PR DESCRIPTION
## Description
This PR bumps up KinD to the latest version - v0.30 and K8s to version 1.34.0.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
