### PR TITLE
chore: bump up Trivy to version v0.69.3

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -153,7 +153,7 @@ Keeps security report resources updated
 | trivy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy is the imge pull policy used for trivy image , valid values are (Always, Never, IfNotPresent) |
 | trivy.image.registry | string | `"mirror.gcr.io"` | registry of the Trivy image |
 | trivy.image.repository | string | `"aquasec/trivy"` | repository of the Trivy image |
-| trivy.image.tag | string | `"0.69.2"` | tag version of the Trivy image |
+| trivy.image.tag | string | `"0.69.3"` | tag version of the Trivy image |
 | trivy.imageScanCacheDir | string | `"/tmp/trivy/.cache"` | imageScanCacheDir the flag to set custom path for trivy image scan `cache-dir` parameter. Only applicable in image scan mode. |
 | trivy.includeDevDeps | bool | `false` | includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false) note: this flag is only applicable when trivy.command is set to filesystem |
 | trivy.insecureRegistries | object | `{}` | The registry to which insecure connections are allowed. There can be multiple registries with different keys. |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -360,7 +360,7 @@ trivy:
     # -- repository of the Trivy image
     repository: aquasec/trivy
     # -- tag version of the Trivy image
-    tag: 0.69.2
+    tag: 0.69.3
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
     imagePullSecret: ~

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -3047,7 +3047,7 @@ metadata:
     app.kubernetes.io/managed-by: kubectl
 data:
   trivy.repository: "mirror.gcr.io/aquasec/trivy"
-  trivy.tag: "0.69.2"
+  trivy.tag: "0.69.3"
   trivy.imagePullPolicy: "IfNotPresent"
   trivy.additionalVulnerabilityReportFields: ""
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"

--- a/docs/docs/crds/clustervulnerability-report.md
+++ b/docs/docs/crds/clustervulnerability-report.md
@@ -44,7 +44,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.69.2
+    version: 0.69.3
   summary:
     criticalCount: 0
     highCount: 4

--- a/docs/docs/crds/configaudit-report.md
+++ b/docs/docs/crds/configaudit-report.md
@@ -34,7 +34,7 @@ report:
   scanner:
     name: Trivy 
     vendor: Aqua Security
-    version: '0.69.2'
+    version: '0.69.3'
   summary:
     criticalCount: 2
     highCount: 0

--- a/docs/docs/crds/exposedsecret-report.md
+++ b/docs/docs/crds/exposedsecret-report.md
@@ -39,7 +39,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.69.2
+    version: 0.69.3
   secrets:
   - category: Stripe
     match: 'publishable_key: *****'

--- a/docs/docs/crds/infraassessment-report.md
+++ b/docs/docs/crds/infraassessment-report.md
@@ -404,7 +404,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: '0.69.2'
+    version: '0.69.3'
   summary:
     criticalCount: 0
     highCount: 0

--- a/docs/docs/crds/rbacassessment-report.md
+++ b/docs/docs/crds/rbacassessment-report.md
@@ -176,7 +176,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: '0.69.2'
+    version: '0.69.3'
   summary:
     criticalCount: 1
     highCount: 0

--- a/docs/docs/crds/sbom-report.md
+++ b/docs/docs/crds/sbom-report.md
@@ -162,7 +162,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.69.2
+    version: 0.69.3
   summary:
     componentsCount: 5
     dependenciesCount: 5

--- a/docs/docs/crds/vulnerability-report.md
+++ b/docs/docs/crds/vulnerability-report.md
@@ -41,7 +41,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.69.2
+    version: 0.69.3
   summary:
     criticalCount: 2
     highCount: 0

--- a/docs/docs/design/design_trivy_file_system_scanner.md
+++ b/docs/docs/design/design_trivy_file_system_scanner.md
@@ -117,10 +117,10 @@ spec:
           emptyDir: { }
       initContainers:
         # The trivy-get-binary init container is used to copy out the trivy executable
-        # binary from the upstream Trivy container image, i.e. aquasec/trivy:0.69.2,
+        # binary from the upstream Trivy container image, i.e. aquasec/trivy:0.69.3,
         # to a shared emptyDir volume.
         - name: trivy-get-binary
