### PR TITLE
fix: use a different temporary directory for each scan

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -98,16 +98,16 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 
 	cacheDir := config.GetImageScanCacheDir()
 
-	volumeMounts := []corev1.VolumeMount{
+	sharedVolumeMounts := []corev1.VolumeMount{
 		{
-			Name:      tmpVolumeName,
+			Name:      trivyCacheVolumeName,
 			ReadOnly:  false,
-			MountPath: "/tmp",
+			MountPath: cacheDir,
 		},
 	}
 	volumes := []corev1.Volume{
 		{
-			Name: tmpVolumeName,
+			Name: trivyCacheVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium: corev1.StorageMediumDefault,
@@ -118,17 +118,17 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 
 	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
 	if volume, volumeMount := config.GenerateConfigFileVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
 	var initContainers []corev1.Container
 
-	args := []string{
+	argsDBUpdater := []string{
 		"--cache-dir",
 		cacheDir,
 		"image",
@@ -137,9 +137,23 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 		dbRepository,
 	}
 	if config.ConfigFileExists() {
-		args = append(args, "--config", configFileMountPath)
+		argsDBUpdater = append(argsDBUpdater, "--config", configFileMountPath)
 	}
 
+	volumes = append(volumes, corev1.Volume{
+		Name: "db-updater",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumDefault,
+			},
+		},
+	})
+	volumeMountsDbUpdater := sharedVolumeMounts
+	volumeMountsDbUpdater = append(volumeMountsDbUpdater, corev1.VolumeMount{
+		Name:      "db-updater",
+		ReadOnly:  false,
+		MountPath: "/tmp",
+	})
 	initContainers = append(initContainers, corev1.Container{
 		Name:                     p.idGenerator.GenerateID(),
 		Image:                    trivyImageRef,
@@ -149,14 +163,14 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 		Command: []string{
 			"trivy",
 		},
-		Args:            args,
+		Args:            argsDBUpdater,
 		Resources:       requirements,
 		SecurityContext: securityContext,
-		VolumeMounts:    volumeMounts,
+		VolumeMounts:    volumeMountsDbUpdater,
 	})
 
 	if !config.GetSkipJavaDBUpdate() && config.TrivyDBRepositoryCredentialsSet() {
-		argsDBUpdater := []string{
+		argsJavaDBUpdater := []string{
 			"--cache-dir",
 			cacheDir,
 			"image",
@@ -165,7 +179,7 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 			config.GetJavaDBRepository(),
 		}
 		if config.ConfigFileExists() {
-			argsDBUpdater = append(argsDBUpdater, "--config", configFileMountPath)
+			argsJavaDBUpdater = append(argsJavaDBUpdater, "--config", configFileMountPath)
 		}
 
 		initContainers = append(initContainers, corev1.Container{
@@ -177,32 +191,36 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 			Command: []string{
 				"trivy",
 			},
-			Args:            argsDBUpdater,
+			Args:            argsJavaDBUpdater,
 			Resources:       requirements,
 			SecurityContext: securityContext,
-			VolumeMounts:    volumeMounts,
+			VolumeMounts:    sharedVolumeMounts,
 		})
 	}
 
 	containers := make([]corev1.Container, 0)
 
-	volumeMounts = append(volumeMounts, getScanResultVolumeMount())
+	sharedVolumeMounts = append(sharedVolumeMounts, getScanResultVolumeMount())
 	volumes = append(volumes, getScanResultVolume())
 
 	if volume, volumeMount := config.GenerateIgnoreFileVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
 	if volume, volumeMount := config.GenerateIgnorePolicyVolumeIfAvailable(trivyConfigName, workload); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
-	for _, c := range containersSpec {
-		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), c.Image) {
+	for _, container := range containersSpec {
+		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), container.Image) {
 			continue
 		}
+		volumes = append(volumes, getTmpVolume(container.Name))
+		volumeMounts := []corev1.VolumeMount{}
+		volumeMounts = append(volumeMounts, getTmpVolumeMount(container.Name))
+		volumeMounts = append(volumeMounts, sharedVolumeMounts...)
 		env := []corev1.EnvVar{
 			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, KeyTrivySeverity),
 			constructEnvVarSourceFromConfigMap("TRIVY_IGNORE_UNFIXED", trivyConfigName, keyTrivyIgnoreUnfixed),
@@ -235,7 +253,7 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 			})
 		}
 
