### PR TITLE
feat(helm): add generic command/args override and customConfigMap volume

### DIFF
--- a/deploy/helm/templates/configmaps/custom-configmap.yaml
+++ b/deploy/helm/templates/configmaps/custom-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.operator.customConfigMap.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-custom
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.operator.customConfigMap.data }}
+  {{ $key }}: |
+    {{- tpl $value $ | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- with .Values.operator.command }}
+          command: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.operator.args }}
+          args: {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
               value: {{ include "trivy-operator.namespace" . }}
@@ -103,15 +109,20 @@ spec:
           {{- with .Values.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or .Values.volumeMounts .Values.alternateReportStorage.enabled .Values.operator.customConfigMap.create .Values.operator.customConfigMap.existingConfigMap }}
+          volumeMounts:
           {{- with .Values.volumeMounts }}
-          volumeMounts: {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.alternateReportStorage.enabled }}
-          {{- if not .Values.volumeMounts }}
-          volumeMounts:
-          {{- end }}
             - name: {{ .Values.alternateReportStorage.volumeName }}
               mountPath: {{ .Values.alternateReportStorage.mountPath }}
+          {{- end }}
+          {{- if or .Values.operator.customConfigMap.create .Values.operator.customConfigMap.existingConfigMap }}
+            - name: custom-configmap
+              mountPath: {{ .Values.operator.customConfigMap.mountPath }}
+              readOnly: true
+          {{- end }}
           {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
@@ -127,16 +138,22 @@ spec:
         fsGroup:   {{ .Values.alternateReportStorage.podSecurityContext.fsGroup }}
       {{- end }}
       {{- end }}
+      {{- if or .Values.volumes .Values.alternateReportStorage.enabled .Values.operator.customConfigMap.create .Values.operator.customConfigMap.existingConfigMap }}
+      volumes:
       {{- with .Values.volumes }}
-      volumes: {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.alternateReportStorage.enabled }}
-      {{- if not .Values.volumes }}
-      volumes:
-      {{- end }}
         - name: {{ .Values.alternateReportStorage.volumeName }}
           persistentVolumeClaim:
             claimName: {{ .Values.alternateReportStorage.volumeName }}
+      {{- end }}
+      {{- if or .Values.operator.customConfigMap.create .Values.operator.customConfigMap.existingConfigMap }}
+        - name: custom-configmap
+          configMap:
+            name: {{ if .Values.operator.customConfigMap.existingConfigMap }}{{ .Values.operator.customConfigMap.existingConfigMap }}{{ else }}{{ include "trivy-operator.fullname" . }}-custom{{ end }}
+            defaultMode: {{ .Values.operator.customConfigMap.defaultMode }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -202,6 +202,49 @@ operator:
   # -- pprofBindAddress the address to bind the pprof server to. By default, it is not enabled.
   pprofBindAddress: ""
 
+  # -- command override for the operator container (list)
+  command: []
+  # -- args override for the operator container (list)
+  args: []
+
+  # -- customConfigMap mounts a ConfigMap into the operator pod as a volume.
+  # Use this for entrypoint scripts, config files, or any data the operator needs.
+  # Either provide inline data (create: true + data) or reference an existing ConfigMap.
+  customConfigMap:
+    # -- create a ConfigMap from inline data below
+    create: false
+    # -- name of the existing ConfigMap to mount (when create is false)
+    existingConfigMap: ""
+    # -- inline data for the ConfigMap (only when create: true).
+    # Keys are filenames, values are file contents. Supports Helm templating via tpl.
+    data: {}
+    # -- mountPath where the ConfigMap is mounted in the container
+    mountPath: "/scripts"
+    # -- defaultMode for the mounted files (0555 = read+execute)
+    defaultMode: 0555
+
+  # Example: periodic restart wrapper for alternateReportStorage TTL workaround
+  # When using alternateReportStorage (file-based mode), scannerReportTTL is not
+  # enforced by the operator (see https://github.com/aquasecurity/trivy-operator/issues/2869).
+  # This wrapper periodically kills and restarts the operator to force rescans.
+  #
+  # operator:
+  #   command: ["/bin/sh", "/scripts/entrypoint.sh"]
+  #   customConfigMap:
+  #     create: true
+  #     data:
+  #       entrypoint.sh: |
+  #         #!/bin/sh
+  #         TTL=$((24 * 3600))  # 24h in seconds — adjust to match scannerReportTTL
+  #         trap 'kill $PID $TIMER 2>/dev/null; exit 0' TERM INT
+  #         while true; do
+  #           trivy-operator & PID=$!
+  #           (sleep "$TTL" && kill $PID 2>/dev/null) & TIMER=$!
+  #           wait $PID 2>/dev/null || true
+  #           kill $TIMER 2>/dev/null; wait $TIMER 2>/dev/null || true
+  #           sleep 2
+  #         done
+
 image:
   registry: "mirror.gcr.io"
   repository: "aquasec/trivy-operator"


### PR DESCRIPTION
- Add operator.command and operator.args for container command override
- Add operator.customConfigMap to mount inline or existing ConfigMap volumes
- Useful for wrapping the operator with custom entrypoint scripts

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
