### PR TITLE
fix: Added rbac.create flag check for end-user clusterroles in helm chart

### DIFF
--- a/deploy/helm/templates/rbac/view-configauditreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-configauditreports-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 # permissions for end users to view configauditreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/deploy/helm/templates/rbac/view-exposedsecretreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-exposedsecretreports-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 # permissions for end users to view exposedsecretreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/deploy/helm/templates/rbac/view-vulnerabilityreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-vulnerabilityreports-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 # permissions for end users to view vulnerabilityreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}


### PR DESCRIPTION
## Description
I want to install the trivy-operator more than once, as I need them to watch different namespaces with different settings (vex repositories and the like).

However, the operator will try to install non-namespaced items multiple times. This should help fix it, as I will set `rbac.create: false` on all operators but one and create custom rbac for them.

I believe this is a fix, as `rbac.create: false` still creates clusterroles today.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
