### PR TITLE
feat(helm): change extraEnv to map with envFrom, add extraEnvSecrets

### DIFF
--- a/deploy/helm/templates/configmaps/extraenv.yaml
+++ b/deploy/helm/templates/configmaps/extraenv.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.extraEnv }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-extraenv
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -56,9 +56,6 @@ spec:
               value: {{ tpl .Values.targetWorkloads . | quote }}
             - name: OPERATOR_SERVICE_ACCOUNT
               value: {{ include "trivy-operator.serviceAccountName" . | quote }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
           {{- if .Values.alternateReportStorage.enabled }}
             - name: OPERATOR_ALTERNATE_REPORT_STORAGE_ENABLED
               value: "true"
@@ -75,6 +72,14 @@ spec:
             {{- if .Values.operator.valuesFromSecret }}
             - secretRef:
                 name: {{ .Values.operator.valuesFromSecret }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            - configMapRef:
+                name: {{ include "trivy-operator.fullname" . }}-extraenv
+            {{- end }}
+            {{- if .Values.extraEnvSecrets }}
+            - secretRef:
+                name: {{ include "trivy-operator.fullname" . }}-extraenv
             {{- end }}
           ports:
             - name: metrics

--- a/deploy/helm/templates/secrets/extraenv.yaml
+++ b/deploy/helm/templates/secrets/extraenv.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.extraEnvSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-extraenv
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.extraEnvSecrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -20,8 +20,16 @@ targetNamespaces: ""
 # mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: ""
 
-# -- extraEnv is a list of extra environment variables for the trivy-operator.
-extraEnv: []
+# -- extraEnv is a map of extra environment variables for the trivy-operator.
+# Rendered into a ConfigMap and attached via envFrom.
+extraEnv: {}
+  # LOG_LEVEL: "info"
+  # FEATURE_X: "true"
+
+# -- extraEnvSecrets is a map of sensitive environment variables for the trivy-operator.
+# Rendered into a Secret (stringData) and attached via envFrom.
+extraEnvSecrets: {}
+  # DATABASE_URL: "postgres://user:pass@db:5432/app"
 
 # -- hostAliases for `deployment` (TrivyOperator) and `statefulset` (TrivyServer)
 


### PR DESCRIPTION
- [BREAKING] Change extraEnv from a list (inline env vars) to a map rendered into a ConfigMap and attached via envFrom
- Add extraEnvSecrets map rendered into a Secret (stringData) via envFrom
- Simpler key/value format replaces verbose name/value list syntax

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
