### PR TITLE
ci: update setup-go action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,9 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
+
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
         with:
@@ -76,9 +78,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
         with:
@@ -99,9 +102,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
         with:
@@ -135,9 +139,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
@@ -201,9 +206,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -35,9 +35,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/private-registries.yaml
+++ b/.github/workflows/private-registries.yaml
@@ -45,9 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -29,9 +29,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.8.2
       - name: Release snapshot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
         with:
@@ -53,9 +54,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install tools
         uses: aquaproj/aqua-installer@v4.0.0
         with:
@@ -113,9 +115,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          check-latest: true
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.8.2
       - name: Login to docker.io registry


### PR DESCRIPTION
## Description

This PR bumps up action/setup-go to v6, and enables `check-latest` to ensure we always use the latest patch version.

It should fix vulns CVE-2025-61727 and CVE-2025-61729 in the pieline: https://github.com/aquasecurity/trivy-operator/actions/runs/20117203883

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