-          image: aquasec/trivy:0.69.2
+          image: aquasec/trivy:0.69.3
           command:
             - cp
             - -v
@@ -135,7 +135,7 @@ spec:
         # This won't be required once Trivy supports ClientServer mode
         # for the fs subcommand.
         - name: trivy-download-db
-          image: aquasec/trivy:0.69.2
+          image: aquasec/trivy:0.69.3
           command:
             - /var/trivy-operator/trivy
             - --download-db-only

--- a/docs/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
+++ b/docs/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
@@ -167,7 +167,7 @@ spec:
           emptyDir: { }
       initContainers:
         - name: trivy-get-binary
-          image: aquasec/trivy:0.69.2
+          image: aquasec/trivy:0.69.3
           command:
             - cp
             - -v
@@ -177,7 +177,7 @@ spec:
             - name: scan-volume
               mountPath: /var/trivy-operator
         - name: trivy-download-db
-          image: aquasec/trivy:0.69.2
+          image: aquasec/trivy:0.69.3
           command:
             - /var/trivy-operator/trivy
             - --download-db-only

--- a/docs/docs/design/ttl_scans.md
+++ b/docs/docs/design/ttl_scans.md
@@ -45,7 +45,7 @@ report:
   scanner:
     name: Trivy
     vendor: Aqua Security
-    version: 0.69.2
+    version: 0.69.3
   summary:
     criticalCount: 0
     highCount: 0

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/aquasecurity/trivy-operator
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.10.0
 	github.com/aquasecurity/go-version v0.0.1
-	github.com/aquasecurity/trivy v0.69.2
+	github.com/aquasecurity/trivy v0.69.3
 	github.com/aquasecurity/trivy-checks v1.12.2-0.20251219190323-79d27547baf5
 	github.com/aquasecurity/trivy-kubernetes v0.9.1
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17 h1:/xWTD1Y
 github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17/go.mod h1:6kYuX29QyBWHJejvbKkA4yzz8EUX/Fn+GmQ09JAZ5lY=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy v0.69.2 h1:nFnB7gEVFWi2QFqPJyn8Zy1bVDKaUljnIy2utUU4Ss4=
-github.com/aquasecurity/trivy v0.69.2/go.mod h1:7JBeGh/u2VguQ/sAmwaoBcYKNlswEXw4xm2HWnn/tZk=
+github.com/aquasecurity/trivy v0.69.3 h1:Q9zHTOiNqPy3/GGn2iJ9nfdzGc5HGiE1i12UNWtzK7U=
+github.com/aquasecurity/trivy v0.69.3/go.mod h1:+zF17ZBOdhFWwD3+GkLxZ/vkmKLudoOtt+hgnc1TQpA=
 github.com/aquasecurity/trivy-checks v1.12.2-0.20251219190323-79d27547baf5 h1:8HnXyjgCiJwVX1mTKeqdyizd7ZBmXMPL+BMQ5UZd0Nk=
 github.com/aquasecurity/trivy-checks v1.12.2-0.20251219190323-79d27547baf5/go.mod h1:hBSA3ziBFwGENK6/PYNIKm6N24SFg0wsv1VXeqPG/3M=
 github.com/aquasecurity/trivy-db v0.0.0-20251222105351-a833f47f8f0d h1:mwCxwhDRnW5UkSQdZfekTCjaLyWp1rqfIa6KKRdMDAo=