-		region := CheckAwsEcrPrivateRegistry(c.Image)
+		region := CheckAwsEcrPrivateRegistry(container.Image)
 		if region != "" {
 			env = append(env, corev1.EnvVar{
 				Name:  "AWS_REGION",
@@ -248,11 +266,11 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 				Value: "true",
 			})
 		}
-		if _, ok := containersCredentials[c.Name]; ok && secret != nil {
-			registryUsernameKey := fmt.Sprintf("%s.username", c.Name)
-			registryPasswordKey := fmt.Sprintf("%s.password", c.Name)
+		if _, ok := containersCredentials[container.Name]; ok && secret != nil {
+			registryUsernameKey := fmt.Sprintf("%s.username", container.Name)
+			registryPasswordKey := fmt.Sprintf("%s.password", container.Name)
 			secretName := secret.Name
-			if CheckGcpCrOrPrivateRegistry(c.Image) &&
+			if CheckGcpCrOrPrivateRegistry(container.Image) &&
 				ctx.GetTrivyOperatorConfig().GetScanJobUseGCRServiceAccount() {
 				createEnvandVolumeForGcr(&env, &volumeMounts, &volumes, &registryPasswordKey, &secretName)
 			} else {
@@ -281,12 +299,12 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 
 		}
 
-		env, err = appendTrivyInsecureEnv(config, c.Image, env)
+		env, err = appendTrivyInsecureEnv(config, container.Image, env)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
 
-		env, err = appendTrivyNonSSLEnv(config, c.Image, env)
+		env, err = appendTrivyNonSSLEnv(config, container.Image, env)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
@@ -296,28 +314,28 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 			return corev1.PodSpec{}, nil, err
 		}
 
-		imageRef, err := containerimage.ParseReference(c.Image)
+		imageRef, err := containerimage.ParseReference(container.Image)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
-		resultFileName := getUniqueScanResultFileName(c.Name)
+		resultFileName := getUniqueScanResultFileName(container.Name)
 		cmd, args := getCommandAndArgs(ctx, Standalone, imageRef.String(), "", resultFileName)
 		if len(clusterSboms) > 0 { // trivy sbom ...
-			if sbomreportData, ok := clusterSboms[c.Name]; ok {
-				secretName := fmt.Sprintf("sbom-%s", c.Name)
+			if sbomreportData, ok := clusterSboms[container.Name]; ok {
+				secretName := fmt.Sprintf("sbom-%s", container.Name)
 				secret, err := CreateSbomDataAsSecret(sbomreportData.Bom, secretName)
 				if err != nil {
 					return corev1.PodSpec{}, nil, err
 				}
 				secrets = append(secrets, &secret)
 				fileName := fmt.Sprintf("%s.json", secretName)
-				mountPath := fmt.Sprintf("/sbom-%s", c.Name)
-				CreateVolumeSbomFiles(&volumeMounts, &volumes, &secretName, fileName, mountPath, c.Name)
+				mountPath := fmt.Sprintf("/sbom-%s", container.Name)
+				CreateVolumeSbomFiles(&volumeMounts, &volumes, &secretName, fileName, mountPath, container.Name)
 				cmd, args = GetSbomScanCommandAndArgs(ctx, Standalone, fmt.Sprintf("%s/%s", mountPath, fileName), "", resultFileName)
 			}
 		}
 		containers = append(containers, corev1.Container{
-			Name:                     c.Name,
+			Name:                     container.Name,
 			Image:                    trivyImageRef,
 			ImagePullPolicy:          corev1.PullPolicy(config.GetImagePullPolicy()),
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
@@ -390,52 +408,40 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 	containers := make([]corev1.Container, 0)
 
 	trivyConfigName := trivyoperator.GetPluginConfigMapName(Plugin)
-	// add tmp volume mount
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      tmpVolumeName,
-			ReadOnly:  false,
-			MountPath: "/tmp",
-		},
+
+	volumes := []corev1.Volume{}
+	sharedVolumeMounts := []corev1.VolumeMount{}
+
+	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+		volumes = append(volumes, *volume)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
+	}
+	if volume, volumeMount := config.GenerateConfigFileVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+		volumes = append(volumes, *volume)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
-	// add tmp volume
-	volumes := []corev1.Volume{
-		{
-			Name: tmpVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{
-					Medium: corev1.StorageMediumDefault,
-				},
-			},
-		},
-	}
-
-	volumeMounts = append(volumeMounts, getScanResultVolumeMount())
+	sharedVolumeMounts = append(sharedVolumeMounts, getScanResultVolumeMount())
 	volumes = append(volumes, getScanResultVolume())
 
 	if volume, volumeMount := config.GenerateIgnoreFileVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
-	}
-	if volume, volumeMount := config.GenerateIgnorePolicyVolumeIfAvailable(trivyConfigName, workload); volume != nil && volumeMount != nil {
-		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
-	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
+	if volume, volumeMount := config.GenerateIgnorePolicyVolumeIfAvailable(trivyConfigName, workload); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
-	}
-	if volume, volumeMount := config.GenerateConfigFileVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
-		volumes = append(volumes, *volume)
-		volumeMounts = append(volumeMounts, *volumeMount)
+		sharedVolumeMounts = append(sharedVolumeMounts, *volumeMount)
 	}
 
 	for _, container := range containersSpec {
 		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), container.Image) {
 			continue
 		}
