### PR TITLE
feat(helm): add native private registry credentials for scan jobs

### DIFF
--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -12,11 +12,19 @@ data:
   {{- with .Values.trivyOperator.scanJobTolerations }}
   scanJob.tolerations: {{ . | toJson | quote }}
   {{- end }}
-  {{- with .Values.trivyOperator.scanJobCustomVolumesMount }}
-  scanJob.customVolumesMount: {{ . | toJson | quote }}
+  {{- $customVolumesMount := .Values.trivyOperator.scanJobCustomVolumesMount | default list }}
+  {{- $customVolumes := .Values.trivyOperator.scanJobCustomVolumes | default list }}
+  {{- if .Values.trivy.registryCredentials.create }}
+    {{- $regMount := dict "name" "registry-creds" "mountPath" "/root/.docker/config.json" "subPath" ".dockerconfigjson" "readOnly" true }}
+    {{- $regVolume := dict "name" "registry-creds" "secret" (dict "secretName" .Values.trivy.registryCredentials.secretName) }}
+    {{- $customVolumesMount = append $customVolumesMount $regMount }}
+    {{- $customVolumes = append $customVolumes $regVolume }}
   {{- end }}
-  {{- with .Values.trivyOperator.scanJobCustomVolumes }}
-  scanJob.customVolumes: {{ . | toJson | quote }}
+  {{- if $customVolumesMount }}
+  scanJob.customVolumesMount: {{ $customVolumesMount | toJson | quote }}
+  {{- end }}
+  {{- if $customVolumes }}
+  scanJob.customVolumes: {{ $customVolumes | toJson | quote }}
   {{- end }}
   {{- with .Values.nodeCollector.tolerations }}
   nodeCollector.tolerations: {{ . | toJson | quote }}

--- a/deploy/helm/templates/secrets/trivy-scan-registry-credentials.yaml
+++ b/deploy/helm/templates/secrets/trivy-scan-registry-credentials.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.trivy.registryCredentials.create }}
+{{- $username := .Values.trivy.registryCredentials.username }}
+{{- $password := .Values.trivy.registryCredentials.password }}
+{{- $registry := .Values.trivy.registryCredentials.registry }}
+{{- $auth := printf "%s:%s" $username $password | b64enc }}
+{{- $dockerConfig := dict "auths" (dict $registry (dict "username" $username "password" $password "auth" $auth)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.trivy.registryCredentials.secretName }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $dockerConfig | toJson | b64enc }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -368,6 +368,24 @@ trivy:
     # -- pullPolicy is the imge pull policy used for trivy image , valid values are (Always, Never, IfNotPresent)
     pullPolicy: IfNotPresent
 
+  # -- registryCredentials configures private registry authentication for Trivy scan jobs.
+  # When create is true, a kubernetes.io/dockerconfigjson Secret is automatically created
+  # and injected into scan jobs via scanJobCustomVolumes/scanJobCustomVolumesMount, allowing
+  # Trivy to pull images from private registries without manual volume configuration.
+  # The secret is mounted at /root/.docker/config.json inside scan job containers.
+  # This merges with any existing scanJobCustomVolumes/scanJobCustomVolumesMount values.
+  registryCredentials:
+    # -- create determines if the docker config secret should be created and injected into scan jobs
+    create: false
+    # -- secretName is the name of the Secret to create
+    secretName: "trivy-registry-credentials"
+    # -- registry is the registry URL (e.g., "registry.example.com", "ghcr.io")
+    registry: ""
+    # -- username for registry authentication
+    username: ""
+    # -- password for registry authentication
+    password: ""
+
   # -- mode is the Trivy client mode. Either Standalone or ClientServer. Depending
   # on the active mode other settings might be applicable or required.
   mode: Standalone

--- a/docs/tutorials/private-registries.md
+++ b/docs/tutorials/private-registries.md
@@ -299,8 +299,42 @@ data:
   .dockerconfigjson: OUTPUT
 ```
 
-## Sixth Option: Grant access through managed registries
+## Sixth Option: Helm-managed registry credentials
 
-The last way that you could give the Trivy operator access to your private container registry is through managed registries. In this case, the container registry and your Kubernetes cluster would have to be on the same cloud provider; then you can define access to your container namespace as part of the IAM account. Once defined, trivy will already have the permissions for the registry.
+If you want the Helm chart to manage registry credentials for scan jobs automatically, you can use the `trivy.registryCredentials` values. This creates a `kubernetes.io/dockerconfigjson` Secret and injects it into scan jobs via `scanJobCustomVolumes`/`scanJobCustomVolumesMount`, so Trivy can authenticate against your private registry without any manual Secret or volume configuration.
+
+```yaml
+trivy:
+  registryCredentials:
+    create: true
+    secretName: "trivy-registry-credentials"
+    registry: "registry.example.com"
+    username: "my-user"
+    password: "my-password"
+```
+
+Then install or upgrade the operator:
+
+```sh
+helm upgrade --install trivy-operator aqua/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version {{ var.chart_version }} \
+  --values ./values.yaml
+```
+
+This will:
+
+1. Create a `kubernetes.io/dockerconfigjson` Secret named `trivy-registry-credentials`
+2. Automatically append the Secret as a volume to scan jobs
+3. Mount it at `/root/.docker/config.json` inside scan job containers
+
+The credentials are merged with any existing `scanJobCustomVolumes`/`scanJobCustomVolumesMount` values, so you can combine this with other custom volumes.
+
+Note: for production use, consider providing the password through `--set` or an external secrets manager rather than storing it in a values file.
+
+## Seventh Option: Grant access through managed registries
+
+Another way to give the Trivy operator access to your private container registry is through managed registries. In this case, the container registry and your Kubernetes cluster would have to be on the same cloud provider; then you can define access to your container namespace as part of the IAM account. Once defined, trivy will already have the permissions for the registry.
 
 For additional information, please refer to the [documentation on managed registries.](https://aquasecurity.github.io/trivy-operator/v0.29.0/docs/vulnerability-scanning/managed-registries/)


### PR DESCRIPTION
Add trivy.registryCredentials to automatically create a dockerconfigjson Secret and inject it into scan jobs via the operator ConfigMap's scanJobCustomVolumes/scanJobCustomVolumesMount.

Previously, users had to manually create the docker config secret and hand-craft the JSON for scanJobCustomVolumes, which was error-prone. This feature automates the common case while merging with any existing user-specified custom volumes.

The credential secret is mounted at /root/.docker/config.json (standard Docker config location) so Trivy can pull images from private registries without additional configuration.

New values:
- trivy.registryCredentials.create: enable secret creation
- trivy.registryCredentials.secretName: secret name
- trivy.registryCredentials.registry: registry URL
- trivy.registryCredentials.username: registry username
- trivy.registryCredentials.password: registry password

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
