### PR TITLE
fix: avoid premature tmp cleanup for multi-container scans

### DIFF
--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -100,13 +100,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 
 	trivyConfigName := trivyoperator.GetPluginConfigMapName(Plugin)
 
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      tmpVolumeName,
-			ReadOnly:  false,
-			MountPath: "/tmp",
-		},
-	}
+	var volumeMounts []corev1.VolumeMount
 	volumes := []corev1.Volume{
 		{
 			Name: tmpVolumeName,
@@ -117,6 +111,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 			},
 		},
 	}
+
 	if volume, volumeMount := config.GenerateSslCertDirVolumeIfAvailable(trivyConfigName); volume != nil && volumeMount != nil {
 		volumes = append(volumes, *volume)
 		volumeMounts = append(volumeMounts, *volumeMount)
@@ -129,6 +124,14 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 	}
 
 	var initContainers []corev1.Container
+	initContainerVolumeMounts := append(
+		[]corev1.VolumeMount{
+			{
+				Name:      tmpVolumeName,
+				ReadOnly:  false,
+				MountPath: "/tmp",
+			},
+		}, volumeMounts...)
 
 	trivyImageRef, err := config.GetImageRef()
 	if err != nil {
@@ -186,7 +189,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 			Args:            []string{"registry", "login", javaDbRegistry.Context().Registry.Name()}, // TRIVY_USERNAME and TRIVY_PASSWORD are set up in initContainerEnvVar()
 			Resources:       resourceRequirements,
 			SecurityContext: securityContext,
-			VolumeMounts:    volumeMounts,
+			VolumeMounts:    initContainerVolumeMounts,
 		})
 	}
 
@@ -211,7 +214,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 			Args:            append(args, "--download-db-only", "--db-repository", dbRepository),
 			Resources:       resourceRequirements,
 			SecurityContext: securityContext,
-			VolumeMounts:    volumeMounts,
+			VolumeMounts:    initContainerVolumeMounts,
 		})
 	}
 
@@ -238,6 +241,14 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), c.Image) {
 			continue
 		}
+		containerVolumeMounts := []corev1.VolumeMount{{
+			Name:      tmpVolumeName,
+			ReadOnly:  false,
+			MountPath: "/tmp",
+			SubPath:   c.Name,
+		}}
+		containerVolumeMounts = append(containerVolumeMounts, volumeMounts...)
+
 		env := []corev1.EnvVar{
 			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, KeyTrivySeverity),
 			constructEnvVarSourceFromConfigMap("TRIVY_IGNORE_UNFIXED", trivyConfigName, keyTrivyIgnoreUnfixed),
@@ -307,7 +318,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 			registryPasswordKey := fmt.Sprintf("%s.password", c.Name)
 			if CheckGcpCrOrPrivateRegistry(c.Image) &&
 				ctx.GetTrivyOperatorConfig().GetScanJobUseGCRServiceAccount() {
-				createEnvandVolumeForGcr(&env, &volumeMounts, &volumes, &registryPasswordKey, &secret.Name)
+				createEnvandVolumeForGcr(&env, &containerVolumeMounts, &volumes, &registryPasswordKey, &secret.Name)
 			} else {
 				env = append(env, corev1.EnvVar{
 					Name: "TRIVY_USERNAME",
@@ -359,7 +370,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 				secrets = append(secrets, &secret)
 				fileName := fmt.Sprintf("%s.json", secretName)
 				mountPath := fmt.Sprintf("/sbom-%s", c.Name)
-				CreateVolumeSbomFiles(&volumeMounts, &volumes, &secretName, fileName, mountPath, c.Name)
+				CreateVolumeSbomFiles(&containerVolumeMounts, &volumes, &secretName, fileName, mountPath, c.Name)
 				cmd, args = GetSbomScanCommandAndArgs(ctx, mode, fmt.Sprintf("%s/%s", mountPath, fileName), trivyServerURL, resultFileName)
 			}
 		}
@@ -373,7 +384,7 @@ func GetPodSpecForImageScan(ctx trivyoperator.PluginContext,
 			Args:                     args,
 			Resources:                resourceRequirements,
 			SecurityContext:          securityContext,
-			VolumeMounts:             volumeMounts,
+			VolumeMounts:             containerVolumeMounts,
 		})
 	}
 	return corev1.PodSpec{

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -52,11 +52,8 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 		},
 	}
 
-	tmpVolumeMount := corev1.VolumeMount{
-		Name:      "tmp",
-		MountPath: "/tmp",
-		ReadOnly:  false,
-	}
+	initContainerTmpVolumeMount := getTmpVolumeMount()
+	tmpVolumeMount := getTmpVolumeMountWithSubPath("nginx")
 
 	timeoutEnv := corev1.EnvVar{
 		Name: "TRIVY_TIMEOUT",
@@ -208,7 +205,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -492,7 +489,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -780,7 +777,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1088,7 +1085,7 @@ CVE-2019-1543`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1401,7 +1398,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1697,7 +1694,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -1985,7 +1982,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -2363,7 +2360,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -2593,7 +2590,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -2828,7 +2825,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -3063,7 +3060,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -3318,7 +3315,7 @@ CVE-2019-1543`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount(),
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount(),
 							{
 								Name:      "ignorefile",
 								MountPath: "/etc/trivy/.trivyignore",
@@ -3579,7 +3576,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount(),
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount(),
 							{
 								Name:      "ignorepolicy",
 								MountPath: "/etc/trivy/policy.rego",
@@ -3815,7 +3812,7 @@ default ignore = false`,
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{getTmpVolumeMount(), getScanResultVolumeMount()},
+						VolumeMounts: []corev1.VolumeMount{tmpVolumeMount, getScanResultVolumeMount()},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
 							AllowPrivilegeEscalation: ptr.To[bool](false),
@@ -5282,7 +5279,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5579,7 +5576,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -5896,7 +5893,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -6204,7 +6201,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               ptr.To[bool](false),
@@ -6510,7 +6507,7 @@ default ignore = false`,
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
-							tmpVolumeMount,
+							initContainerTmpVolumeMount,
 							corev1.VolumeMount{
 								Name:      "configfile",
 								MountPath: "/etc/trivy/trivy-config.yaml",
@@ -7958,6 +7955,15 @@ func getTmpVolumeMount() corev1.VolumeMount {
 		Name:      "tmp",
 		ReadOnly:  false,
 		MountPath: "/tmp",
+	}
+}
+
+func getTmpVolumeMountWithSubPath(subPath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "tmp",
+		ReadOnly:  false,
+		MountPath: "/tmp",
+		SubPath:   subPath,
 	}
 }
 


### PR DESCRIPTION
## Description
When running trivy-operator in ClientServer mode, ScanJobs will fail due to the temp directory being cleaned up by another container's scan. This causes VulnerabilityReports to either not be generated, or delayed until you are lucky enough for all containers to complete their image scans before a cleanup occurs.

This pull request is based on the patch @daanschipper mentioned in the original issue (https://github.com/daanschipper/trivy-operator/commit/17491139c5a38a662819d44937ba7594df743e21) to use per-container tmp volumes when running scans to avoid the premature temp file cleanup.

## Related issues
- Close #2815

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
