### PR TITLE
fix(ci): install ARM64 cross-compiler for FIPS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,6 +128,8 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: false
+      - name: Install ARM64 cross-compiler
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Install cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # was: sigstore/cosign-installer@v3.8.2
       - name: Login to docker.io registry

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,14 @@ builds:
     goarch:
       - amd64
       - arm64
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - GOEXPERIMENT=boringcrypto,jsonv2
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
 archives:
   - name_template: >-
       {{- .ProjectName }}_


### PR DESCRIPTION
## Description
This PR fixes the ARM64 FIPS build failure by installing the gcc-aarch64-linux-gnu cross-compiler on the CI runner and configuring GoReleaser to use it when cross-compiling for linux/arm64.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
