### PR TITLE
fix: vulnerability metric export fails because of duplicate entries

### DIFF
--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -118,7 +118,8 @@ var _ = Describe("ResourcesMetricsCollector", func() {
 				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", PkgPath: "ab2", Resource: "dppkg", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-6", Title: "VR3 Critical vulnerability 6", Score: ptr.To[float64](8.4)},
 				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", Target: "ab2", Resource: "dppkg", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-7", Title: "VR3 Critical vulnerability 7", Score: ptr.To[float64](8.4)},
 				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", Resource: "dppkg", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-8", Title: "VR3 Critical vulnerability 8", Score: ptr.To[float64](8.4)},
-				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", Resource: "dppkg-other", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-8", Title: "VR3 Critical vulnerability 8", Score: ptr.To[float64](8.4)},
+				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", Resource: "dppkg-other", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-8", Title: "VR3 Critical vulnerability 8", Score: ptr.To[float64](8.4), CVSSSource: "some source"},
+				{InstalledVersion: "1.19.7", Class: "os-pkgs", PackageType: "debian", Resource: "dppkg-other", Severity: v1alpha1.SeverityCritical, VulnerabilityID: "CVE-VR3-CRITICAL-8", Title: "VR3 Critical vulnerability 8", Score: ptr.To[float64](8.4), CVSSSource: "another source"},
 			}
 
 			client.WithRuntimeObjects(vr1, vr2, vr3)


### PR DESCRIPTION
## Description
Vulnerability Metric Export fails in some cases, when the detected Vulnerabilities differ only in fields, that are not exported to Prometheus. This fix deduplicates the Vulnerabilities based on actually exported Values before passing them to the Metrics Collector.

## Related issues
- Close #2502

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