--- a/pkg/plugins/trivy/config_test.go
+++ b/pkg/plugins/trivy/config_test.go
@@ -776,7 +776,7 @@ func TestPlugin_Init(t *testing.T) {
 			},
 			Data: map[string]string{
 				"trivy.repository":                DefaultImageRepository,
-				"trivy.tag":                       "0.69.2",
+				"trivy.tag":                       "0.69.3",
 				"trivy.severity":                  DefaultSeverity,
 				"trivy.slow":                      "true",
 				"trivy.mode":                      string(Standalone),

--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -80,7 +80,7 @@ func (p *plugin) Init(ctx trivyoperator.PluginContext) error {
 	return ctx.EnsureConfig(trivyoperator.PluginConfig{
 		Data: map[string]string{
 			keyTrivyImageRepository:           DefaultImageRepository,
-			keyTrivyImageTag:                  "0.69.2",
+			keyTrivyImageTag:                  "0.69.3",
 			KeyTrivySeverity:                  DefaultSeverity,
 			keyTrivySlow:                      "true",
 			keyTrivyMode:                      string(Standalone),

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -6089,7 +6089,7 @@ default ignore = false`,
 			},
 			config: map[string]string{
 				"trivy.repository":                "docker.io/aquasec/trivy",
-				"trivy.tag":                       "0.69.2",
+				"trivy.tag":                       "0.69.3",
 				"trivy.mode":                      string(trivy.Standalone),
 				"trivy.dbRepository":              trivy.DefaultDBRepository,
 				"trivy.javaDbRepository":          trivy.DefaultJavaDBRepository,
@@ -6129,7 +6129,7 @@ default ignore = false`,
 				InitContainers: []corev1.Container{
 					{
 						Name:                     "00000000-0000-0000-0000-000000000001",
-						Image:                    "docker.io/aquasec/trivy:0.69.2",
+						Image:                    "docker.io/aquasec/trivy:0.69.3",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
@@ -6219,7 +6219,7 @@ default ignore = false`,
 				Containers: []corev1.Container{
 					{
 						Name:                     "nginx",
-						Image:                    "docker.io/aquasec/trivy:0.69.2",
+						Image:                    "docker.io/aquasec/trivy:0.69.3",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
@@ -6376,7 +6376,7 @@ default ignore = false`,
 			},
 			config: map[string]string{
 				"trivy.repository":                "docker.io/aquasec/trivy",
-				"trivy.tag":                       "0.69.2",
+				"trivy.tag":                       "0.69.3",
 				"trivy.mode":                      string(trivy.Standalone),
 				"trivy.dbRepository":              trivy.DefaultDBRepository,
 				"trivy.javaDbRepository":          trivy.DefaultJavaDBRepository,
@@ -6433,7 +6433,7 @@ default ignore = false`,
 				InitContainers: []corev1.Container{
 					{
 						Name:                     "00000000-0000-0000-0000-000000000001",
-						Image:                    "docker.io/aquasec/trivy:0.69.2",
+						Image:                    "docker.io/aquasec/trivy:0.69.3",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{
@@ -6530,7 +6530,7 @@ default ignore = false`,
 				Containers: []corev1.Container{
 					{
 						Name:                     "nginx",
-						Image:                    "docker.io/aquasec/trivy:0.69.2",
+						Image:                    "docker.io/aquasec/trivy:0.69.3",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{

--- a/pkg/vulnerabilityreport/controller/scanjob_test.go
+++ b/pkg/vulnerabilityreport/controller/scanjob_test.go
@@ -234,7 +234,7 @@ func TestStreamReportToFile(t *testing.T) {
 					Scanner: TestScanner{
 						Name:    "Trivy",
 						Vendor:  "Aqua Security",
-						Version: "v0.69.2",
+						Version: "v0.69.3",
 					},
 					Summary: TestSummary{
 						CriticalCount: 2,
@@ -406,7 +406,7 @@ func BenchmarkStreamReportToFile(b *testing.B) {
 			Scanner: TestScanner{
 				Name:    "Trivy",
 				Vendor:  "Aqua Security",
-				Version: "v0.69.2",
+				Version: "v0.69.3",
 			},
 			Summary: TestSummary{
 				MediumCount: 100,


### PR DESCRIPTION
## Description
It bumps up Trivy to version v0.69.3.

Also this PR fixes vulnerabilities in the deps.
```sh
% trivy i -q docker.io/afdesk/trivy-operator:v0.69.3  

Report Summary

┌─────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                         Target                          │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/afdesk/trivy-operator:v0.69.3 (alpine 3.23.3) │  alpine  │        0        │    -    │
├─────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/trivy-operator                            │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
```
## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
