### PR TITLE
ci: added extra_file LICENSE for Dockerfile.ubi9

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -138,6 +138,8 @@ dockers:
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: arm64
+    extra_files:
+      - LICENSE
     ids:
       - trivy-operator
     build_flag_templates:
@@ -198,6 +200,8 @@ dockers:
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: s390x
+    extra_files:
+      - LICENSE
     ids:
       - trivy-operator
     build_flag_templates:
@@ -218,6 +222,8 @@ dockers:
     goos: linux
     dockerfile: build/trivy-operator/Dockerfile.ubi9
     goarch: ppc64le
+    extra_files:
+      - LICENSE
     ids:
       - trivy-operator
     build_flag_templates:


### PR DESCRIPTION
## Description

It fixes the failing UBI9 builds by ensuring LICENSE is in every UBI9 Docker build context.

Before:
```sh
$ goreleaser release --clean --skip=publish,sign --snapshot
  • skipping announce, publish, sign, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=1388637317d1e89e6bca6d74d06aa0828563bf0a branch=main current_tag=v0.22.0 previous_tag=v0.21.3 dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
...
• docker images
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-arm64
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ubi9-arm64
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ppc64le
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ubi9-ppc64le
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ubi9-amd64
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-amd64
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ubi9-s390x
    • building docker image                          image=docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-s390x
      • took: 12s
  ⨯ release failed after 41s                        
    error=
    │ docker build failed: seems like you tried to copy a file that is not available in the build context.
    │ Here's more information about the build context:
    │ dir: "/var/folders/q0/ykp5nvjx0j5_t4llxyh5hcm40000gn/T/goreleaserdocker2944505592"
    │ files in that dir:
    │  Dockerfile
    │  trivy-operator
    │ Previous error:
    │ failed to build docker.io/aquasec/trivy-operator:1388637317d1e89e6bca6d74d06aa0828563bf0a-ubi9-ppc64le: exit status 1: #0 building with "desktop-linux" instance using docker driver
    │ #1 [internal] load build definition from Dockerfile
    │ #1 transferring dockerfile: 928B done
    │ #1 DONE 0.0s
    │ #2 [internal] load metadata for registry.access.redhat.com/ubi9/ubi-minimal@sha256:759f5f42d9d6ce2a705e290b7fc549e2d2cd39312c4fa345f93c02e4abb8da95
    │ #2 DONE 1.1s
    │ #3 [internal] load .dockerignore
    │ #3 transferring context: 2B done
    │ #3 DONE 0.0s
    │ #4 [1/7] FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:759f5f42d9d6ce2a705e290b7fc549e2d2cd39312c4fa345f93c02e4abb8da95
    │ #4 resolve registry.access.redhat.com/ubi9/ubi-minimal@sha256:759f5f42d9d6ce2a705e290b7fc549e2d2cd39312c4fa345f93c02e4abb8da95 0.0s done
    │ #4 DONE 0.0s
    │ #5 [internal] load build context
    │ #5 transferring context: 152.27MB 3.0s done
    │ #5 DONE 3.1s
    │ #6 [2/7] RUN microdnf -y install shadow-utils     && microdnf clean all
    │ #6 CACHED
    │ #7 [3/7] RUN mkdir -p /licenses
    │ #7 CACHED
    │ #8 [4/7] COPY LICENSE /licenses/LICENSE
    │ #8 ERROR: failed to calculate checksum of ref weobtoqjmmyp7amm3oelodg8l::y93tult5goq0udw1molrvyh5n: "/LICENSE": not found
    │ ------
    │  > [4/7] COPY LICENSE /licenses/LICENSE:
    │ ------
    │ Dockerfile:17
    │ --------------------
    │   15 |     # Include license in the image
    │   16 |     RUN mkdir -p /licenses
    │   17 | >>> COPY LICENSE /licenses/LICENSE
    │   18 |     RUN useradd -u 10000 trivyoperator
    │   19 |     WORKDIR /opt/bin/
    │ --------------------
    │ ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref weobtoqjmmyp7amm3oelodg8l::y93tult5goq0udw1molrvyh5n: "/LICENSE": not found
    │ View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/31wemcud2zq8xem3q8vvue66c
    │ Learn more at https://goreleaser.com/errors/docker-build

```
After:
```sh
$ goreleaser release --clean --skip=publish,sign --snapshot
  • skipping announce, publish, sign, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=f290f3e02015b35e4e778b77b3600ed68e394bec branch=ci/fix-licences current_tag=v0.22.0 previous_tag=v0.21.3 dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
 ...
    • building                                       binary=dist/trivy-operator_linux_ppc64le_power8/trivy-operator
    • building                                       binary=dist/trivy-operator_linux_s390x/trivy-operator
    • building                                       binary=dist/trivy-operator_linux_arm_7/trivy-operator
    • building                                       binary=dist/trivy-operator_linux_amd64_v1/trivy-operator
    • building                                       binary=dist/trivy-operator_linux_arm64_v8.0/trivy-operator
      • took: 16s
  • archives
    • archiving                                      name=dist/trivy_operator_Linux_x86_64.tar.gz
    • archiving                                      name=dist/trivy_operator_Linux_ARM64.tar.gz
    • archiving                                      name=dist/trivy_operator_Linux_ARM.tar.gz
    • archiving                                      name=dist/trivy_operator_Linux_ppc64le.tar.gz
    • archiving                                      name=dist/trivy_operator_Linux_s390x.tar.gz
      • took: 12s
  • calculating checksums
  • docker images
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-arm64
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-ubi9-arm64
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-ubi9-ppc64le
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-ubi9-amd64
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-amd64
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-ppc64le
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-s390x
    • building docker image                          image=docker.io/aquasec/trivy-operator:f290f3e02015b35e4e778b77b3600ed68e394bec-ubi9-s390x
      • took: 1m41s
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • release succeeded after 2m9s
  • thanks for using GoReleaser!

```


## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
