### PR TITLE
feat: Separate Node Collector and Scan Job Affinity

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -32,6 +32,7 @@ Keeps security report resources updated
 | image.tag | string | `""` | tag is an override of the image tag, which is by default set by the appVersion field in Chart.yaml. |
 | managedBy | string | `"Helm"` | managedBy is similar to .Release.Service but allows to overwrite the value |
 | nameOverride | string | `""` | nameOverride override operator name |
+| nodeCollector.affinity | object | `{}` | affinity to be applied to the node-collector |
 | nodeCollector.excludeNodes | string | `nil` | excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev) |
 | nodeCollector.imagePullSecret | string | `nil` | imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace |
 | nodeCollector.registry | string | `"ghcr.io"` | registry of the node-collector image |
@@ -204,7 +205,7 @@ Keeps security report resources updated
 | trivyOperator.policiesConfig | string | `""` | policiesConfig Custom Rego Policies to be used by the config audit scanner See https://github.com/aquasecurity/trivy-operator/blob/main/docs/tutorials/writing-custom-configuration-audit-policies.md for more details. |
 | trivyOperator.reportRecordFailedChecksOnly | bool | `true` | reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment) |
 | trivyOperator.reportResourceLabels | string | `""` | reportResourceLabels comma-separated scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app` |
-| trivyOperator.scanJobAffinity | object | `{}` | scanJobAffinity affinity to be applied to the scanner pods and node-collector |
+| trivyOperator.scanJobAffinity | object | `{}` | scanJobAffinity affinity to be applied to the scanner pods |
 | trivyOperator.scanJobAnnotations | string | `""` | scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner jobs and pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner jobs and pods with the annotations `foo: bar` and `env: stage` |
 | trivyOperator.scanJobAutomountServiceAccountToken | bool | `false` | scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job |
 | trivyOperator.scanJobCompressLogs | bool | `true` | scanJobCompressLogs control whether scanjob output should be compressed or plain |

--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -18,6 +18,9 @@ data:
   {{- with .Values.trivyOperator.scanJobCustomVolumes }}
   scanJob.customVolumes: {{ . | toJson | quote }}
   {{- end }}
+  {{- with .Values.nodeCollector.affinity }}
+  nodeCollector.affinity: {{ . | toJson | quote }}
+  {{- end }}
   {{- with .Values.nodeCollector.tolerations }}
   nodeCollector.tolerations: {{ . | toJson | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -257,7 +257,7 @@ trivyOperator:
   scanJobCompressLogs: true
   # -- scanJobsInSameNamespace control whether to run vulnerability scan jobs in same namespace of workload
   scanJobsInSameNamespace: false
-  # -- scanJobAffinity affinity to be applied to the scanner pods and node-collector
+  # -- scanJobAffinity affinity to be applied to the scanner pods
   scanJobAffinity: {}
   # -- scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints
   scanJobTolerations: []
@@ -765,6 +765,8 @@ nodeCollector:
   imagePullSecret: ~
   # -- excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev)
   excludeNodes:
+  # -- affinity to be applied to the node-collector
+  affinity: {}
   # -- tolerations to be applied to the node-collector so that they can run on nodes with matching taints
   tolerations: []
   # -- If you do want to specify tolerations, uncomment the following lines, adjust them as necessary, and remove the

--- a/pkg/configauditreport/controller/node.go
+++ b/pkg/configauditreport/controller/node.go
@@ -121,7 +121,7 @@ func (r *NodeReconciler) reconcileNodes() reconcile.Func {
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("preparing job: %w", err)
 		}
-		jobAffinity, err := r.GetScanJobAffinity()
+		nodeAffinity, err := r.GetNodeCollectorAffinity()
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("getting job affinity: %w", err)
 		}
@@ -177,7 +177,7 @@ func (r *NodeReconciler) reconcileNodes() reconcile.Func {
 			j.WithJobNamespace(on),
 			j.WithServiceAccount(r.ServiceAccount),
 			j.WithCollectorTimeout(r.Config.ScanJobTimeout),
-			j.WithJobAffinity(jobAffinity),
+			j.WithJobAffinity(nodeAffinity),
 			j.WithJobTolerations(nodeTolerations),
 			j.WithPodSpecSecurityContext(scanJobSecurityContext),
 			j.WithContainerSecurityContext(scanJobContainerSecurityContext),

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -61,6 +61,7 @@ const (
 	KeyVulnerabilityScansInSameNamespace = "vulnerabilityReports.scanJobsInSameNamespace"
 	keyConfigAuditReportsScanner         = "configAuditReports.scanner"
 	keyScanJobAffinity                   = "scanJob.affinity"
+	keyNodeCollectorAffinity             = "nodeCollector.affinity"
 	keyScanJobTolerations                = "scanJob.tolerations"
 	keyNodeCollectorTolerations          = "nodeCollector.tolerations"
 	KeyScanJobcompressLogs               = "scanJob.compressLogs"
@@ -217,6 +218,20 @@ func (c ConfigData) ExcludeImages() []string {
 		return patterns
 	}
 	return []string{}
+}
+
+func (c ConfigData) GetNodeCollectorAffinity() (*corev1.Affinity, error) {
+	if c[keyNodeCollectorAffinity] == "" {
+		return nil, nil
+	}
+
+	NodeCollectorAffinity := &corev1.Affinity{}
+	err := json.Unmarshal([]byte(c[keyNodeCollectorAffinity]), NodeCollectorAffinity)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing incorrectly formatted custom node collector template affinity: %s", c[keyNodeCollectorAffinity])
+	}
+
+	return NodeCollectorAffinity, nil
 }
 
 func (c ConfigData) GetNodeCollectorTolerations() ([]corev1.Toleration, error) {


### PR DESCRIPTION
## Description

Add `nodeCollector.Affinity` field to Helm `values.yaml` and separate affinity setting for node collectors from scan jobs.

## Related issues
- Close #2834

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
