### PR TITLE
feat(helm): add operator.shareProcessNamespace option

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.operator.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if .Values.hostAliases }}
       hostAliases:
         {{- toYaml .Values.hostAliases | nindent 8 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -202,6 +202,11 @@ operator:
   # -- pprofBindAddress the address to bind the pprof server to. By default, it is not enabled.
   pprofBindAddress: ""
 
+  # -- shareProcessNamespace enables shared PID namespace for the pod.
+  # Required when sidecars or custom entrypoint wrappers need to signal
+  # the operator process (e.g., to kill/restart it).
+  shareProcessNamespace: false
+
 image:
   registry: "mirror.gcr.io"
   repository: "aquasec/trivy-operator"


### PR DESCRIPTION
## Summary
- Adds `operator.shareProcessNamespace` (default: `false`) to `values.yaml`
- When enabled, sets `shareProcessNamespace: true` on the operator pod spec
- Required when sidecars or custom entrypoint wrappers need to signal (kill/restart) the operator process via PID

## Changes
- `deploy/helm/values.yaml` — new `operator.shareProcessNamespace` value
- `deploy/helm/templates/deployment.yaml` — conditional `shareProcessNamespace: true` block

## Test plan
- [ ] `helm template` with defaults — `shareProcessNamespace` absent from output
- [ ] `helm template --set operator.shareProcessNamespace=true` — `shareProcessNamespace: true` present in pod spec