### PR TITLE
Add Kubernetes health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <img src="https://img.shields.io/static/v1?label=Slack&message=Join+our+Community&color=4a154b&logo=slack">
 </a>
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/trivy-operator)](https://artifacthub.io/packages/helm/trivy-operator/trivy-operator)
+[![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)](https://releaserun.com/badges/kubernetes/)
 
 # Introduction
 


### PR DESCRIPTION
Adds a [ReleaseRun](https://releaserun.com) health badge showing the current health status of Kubernetes. Updates automatically based on version freshness, CVE status, and end-of-life timeline.

**Preview**: ![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)

Free, no API key needed. Happy to adjust placement if you'd prefer it elsewhere.