### PR TITLE
chore(helm): set sensible resource defaults and drop CPU limits

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -508,7 +508,7 @@ trivy:
       memory: 100M
       # ephemeralStorage: "2Gi"
     limits:
-      cpu: 500m
+      # cpu: 500m
       memory: 500M
       # ephemeralStorage: "2Gi"
 
@@ -606,11 +606,11 @@ trivy:
     # -- resources set trivy-server resource
     resources:
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 25m
+        memory: 150Mi
         # ephemeral-storage: "2Gi"
       limits:
-        cpu: 1
+        # cpu: 1
         memory: 1Gi
         # ephemeral-storage: "2Gi"
 
@@ -705,17 +705,12 @@ volumes:
   - name: cache-policies
     emptyDir: {}
 
-resources: {}
-# -- We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you do want to specify resources, uncomment the following
-# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-# limits:
-#   cpu: 100m
-#   memory: 128Mi
-# requests:
-#   cpu: 100m
-#   memory: 128Mi
+resources:
+  requests:
+    cpu: 35m
+    memory: 300Mi
+  limits:
+    memory: 500Mi
 
 # -- nodeSelector set the operator nodeSelector
 nodeSelector: {}


### PR DESCRIPTION
## Summary

- Set production-tested resource defaults for the operator pod (was `resources: {}`)
- Lower trivy-server resource requests to match real-world usage
- Comment out all CPU limits across components to allow burstable scheduling

## Motivation

Helm deep-merges dictionaries, so consumers using ArgoCD or extra values overlays **cannot remove individual keys** from resource specs — they can only change values. Lists are replaced entirely, but dict keys are permanent once set in `values.yaml`.

This means if the chart ships with `resources.requests.cpu: 200m` and a user doesn't want a CPU request at all (e.g. for burstable QoS), there's no way to remove that key via values overrides.

## Alternative approach

If setting static defaults is not desirable, replacing the current resource blocks with `resources: {}` would also solve the merge problem — consumers can then define exactly the keys they need without inheriting any they can't remove. Happy to adjust the PR either way.

## Changes

| Section | Before | After |
|---|---|---|
| `resources` (operator) | `{}` | requests: 35m CPU, 300Mi mem; limits: 500Mi mem |
| `trivy.resources` (scan jobs) | `cpu: 500m` limit active | CPU limit commented out |
| `trivy.server.resources` | 200m CPU, 512Mi mem requests; `cpu: 1` limit | 25m CPU, 150Mi mem requests; CPU limit commented out |

## Test plan

- [ ] `helm template` renders correct resource blocks for operator deployment
- [ ] `helm template` renders correct resource blocks for trivy server statefulset
- [ ] Verify no active CPU limits in rendered output
- [ ] Deploy with extra values overlay and confirm keys can be added/changed as expected