### PR TITLE
fix: alternateReportStorage PVC no longer ignores namespace from values.yaml

### DIFF
--- a/deploy/helm/templates/pvc.yaml
+++ b/deploy/helm/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.alternateReportStorage.volumeName }}
-  namespace: {{ .Release.namespace }}
+  namespace: {{ include "trivy-operator.namespace" . }}
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Description
We encountered the issue in #2697 as well due to us using a different namespace for the operator.
The current chart will always use `.Release.namespace` which ends up being `trivy-system` even if the namespace is not being used by any other component.

Looks like this is the only place that `.Release.namespace` was incorrectly used and appeared after #2646  and this fix should make it consistent with the rest of the chart.

This format for the namespace matches the format for the following now:
* https://github.com/aquasecurity/trivy-operator/blob/f74e994d8a77c96d192207e618c346d745298082/deploy/helm/templates/secrets/operator.yaml#L7
* https://github.com/aquasecurity/trivy-operator/blob/f74e994d8a77c96d192207e618c346d745298082/deploy/helm/templates/deployment.yaml#L5
* https://github.com/aquasecurity/trivy-operator/blob/f74e994d8a77c96d192207e618c346d745298082/deploy/helm/templates/serviceaccount.yaml#L6
* https://github.com/aquasecurity/trivy-operator/blob/f74e994d8a77c96d192207e618c346d745298082/deploy/helm/templates/secrets/operator.yaml#L7
* And so on...

## Related issues
- Closes #2697 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
