### PR TITLE
docs: clarify potential flag collision

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -115,7 +115,10 @@ operator:
   configAuditScannerScanOnlyCurrentRevisions: true
   # -- batchDeleteDelay the duration to wait before deleting another batch of config audit reports.
   batchDeleteDelay: 10s
-  # -- accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts to allow `vulnerability scan job` to pull images from private registries
+  # -- accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts so that
+  # `vulnerability scan jobs` may derive and access imagePullSecrets from the pod's or serviceaccount's spec.
+  # The setting is mutually exclusive with privateRegistryScanSecretsNames, when true, secrets from privateRegistryScanSecretsNames
+  # are not considered when pulling images to scan
   accessGlobalSecretsAndServiceAccount: true
   # -- builtInTrivyServer The flag enables the usage of built-in trivy server in cluster. It also overrides the following trivy params with built-in values
   # trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975
@@ -178,7 +181,11 @@ operator:
   # -- webhookSendDeletedReports the flag to enable sending deleted reports if webhookBroadcastURL is enabled
   webhookSendDeletedReports: false
 
-  # -- privateRegistryScanSecretsNames is map of namespace:secrets, secrets are comma seperated which can be used to authenticate in private registries in case if there no imagePullSecrets provided example : {"mynamespace":"mySecrets,anotherSecret"}
+  # -- privateRegistryScanSecretsNames is a map of namespace:secrets, secrets are comma separated, which can be used to
+  # authenticate in private registries in case no imagePullSecrets may be derived from pod's or serviceaccount's spec,
+  # example : {"mynamespace":"mySecrets,anotherSecret"}
+  # The setting is mutually exclusive with accessGlobalSecretsAndServiceAccount, the former must be set to false for
+  # secrets from privateRegistryScanSecretsNames to be considered when pulling images to scan
   privateRegistryScanSecretsNames: {}
 
   # -- mergeRbacFindingWithConfigAudit the flag to enable merging rbac finding with config-audit report

--- a/docs/tutorials/private-registries.md
+++ b/docs/tutorials/private-registries.md
@@ -216,9 +216,11 @@ kubectl apply -f imagepullsecret.yaml -n app
 ```
 
 Next, we will change the `privateRegistryScanSecretsNames` of the `values.yaml` manifest. For this, we can create a new `values.yaml` manifest with our desired modification. We need to provide desired namespace and secret name. In our example they are `app` and `dockerconfigjson-github-com` accordingly.
+Note that `privateRegistryScanSecretsNames` are evaluated only when `accessGlobalSecretsAndServiceAccount` is set to `false`.
 
 ```sh
 operator:
+    accessGlobalSecretsAndServiceAccount: false
     privateRegistryScanSecretsNames: {"app":"dockerconfigjson-github-com"}
 ```
 


### PR DESCRIPTION
## Description

First, thank you very much for developing the trivy suite and making it available to the general public.

More specifically, accessGlobalSecretsAndServiceAccount may not be true for privateRegistryScanSecretsNames to be considered.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
