### PR TITLE
fix: always generate the compliance report

### DIFF
--- a/pkg/compliance/clustercompliancereport.go
+++ b/pkg/compliance/clustercompliancereport.go
@@ -85,8 +85,6 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
 					return err
 				}
 				log.Info("Cluster compliance report written", "path", reportPath)
-
-				return nil
 			}
 			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
 			if err != nil {

--- a/pkg/compliance/clustercompliancereport_test.go
+++ b/pkg/compliance/clustercompliancereport_test.go
@@ -94,7 +94,7 @@ func TestClusterComplianceReconciler_generateComplianceReport(t *testing.T) {
 				r := &ClusterComplianceReportReconciler{Client: c, Mgr: fm, Clock: ext.NewFixedClock(now), Config: etc.Config{AltReportStorageEnabled: true, AltReportDir: dir}}
 				return r, types.NamespacedName{Name: "nsa"}, fm, dir
 			},
-			expect: expectation{wantErr: false, mgrCalled: false, requeuePos: false, wantFile: true},
+			expect: expectation{wantErr: false, mgrCalled: true, requeuePos: false, wantFile: true},
 		},
 		{
 			name: "invoke once calls mgr",


### PR DESCRIPTION
## Description
This PR ensures that ClusterComplianceReport generation always invokes the manager even when alternate storage is enabled. It allows to re-use the report for other cases.

## Related issues
- Close #2748 

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
