### PR TITLE
feat(helm): add extraContainers and extraVolumes support to deployment

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -113,6 +113,21 @@ spec:
             - name: {{ .Values.alternateReportStorage.volumeName }}
               mountPath: {{ .Values.alternateReportStorage.mountPath }}
           {{- end }}
+        {{- if .Values.extraContainers }}
+        {{- range .Values.extraContainers }}
+        {{- if $.Values.alternateReportStorage.enabled }}
+        - {{- toYaml (omit . "volumeMounts") | nindent 10 }}
+          volumeMounts:
+          {{- with .volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+            - name: {{ $.Values.alternateReportStorage.volumeName }}
+              mountPath: {{ $.Values.alternateReportStorage.mountPath }}
+        {{- else }}
+        - {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -127,16 +142,19 @@ spec:
         fsGroup:   {{ .Values.alternateReportStorage.podSecurityContext.fsGroup }}
       {{- end }}
       {{- end }}
+      {{- if or .Values.volumes .Values.alternateReportStorage.enabled .Values.extraVolumes }}
+      volumes:
       {{- with .Values.volumes }}
-      volumes: {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.alternateReportStorage.enabled }}
-      {{- if not .Values.volumes }}
-      volumes:
-      {{- end }}
         - name: {{ .Values.alternateReportStorage.volumeName }}
           persistentVolumeClaim:
             claimName: {{ .Values.alternateReportStorage.volumeName }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -837,3 +837,38 @@ alternateReportStorage:
   podSecurityContext:
     runAsUser: 10000
     fsGroup: 10000
+
+# -- extraContainers is a list of additional sidecar containers to inject into the
+# trivy-operator deployment pod. This enables use cases like log shippers, report
+# exporters, monitoring agents, or custom processing sidecars.
+# Each entry is a standard Kubernetes container spec.
+# When alternateReportStorage.enabled is true, the report PVC volume is automatically
+# mounted into each extra container at alternateReportStorage.mountPath so sidecars
+# can access report files without manual volume mount configuration.
+extraContainers: []
+# - name: log-shipper
+#   image: busybox:latest
+#   command:
+#     - /bin/sh
+#     - -c
+#     - "tail -f /var/log/*.log"
+#   volumeMounts:
+#     - name: logs
+#       mountPath: /var/log
+#   resources:
+#     requests:
+#       cpu: 100m
+#       memory: 64Mi
+#     limits:
+#       cpu: 200m
+#       memory: 128Mi
+
+# -- extraVolumes is a list of additional volumes to add to the trivy-operator
+# deployment pod. These volumes can be referenced by volumeMounts in both the main
+# operator container and any extra containers defined in extraContainers.
+extraVolumes: []
+# - name: logs
+#   emptyDir: {}
+# - name: custom-config
+#   configMap:
+#     name: my-custom-config


### PR DESCRIPTION
## Summary
- Adds `extraContainers` and `extraVolumes` values to inject sidecar containers and additional volumes into the trivy-operator deployment pod.
- When `alternateReportStorage` is enabled, the report PVC is automatically mounted into each extra container so sidecars can access report files without manual volume configuration.
- Refactors the volumes block to cleanly combine `volumes`, `alternateReportStorage`, and `extraVolumes` under a single conditional.

## Test plan
- [x] `helm template` with defaults produces unchanged output
- [x] `helm template` with `extraContainers` and `extraVolumes` set renders sidecar and volume correctly
- [x] `helm template` with `alternateReportStorage.enabled=true` + `extraContainers` auto-mounts the PVC into sidecars
- [x] `helm template` with only `alternateReportStorage.enabled=true` (no extraContainers) still works as before