+		volumes = append(volumes, getTmpVolume(container.Name))
+		volumeMounts := []corev1.VolumeMount{}
+		volumeMounts = append(volumeMounts, getTmpVolumeMount(container.Name))
+		volumeMounts = append(volumeMounts, sharedVolumeMounts...)
 		env := []corev1.EnvVar{
 			constructEnvVarSourceFromConfigMap("HTTP_PROXY", trivyConfigName, keyTrivyHTTPProxy),
 			constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),

--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -132,6 +132,25 @@ func getScanResultVolumeMount() corev1.VolumeMount {
 	}
 }
 
+func getTmpVolume(containerName string) corev1.Volume {
+	return corev1.Volume{
+		Name: fmt.Sprintf("%s-%s", tmpVolumeName, containerName),
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumDefault,
+			},
+		},
+	}
+}
+
+func getTmpVolumeMount(containerName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      fmt.Sprintf("%s-%s", tmpVolumeName, containerName),
+		ReadOnly:  false,
+		MountPath: "/tmp",
+	}
+}
+
 func ConfigWorkloadAnnotationEnvVars(workload client.Object, annotation, envVarName, trivyConfigName, configKey string) corev1.EnvVar {
 	if value, ok := workload.GetAnnotations()[annotation]; ok {
 		return corev1.EnvVar{

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -113,6 +113,7 @@ func (p *plugin) GetScanJobSpec(ctx trivyoperator.PluginContext, workload client
 
 const (
 	tmpVolumeName               = "tmp"
+	trivyCacheVolumeName        = "trivy-cache"
 	ignoreFileVolumeName        = "ignorefile"
 	configFileVolumeName        = "configfile"
 	sslCertDirVolumeName        = "ssl-cert-dir"

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -43,19 +44,21 @@ var (
 
 func TestPlugin_GetScanJobSpec(t *testing.T) {
 
-	tmpVolume := corev1.Volume{
-		Name: "tmp",
+	trivyCacheVolume := corev1.Volume{
+		Name: "trivy-cache",
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{
 				Medium: corev1.StorageMediumDefault,
 			},
 		},
 	}
-
-	tmpVolumeMount := corev1.VolumeMount{
-		Name:      "tmp",
-		MountPath: "/tmp",
-		ReadOnly:  false,
+	trivyCacheVolumeMount := corev1.VolumeMount{
+		Name:      "trivy-cache",
+		MountPath: "/tmp/trivy/.cache",
+	}
+	trivyFsCacheVolumeMount := corev1.VolumeMount{
+		Name:      "trivy-cache",
+		MountPath: "/var/trivyoperator/trivy-db",
 	}
 
 	timeoutEnv := corev1.EnvVar{
@@ -129,7 +132,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -208,7 +213,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -355,7 +360,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -414,7 +421,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -492,7 +501,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -643,7 +652,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -702,7 +713,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -780,7 +793,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -931,7 +944,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -994,7 +1009,8 @@ CVE-2019-1543`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
 					{
 						Name: "ignorefile",
 						VolumeSource: corev1.VolumeSource{
@@ -1011,6 +1027,7 @@ CVE-2019-1543`,
 							},
 						},
 					},
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -1088,7 +1105,7 @@ CVE-2019-1543`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1239,7 +1256,9 @@ CVE-2019-1543`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 							{
 								Name:      "ignorefile",
 								MountPath: "/etc/trivy/.trivyignore",
@@ -1307,7 +1326,8 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
 					{
 						Name: "ignorepolicy",
 						VolumeSource: corev1.VolumeSource{
@@ -1324,6 +1344,7 @@ default ignore = false`,
 							},
 						},
 					},
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -1401,7 +1422,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1552,7 +1573,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 							{
 								Name:      "ignorepolicy",
 								MountPath: "/etc/trivy/policy.rego",
@@ -1618,7 +1641,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -1697,7 +1722,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1844,7 +1869,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1906,7 +1933,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -1985,7 +2014,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -2132,7 +2161,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -2187,11 +2218,12 @@ default ignore = false`,
 			expectedJobSpec: corev1.PodSpec{
 				Affinity:                     trivyoperator.LinuxNodeAffinity(),
 				RestartPolicy:                corev1.RestartPolicyNever,
-				ServiceAccountName:           "trivyoperator-sa",
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
+				ServiceAccountName:           "trivyoperator-sa",
 				AutomountServiceAccountToken: ptr.To[bool](false),
-				Volumes: []corev1.Volume{getTmpVolume(),
+				Volumes: []corev1.Volume{
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -2363,236 +2395,10 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
-						SecurityContext: &corev1.SecurityContext{
-							Privileged:               ptr.To[bool](false),
-							AllowPrivilegeEscalation: ptr.To[bool](false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
-							},
-							ReadOnlyRootFilesystem: ptr.To[bool](true),
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "ClientServer mode without insecure registry",
-			trivyOperatorConfig: map[string]string{
-				trivyoperator.KeyVulnerabilityScannerEnabled:  "true",
-				trivyoperator.KeyExposedSecretsScannerEnabled: "true",
-				trivyoperator.KeyScanJobcompressLogs:          "true",
-			},
-			config: map[string]string{
-				"trivy.repository":                "docker.io/aquasec/trivy",
-				"trivy.tag":                       "0.35.0",
-				"trivy.mode":                      string(trivy.ClientServer),
-				"trivy.serverURL":                 "http://trivy.trivy:4954",
-				"trivy.dbRepository":              trivy.DefaultDBRepository,
-				"trivy.javaDbRepository":          trivy.DefaultJavaDBRepository,
-				"trivy.resources.requests.cpu":    "100m",
-				"trivy.resources.requests.memory": "100M",
-				"trivy.resources.limits.cpu":      "500m",
-				"trivy.resources.limits.memory":   "500M",
-			},
-			workloadSpec: &corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Pod",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "nginx",
-					Namespace: "prod-ns",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "nginx",
-							Image: "nginx:1.16",
-						},
-					},
-				},
-			},
-			expectedJobSpec: corev1.PodSpec{
-				Affinity:                     trivyoperator.LinuxNodeAffinity(),
-				RestartPolicy:                corev1.RestartPolicyNever,
-				ImagePullSecrets:             []corev1.LocalObjectReference{},
-				ServiceAccountName:           "trivyoperator-sa",
-				AutomountServiceAccountToken: ptr.To[bool](false),
-				Volumes: []corev1.Volume{getTmpVolume(),
-					getScanResultVolume(),
-				},
-				Containers: []corev1.Container{
-					{
-						Name:                     "nginx",
-						Image:                    "docker.io/aquasec/trivy:0.35.0",
-						ImagePullPolicy:          corev1.PullIfNotPresent,
-						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						Env: []corev1.EnvVar{
-							{
-								Name: "HTTP_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "HTTPS_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.httpsProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "NO_PROXY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.noProxy",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_SEVERITY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.severity",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_IGNORE_UNFIXED",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.ignoreUnfixed",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_OFFLINE_SCAN",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.offlineScan",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_JAVA_DB_REPOSITORY",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.javaDbRepository",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							timeoutEnv,
-							{
-								Name: "TRIVY_SKIP_FILES",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.skipFiles",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_SKIP_DIRS",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.skipDirs",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_TOKEN_HEADER",
-								ValueFrom: &corev1.EnvVarSource{
-									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.serverTokenHeader",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_TOKEN",
-								ValueFrom: &corev1.EnvVarSource{
-									SecretKeyRef: &corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.serverToken",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-							{
-								Name: "TRIVY_CUSTOM_HEADERS",
-								ValueFrom: &corev1.EnvVarSource{
-									SecretKeyRef: &corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "trivy-operator-trivy-config",
-										},
-										Key:      "trivy.serverCustomHeaders",
-										Optional: ptr.To[bool](true),
-									},
-								},
-							},
-						},
-						Command: []string{
-							"/bin/sh",
-						},
-						Args: []string{
-							"-c",
-							"trivy image nginx:1.16 --cache-dir /tmp/trivy/.cache --format json --image-config-scanners secret --security-checks vuln,secret --server http://trivy.trivy:4954 --slow --output /tmp/scan/result_nginx.json 2>/tmp/scan/result_nginx.json.log ; rc=$?; if [ $rc -eq 1 ]; then cat /tmp/scan/result_nginx.json.log; else bzip2 -c /tmp/scan/result_nginx.json | base64; fi; exit $rc",
-						},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("100M"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("500m"),
-								corev1.ResourceMemory: resource.MustParse("500M"),
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -2649,8 +2455,9 @@ default ignore = false`,
 				ServiceAccountName:           "trivyoperator-sa",
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
-				Volumes: []corev1.Volume{getTmpVolume(),
+				Volumes: []corev1.Volume{
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -2826,7 +2633,10 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
+						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -2883,8 +2693,9 @@ default ignore = false`,
 				ServiceAccountName:           "trivyoperator-sa",
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
-				Volumes: []corev1.Volume{getTmpVolume(),
+				Volumes: []corev1.Volume{
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -3060,7 +2871,10 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
+						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -3122,7 +2936,8 @@ CVE-2019-1543`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 
-				Volumes: []corev1.Volume{getTmpVolume(), getScanResultVolume(),
+				Volumes: []corev1.Volume{
+					getScanResultVolume(),
 					{
 						Name: "ignorefile",
 						VolumeSource: corev1.VolumeSource{
@@ -3139,6 +2954,7 @@ CVE-2019-1543`,
 							},
 						},
 					},
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -3314,7 +3130,9 @@ CVE-2019-1543`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount(),
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
 							{
 								Name:      "ignorefile",
 								MountPath: "/etc/trivy/.trivyignore",
@@ -3382,7 +3200,8 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 
-				Volumes: []corev1.Volume{getTmpVolume(), getScanResultVolume(),
+				Volumes: []corev1.Volume{
+					getScanResultVolume(),
 					{
 						Name: "ignorepolicy",
 						VolumeSource: corev1.VolumeSource{
@@ -3399,6 +3218,7 @@ default ignore = false`,
 							},
 						},
 					},
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -3574,7 +3394,9 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount(),
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
 							{
 								Name:      "ignorepolicy",
 								MountPath: "/etc/trivy/policy.rego",
@@ -3636,8 +3458,9 @@ default ignore = false`,
 				ServiceAccountName:           "trivyoperator-sa",
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
-				Volumes: []corev1.Volume{getTmpVolume(),
+				Volumes: []corev1.Volume{
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				Containers: []corev1.Container{
 					{
@@ -3809,7 +3632,10 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							getScanResultVolumeMount(),
+						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -3867,6 +3693,7 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
+					trivyCacheVolume,
 					{
 						Name: trivy.FsSharedVolumeName,
 						VolumeSource: corev1.VolumeSource{
@@ -3875,15 +3702,8 @@ default ignore = false`,
 							},
 						},
 					},
-					{
-						Name: "tmp",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{
-								Medium: corev1.StorageMediumDefault,
-							},
-						},
-					},
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -3908,15 +3728,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -4005,15 +3821,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -4157,15 +3969,12 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 							getScanResultVolumeMount(),
 						},
@@ -4237,15 +4046,8 @@ default ignore = false`,
 							},
 						},
 					},
-					{
-						Name: "tmp",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{
-								Medium: corev1.StorageMediumDefault,
-							},
-						},
-					},
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -4274,11 +4076,6 @@ default ignore = false`,
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -4460,15 +4257,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 							getScanResultVolumeMount(),
 						},
@@ -4531,6 +4324,7 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
+					trivyCacheVolume,
 					{
 						Name: trivy.FsSharedVolumeName,
 						VolumeSource: corev1.VolumeSource{
@@ -4539,15 +4333,8 @@ default ignore = false`,
 							},
 						},
 					},
-					{
-						Name: "tmp",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{
-								Medium: corev1.StorageMediumDefault,
-							},
-						},
-					},
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -4572,15 +4359,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -4669,15 +4452,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -4821,15 +4600,12 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
+							trivyFsCacheVolumeMount,
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 							getScanResultVolumeMount(),
 						},
@@ -4901,15 +4677,8 @@ default ignore = false`,
 							},
 						},
 					},
-					{
-						Name: "tmp",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{
-								Medium: corev1.StorageMediumDefault,
-							},
-						},
-					},
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -4938,11 +4707,6 @@ default ignore = false`,
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -5124,15 +4888,11 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
+							getTmpVolumeMount("nginx"),
 							{
 								Name:      trivy.FsSharedVolumeName,
 								ReadOnly:  false,
 								MountPath: "/var/trivyoperator",
-							},
-							{
-								Name:      "tmp",
-								MountPath: "/tmp",
-								ReadOnly:  false,
 							},
 							getScanResultVolumeMount(),
 						},
@@ -5196,7 +4956,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -5275,7 +5037,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5426,7 +5188,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5494,7 +5258,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -5572,7 +5338,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5741,7 +5507,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5811,7 +5579,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume, getScanResultVolume(),
+					trivyCacheVolume,
+					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -5889,7 +5659,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -6058,7 +5828,9 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount, getScanResultVolumeMount(),
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
+							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -6116,8 +5888,9 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume,
+					trivyCacheVolume,
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -6197,7 +5970,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -6344,7 +6117,8 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
 							getScanResultVolumeMount(),
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -6404,7 +6178,7 @@ default ignore = false`,
 				ImagePullSecrets:             []corev1.LocalObjectReference{},
 				AutomountServiceAccountToken: ptr.To[bool](false),
 				Volumes: []corev1.Volume{
-					tmpVolume,
+					trivyCacheVolume,
 					corev1.Volume{
 						Name: "configfile",
 						VolumeSource: corev1.VolumeSource{
@@ -6422,6 +6196,7 @@ default ignore = false`,
 						},
 					},
 					getScanResultVolume(),
+					getTmpVolume("nginx"),
 				},
 				InitContainers: []corev1.Container{
 					{
@@ -6503,7 +6278,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							trivyCacheVolumeMount,
 							corev1.VolumeMount{
 								Name:      "configfile",
 								MountPath: "/etc/trivy/trivy-config.yaml",
@@ -6655,7 +6430,8 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							getTmpVolumeMount("nginx"),
+							trivyCacheVolumeMount,
 							corev1.VolumeMount{
 								Name:      "configfile",
 								MountPath: "/etc/trivy/trivy-config.yaml",
@@ -6725,7 +6501,7 @@ default ignore = false`,
 		expectedSecretsData []map[string][]byte
 		expectedJobSpec     corev1.PodSpec
 	}{{
-		name: "Trivy fs scan command in Standalone mode",
+		name: "Trivy fs scan command in Standalone mode same namespace",
 		trivyOperatorConfig: map[string]string{
 			trivyoperator.KeyVulnerabilityScannerEnabled:       "true",
 			trivyoperator.KeyExposedSecretsScannerEnabled:      "true",
@@ -6770,6 +6546,7 @@ default ignore = false`,
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
 			AutomountServiceAccountToken: ptr.To[bool](false),
 			Volumes: []corev1.Volume{
+				trivyCacheVolume,
 				{
 					Name: trivy.FsSharedVolumeName,
 					VolumeSource: corev1.VolumeSource{
@@ -6778,15 +6555,8 @@ default ignore = false`,
 						},
 					},
 				},
-				{
-					Name: "tmp",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{
-							Medium: corev1.StorageMediumDefault,
-						},
-					},
-				},
 				getScanResultVolume(),
+				getTmpVolume("nginx"),
 			},
 			InitContainers: []corev1.Container{
 				{
@@ -6811,15 +6581,11 @@ default ignore = false`,
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
+						trivyFsCacheVolumeMount,
 						{
 							Name:      trivy.FsSharedVolumeName,
 							ReadOnly:  false,
 							MountPath: "/var/trivyoperator",
-						},
-						{
-							Name:      "tmp",
-							MountPath: "/tmp",
-							ReadOnly:  false,
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -6908,15 +6674,11 @@ default ignore = false`,
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
+						trivyFsCacheVolumeMount,
 						{
 							Name:      trivy.FsSharedVolumeName,
 							ReadOnly:  false,
 							MountPath: "/var/trivyoperator",
-						},
-						{
-							Name:      "tmp",
-							MountPath: "/tmp",
-							ReadOnly:  false,
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -7061,15 +6823,12 @@ default ignore = false`,
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
+						getTmpVolumeMount("nginx"),
+						trivyFsCacheVolumeMount,
 						{
 							Name:      trivy.FsSharedVolumeName,
 							ReadOnly:  false,
 							MountPath: "/var/trivyoperator",
-						},
-						{
-							Name:      "tmp",
-							MountPath: "/tmp",
-							ReadOnly:  false,
 						},
 						getScanResultVolumeMount(),
 					},
@@ -7812,9 +7571,9 @@ func getScanResultVolume() corev1.Volume {
 		},
 	}
 }
-func getTmpVolume() corev1.Volume {
+func getTmpVolume(containerName string) corev1.Volume {
 	return corev1.Volume{
-		Name: "tmp",
+		Name: fmt.Sprintf("tmp-%s", containerName),
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{
 				Medium: corev1.StorageMediumDefault,
@@ -7831,9 +7590,9 @@ func getScanResultVolumeMount() corev1.VolumeMount {
 	}
 }
 
-func getTmpVolumeMount() corev1.VolumeMount {
+func getTmpVolumeMount(containerName string) corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      "tmp",
+		Name:      fmt.Sprintf("tmp-%s", containerName),
 		ReadOnly:  false,
 		MountPath: "/tmp",
 	}


### PR DESCRIPTION
## Description

More info in #2859

## Related issues
- Close #2859

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
