### PR TITLE
fix: filesystem scan did not respect "--skip-java-db-update"

### DIFF
--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -527,6 +527,11 @@ func GetFSScanningArgs(ctx trivyoperator.PluginContext, command Command, mode Mo
 		args = append(args, "--server", trivyServerURL)
 	}
 
+	skipJavaDBUpdate := SkipJavaDBUpdate(c)
+	if skipJavaDBUpdate != "" {
+		args = append(args, skipJavaDBUpdate)
+	}
+
 	slow := Slow(c)
 	if slow != "" {
 		args = append(args, slow)
@@ -568,6 +573,10 @@ func GetSbomFSScanningArgs(ctx trivyoperator.PluginContext, mode Mode, trivyServ
 
 	if mode == ClientServer {
 		args = append(args, "--server", trivyServerURL)
+	}
+	skipJavaDBUpdate := SkipJavaDBUpdate(c)
+	if skipJavaDBUpdate != "" {
+		args = append(args, skipJavaDBUpdate)
 	}
 	slow := Slow(c)
 	if slow != "" {

--- a/pkg/plugins/trivy/filesystem_test.go
+++ b/pkg/plugins/trivy/filesystem_test.go
@@ -75,12 +75,13 @@ func TestGetSbomFSScanningArgs(t *testing.T) {
 
 func TestGetFSScanningArgs(t *testing.T) {
 	testCases := []struct {
-		name           string
-		mode           trivy.Mode
-		command        trivy.Command
-		serverUrl      string
-		resultFileName string
-		wantArgs       []string
+		name             string
+		mode             trivy.Mode
+		command          trivy.Command
+		serverUrl        string
+		resultFileName   string
+		skipJavaDBUpdate bool
+		wantArgs         []string
 	}{
 		{
 			name:     "command and args for standalone mode",
@@ -96,9 +97,32 @@ func TestGetFSScanningArgs(t *testing.T) {
 			resultFileName: "",
 			wantArgs:       []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--server", "http://trivy-server:8080", "--slow", "--include-dev-deps"},
 		},
+		{
+			name:             "standalone mode with skip java db update",
+			mode:             trivy.Standalone,
+			command:          trivy.Filesystem,
+			skipJavaDBUpdate: true,
+			wantArgs:         []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--skip-java-db-update", "--slow", "--include-dev-deps"},
+		},
+		{
+			name:             "client/server mode with skip java db update",
+			mode:             trivy.ClientServer,
+			command:          trivy.Rootfs,
+			serverUrl:        "http://trivy-server:8080",
+			skipJavaDBUpdate: true,
+			wantArgs:         []string{"--cache-dir", "/var/trivyoperator/trivy-db", "--quiet", "filesystem", "--scanners", "", "--skip-db-update", "--format", "json", "/", "--server", "http://trivy-server:8080", "--skip-java-db-update", "--slow", "--include-dev-deps"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			configData := map[string]string{
+				"trivy.tag":                    "0.41.0",
+				"trivy.clientServerSkipUpdate": "false",
+				"trivy.includeDevDeps":         "true",
+			}
+			if tc.skipJavaDBUpdate {
+				configData["trivy.skipJavaDBUpdate"] = "true"
+			}
 			client := fake.NewClientBuilder().
 				WithScheme(trivyoperator.NewScheme()).
 				WithObjects(&corev1.ConfigMap{
@@ -106,11 +130,7 @@ func TestGetFSScanningArgs(t *testing.T) {
 						Name:      "trivy-operator-trivy-config",
 						Namespace: "trivyoperator-ns",
 					},
-					Data: map[string]string{
-						"trivy.tag":                    "0.41.0",
-						"trivy.clientServerSkipUpdate": "false",
-						"trivy.includeDevDeps":         "true",
-					},
+					Data: configData,
 				}).
 				Build()
 


### PR DESCRIPTION
## Description

The `--skip-java-db-update` flag was not being passed to Trivy when running filesystem scans (both standalone and client/server mode). This meant that even when users configured `trivy.skipJavaDBUpdate: true`, filesystem scans would still attempt to update the Java DB.

This fix adds the `SkipJavaDBUpdate` argument to both `GetFSScanningArgs` and `GetFSClientServerScanningArgs`, consistent with how it is already handled in image scanning.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
