### PR TITLE
Bugfix/2938 add helm value access mode

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -13,7 +13,7 @@ Keeps security report resources updated
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | affinity set the operator affinity |
-| alternateReportStorage | object | `{"enabled":false,"mountPath":"/mnt/data/trivy-operator","podSecurityContext":{"fsGroup":10000,"runAsUser":10000},"storage":"10Gi","storageClassName":"","volumeName":"trivy-operator-pvc"}` | alternateReportStorage is the flag to enable alternate storage for all trivy reports (crds) in the form json files inside of a persistent volume |
+| alternateReportStorage | object | `{"enabled":false,"mountPath":"/mnt/data/trivy-operator","podSecurityContext":{"fsGroup":10000,"runAsUser":10000},"storage":"10Gi","storageClassName":"","accessModes":["ReadWriteOnce"],"volumeName":"trivy-operator-pvc"}` | alternateReportStorage is the flag to enable alternate storage for all trivy reports (crds) in the form json files inside of a persistent volume |
 | alternateReportStorage.storageClassName | string | `""` | storageClassName for the PVC (optional, uses cluster default if not specified) |
 | automountServiceAccountToken | bool | `true` | automountServiceAccountToken the flag to enable automount for service account token |
 | compliance.cron | string | `"0 */6 * * *"` | cron this flag control the cron interval for compliance report generation |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -190,6 +190,7 @@ Keeps security report resources updated
 | trivy.storageClassEnabled | bool | `true` | whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage) |
 | trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class |
 | trivy.storageSize | string | `"5Gi"` | storageSize is the size of the trivy server PVC |
+| trivy.storageAccessModes | list | `[ ReadWriteOnce ]` | storageAccessModes is the PVC accessModes list |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"false"` | The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from mirror.gcr.io/aquasec/trivy-checks  |

--- a/deploy/helm/templates/pvc.yaml
+++ b/deploy/helm/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "trivy-operator.namespace" . }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .Values.alternateReportStorage.accessModes | nindent 4 }}
   {{- if .Values.alternateReportStorage.storageClassName }}
   storageClassName: {{ .Values.alternateReportStorage.storageClassName }}
   {{- end }}

--- a/deploy/helm/templates/trivy-server/statefulset.yaml
+++ b/deploy/helm/templates/trivy-server/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
           requests:
             storage: {{ .Values.trivy.storageSize }}
         accessModes:
-          - ReadWriteOnce
+          {{- toYaml .Values.trivy.storageAccessModes | nindent 10 }}
         storageClassName: {{ .Values.trivy.storageClassName }}
   {{- end }}
   template:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -388,6 +388,10 @@ trivy:
   # -- storageSize is the size of the trivy server PVC
   storageSize: "5Gi"
 
+  # -- storageAccessModes is the access modes for trivy server PVC
+  storageAccessModes:
+    - ReadWriteOnce
+
   # -- labels is the extra labels to be used for trivy server statefulset
   labels: {}
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -834,6 +834,8 @@ alternateReportStorage:
   storage: "10Gi"
   # -- storageClassName for the PVC (optional, uses cluster default if not specified)
   storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
   podSecurityContext:
     runAsUser: 10000
     fsGroup: 10000

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -73,10 +73,10 @@ configuration settings for common use cases. For example, switch Trivy from [Sta
 | `alternateReportStorage.enabled`| `"false"` | Control where reports are written. By default this is false, so reports will be written normally as CRDs in ETCD memory. However, if you would rather reports be written to a persistent volume, flip this to true. If done a persistent volume claim will be inluded in your installation and all reports will be written there.|
 | `alternateReportStorage.mountPath`|`"/mnt/data/trivy-operator"`| The mount path for your persistent volume.|
 | `alternateReportStorage.volumeName`|`"trivy-operator-pvc"`| Name of your persistant volume.|
-|`alternateReportStorage.storage`|`"10Gi"`| Amount of storage for your persistent volume.|
-|`alternateReportStorage.accessModes`|`"- ReadWriteOnce"`| The accessMode for the persistent volume.  See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes .|
-|`alternateReportStorage.podSecurityContext.runAsUser`| `10000` | Specifies the UNIX user ID that all processes in the container should run as (for the persistent volume), ensuring they don’t execute as the root user and limiting their privileges.|
-|`alternateReportStorage.podSecurityContext.fsGroup`| `10000` | Defines a UNIX group ID that Kubernetes will use to change the ownership of any mounted volumes so that files created by the container (persistent volume) are accessible to processes running under that group.|
+| `alternateReportStorage.storage`|`"10Gi"`| Amount of storage for your persistent volume.|
+| `alternateReportStorage.accessModes`|`[ ReadWriteOnce ]`| The accessMode for the persistent volume.  See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes .|
+| `alternateReportStorage.podSecurityContext.runAsUser`| `10000` | Specifies the UNIX user ID that all processes in the container should run as (for the persistent volume), ensuring they don’t execute as the root user and limiting their privileges.|
+| `alternateReportStorage.podSecurityContext.fsGroup`| `10000` | Defines a UNIX group ID that Kubernetes will use to change the ownership of any mounted volumes so that files created by the container (persistent volume) are accessible to processes running under that group.|
 
 !!! note
     For parameters that use time values, such as `ScanJobTTL`, valid time units are "ns", "us" (or "µs"), "ms", "s", "m", and "h".

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -74,6 +74,7 @@ configuration settings for common use cases. For example, switch Trivy from [Sta
 | `alternateReportStorage.mountPath`|`"/mnt/data/trivy-operator"`| The mount path for your persistent volume.|
 | `alternateReportStorage.volumeName`|`"trivy-operator-pvc"`| Name of your persistant volume.|
 |`alternateReportStorage.storage`|`"10Gi"`| Amount of storage for your persistent volume.|
+|`alternateReportStorage.accessModes`|`"- ReadWriteOnce"`| The accessMode for the persistent volume.  See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes .|
 |`alternateReportStorage.podSecurityContext.runAsUser`| `10000` | Specifies the UNIX user ID that all processes in the container should run as (for the persistent volume), ensuring they don’t execute as the root user and limiting their privileges.|
 |`alternateReportStorage.podSecurityContext.fsGroup`| `10000` | Defines a UNIX group ID that Kubernetes will use to change the ownership of any mounted volumes so that files created by the container (persistent volume) are accessible to processes running under that group.|
 


### PR DESCRIPTION
## Description

Adds a configuration option to the Helm chart to allow accessMode override for the persistent volume.

## Related issues
- Close #2938 

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
