### PR TITLE
feat: avoid double TRIVY_INSECURE

### DIFF
--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -194,16 +194,16 @@ func GetPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, config Confi
 				Name:  "TRIVY_INSECURE",
 				Value: "true",
 			})
+		} else {
+			env, err = appendTrivyInsecureEnv(config, c.Image, env)
+			if err != nil {
+				return corev1.PodSpec{}, nil, err
+			}
 		}
 
 		if config.OfflineScan() {
 			env = append(env, constructEnvVarSourceFromConfigMap("TRIVY_OFFLINE_SCAN",
 				trivyConfigName, keyTrivyOfflineScan))
-		}
-
-		env, err = appendTrivyInsecureEnv(config, c.Image, env)
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
 		}
 
 		resourceRequirements, err := config.GetResourceRequirements()
@@ -425,16 +425,16 @@ func GetPodSpecForClientServerFSMode(ctx trivyoperator.PluginContext, config Con
 				trivyConfigName, keyTrivyOfflineScan))
 		}
 
-		env, err = appendTrivyInsecureEnv(config, c.Image, env)
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
-		}
-
 		if config.GetServerInsecure() {
 			env = append(env, corev1.EnvVar{
 				Name:  "TRIVY_INSECURE",
 				Value: "true",
 			})
+		} else {
+			env, err = appendTrivyInsecureEnv(config, c.Image, env)
+			if err != nil {
+				return corev1.PodSpec{}, nil, err
+			}
 		}
 
 		resourceRequirements, err := config.GetResourceRequirements()


### PR DESCRIPTION
## Description

This avoid warnings in trivy-operator logs

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
