### PR TITLE
fix: replace deprecated --slow flag with --parallel 1 for Trivy >= 0.48.0

### DIFF
--- a/pkg/plugins/trivy/flags.go
+++ b/pkg/plugins/trivy/flags.go
@@ -18,7 +18,9 @@ func compareTagVersion(currentTag, constraint string) bool {
 	return c.Check(v)
 }
 
-// Slow determine if to use the slow flag (improve memory footprint)
+// Slow determine if to use the slow flag or its replacement --parallel
+// (improve memory footprint). Trivy >= 0.48.0 deprecated --slow in favor
+// of --parallel 1.
 func Slow(c Config) string {
 	tag, err := c.GetImageTag()
 	if err != nil {
@@ -29,6 +31,9 @@ func Slow(c Config) string {
 		return ""
 	}
 	if c.GetSlow() {
+		if compareTagVersion(tag, ">= 0.48.0") {
+			return "--parallel 1"
+		}
 		return "--slow"
 	}
 	return ""

--- a/pkg/plugins/trivy/flags_test.go
+++ b/pkg/plugins/trivy/flags_test.go
@@ -16,7 +16,7 @@ func TestSlow(t *testing.T) {
 		want       string
 	}{{
 
-		name: "slow param set to true",
+		name: "slow param set to true with old tag",
 		configData: map[string]string{
 			"trivy.tag":  "0.35.0",
 			"trivy.slow": "true",
@@ -32,7 +32,7 @@ func TestSlow(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "slow param set to no valid value",
+			name: "slow param set to no valid value with old tag",
 			configData: map[string]string{
 				"trivy.tag":  "0.35.0",
 				"trivy.slow": "false2",
@@ -49,12 +49,28 @@ func TestSlow(t *testing.T) {
 		},
 
 		{
-			name: "slow param set to true and trivy tag is bigger then 0.35.0",
+			name: "slow param set to true and trivy tag is between 0.35.0 and 0.48.0",
 			configData: map[string]string{
 				"trivy.slow": "true",
 				"trivy.tag":  "0.36.0",
 			},
 			want: "--slow",
+		},
+		{
+			name: "slow param set to true and trivy tag is 0.48.0 uses --parallel 1",
+			configData: map[string]string{
+				"trivy.slow": "true",
+				"trivy.tag":  "0.48.0",
+			},
+			want: "--parallel 1",
+		},
+		{
+			name: "slow param set to true and trivy tag is higher than 0.48.0 uses --parallel 1",
+			configData: map[string]string{
+				"trivy.slow": "true",
+				"trivy.tag":  "0.69.0",
+			},
+			want: "--parallel 1",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- Replace deprecated `--slow` flag with `--parallel 1` for Trivy versions >= 0.48.0
- Maintain backward compatibility: `--slow` is still used for Trivy 0.35.0–0.47.x

## Motivation
Closes #2896 — Trivy v0.48.0 deprecated `--slow` in favor of `--parallel 1` ([aquasecurity/trivy#5572](https://github.com/aquasecurity/trivy/pull/5572)). The operator was still emitting `--slow` for all versions, causing `WARN "--slow" is deprecated. Use "--parallel 1" instead.` in scan job logs.

## Changes
- `pkg/plugins/trivy/flags.go`: Add version check — emit `--parallel 1` for >= 0.48.0, `--slow` for < 0.48.0
- `pkg/plugins/trivy/flags_test.go`: Add test cases for 0.48.0 and 0.69.0 expecting `--parallel 1`

## Test plan
- [x] Existing tests for tags < 0.48.0 pass unchanged (still expect `--slow`)
- [x] New test: tag `0.48.0` → expects `--parallel 1`
- [x] New test: tag `0.69.0` → expects `--parallel 1`
- [x] Plugin tests use tag `0.35.0` — unaffected by this change