### PR TITLE
fix(helm): render bool/numeric config keys when set to false/0; add unittest + values schema

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # was: actions/checkout@v6.0.2
         with:
           persist-credentials: false
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.3
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.1.0
       - name: Run helm unittest
         run: helm unittest deploy/helm
 

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -19,6 +19,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  helm-unittest:
+    name: Run helm unittest
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.3
+      - name: Run helm unittest
+        run: helm unittest deploy/helm
+
   chart-testing:
     name: Run chart testing
     runs-on: ubuntu-22.04

--- a/deploy/helm/ci/client-server-values.yaml
+++ b/deploy/helm/ci/client-server-values.yaml
@@ -1,0 +1,8 @@
+# ct lint-and-install scenario: trivy ClientServer mode with the
+# in-cluster built-in server. Exercises the templates that only
+# render under this combination (trivy.serverURL, the built-in
+# server StatefulSet, etc.).
+operator:
+  builtInTrivyServer: true
+trivy:
+  mode: ClientServer

--- a/deploy/helm/ci/compress-disabled-values.yaml
+++ b/deploy/helm/ci/compress-disabled-values.yaml
@@ -1,0 +1,6 @@
+# ct lint-and-install scenario: scanJobCompressLogs disabled.
+# Proves the rendering fix works end-to-end: setting the value to
+# false renders "false" into the ConfigMap rather than silently
+# falling back to the operator's hard-coded default.
+trivyOperator:
+  scanJobCompressLogs: false

--- a/deploy/helm/ci/default-values.yaml
+++ b/deploy/helm/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# ct lint-and-install scenario: chart defaults.
+# Intentionally empty — exercises every value from values.yaml unchanged.

--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -61,9 +61,7 @@ data:
   {{- with .Values.trivyOperator.scanJobPodPriorityClassName }}
   scanJob.podPriorityClassName: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivyOperator.scanJobCompressLogs }}
-  scanJob.compressLogs: {{ . | toJson | quote }}
-  {{- end }}
+  scanJob.compressLogs: {{ .Values.trivyOperator.scanJobCompressLogs | toJson | quote }}
   {{- if or .Values.operator.vulnerabilityScannerEnabled .Values.operator.exposedSecretScannerEnabled .Values.operator.scannerReportTTL }}
   vulnerabilityReports.scanner: {{ .Values.trivyOperator.vulnerabilityReportsPlugin | quote }}
   vulnerabilityReports.scanJobsInSameNamespace: {{ .Values.trivyOperator.scanJobsInSameNamespace | quote }}

--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -30,13 +30,9 @@ data:
   {{- with .Values.trivyOperator.scanJobAnnotations }}
   scanJob.annotations: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivyOperator.scanJobAutomountServiceAccountToken }}
-  scanJob.automountServiceAccountToken: {{ . | quote }}
-  {{- end }}
+  scanJob.automountServiceAccountToken: {{ .Values.trivyOperator.scanJobAutomountServiceAccountToken | quote }}
   scanJob.useGCRServiceAccount: {{ .Values.trivyOperator.useGCRServiceAccount | quote }}
-  {{- with .Values.trivyOperator.skipInitContainers }}
-  scanJob.skipInitContainers: {{ . | quote }}
-  {{- end }}
+  scanJob.skipInitContainers: {{ .Values.trivyOperator.skipInitContainers | quote }}
   {{- with .Values.trivyOperator.excludeImages }}
   scanJob.excludeImages: {{ . | quote }}
   {{- end }}
@@ -76,9 +72,7 @@ data:
   report.resourceLabels: {{ . | quote }}
   metrics.resourceLabelsPrefix: {{ $.Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
   {{- end }}
-  {{- with .Values.trivyOperator.reportRecordFailedChecksOnly }}
-  report.recordFailedChecksOnly: {{ . | quote }}
-  {{- end }}
+  report.recordFailedChecksOnly: {{ .Values.trivyOperator.reportRecordFailedChecksOnly | quote }}
   {{- with .Values.trivyOperator.skipResourceByLabels }}
   skipResourceByLabels: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/templates/configmaps/trivy.yaml
+++ b/deploy/helm/templates/configmaps/trivy.yaml
@@ -24,9 +24,7 @@ data:
   {{- with .Values.trivy.httpsProxy }}
   trivy.httpsProxy: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivy.serverInsecure }}
-  trivy.serverInsecure: {{ . | quote }}
-  {{- end }}
+  trivy.serverInsecure: {{ .Values.trivy.serverInsecure | quote }}
   {{- with .Values.trivy.sslCertDir }}
   trivy.sslCertDir: {{ . | quote }}
   {{- end }}
@@ -61,22 +59,12 @@ data:
   {{- with .Values.trivy.vulnType }}
   trivy.vulnType: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivy.dbRepositoryInsecure }}
-  trivy.dbRepositoryInsecure: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.trivy.useBuiltinRegoPolicies }}
-  trivy.useBuiltinRegoPolicies: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.trivy.useEmbeddedRegoPolicies }}
-  trivy.useEmbeddedRegoPolicies: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.trivy.offlineScan }}
-  trivy.offlineScan: {{ . | quote }}
-  {{- end }}
+  trivy.dbRepositoryInsecure: {{ .Values.trivy.dbRepositoryInsecure | quote }}
+  trivy.useBuiltinRegoPolicies: {{ .Values.trivy.useBuiltinRegoPolicies | quote }}
+  trivy.useEmbeddedRegoPolicies: {{ .Values.trivy.useEmbeddedRegoPolicies | quote }}
+  trivy.offlineScan: {{ .Values.trivy.offlineScan | quote }}
   trivy.supportedConfigAuditKinds: {{ .Values.trivy.supportedConfigAuditKinds | quote }}
-  {{- with .Values.trivy.ignoreUnfixed }}
-  trivy.ignoreUnfixed: {{ . | quote }}
-  {{- end }}
+  trivy.ignoreUnfixed: {{ .Values.trivy.ignoreUnfixed | quote }}
   {{- with .Values.trivy.timeout }}
   trivy.timeout: {{ . | quote }}
   {{- end }}
@@ -104,9 +92,7 @@ data:
   trivy.mode: {{ .Values.trivy.mode | quote }}
   {{- if eq .Values.trivy.mode "ClientServer" }}
   trivy.serverURL: {{ required ".Values.trivy.serverURL is required" .Values.trivy.serverURL | quote }}
-  {{- with .Values.trivy.clientServerSkipUpdate }}
-  trivy.clientServerSkipUpdate: {{ . | quote }}
-  {{- end }}
+  trivy.clientServerSkipUpdate: {{ .Values.trivy.clientServerSkipUpdate | quote }}
   {{- end }}
   {{- end }}
   {{- with dig "resources" "requests" "cpu" "" .Values.trivy }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.operator.replicas }}
-  {{- with .Values.operator.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ . }}
+  {{- if not (kindIs "invalid" .Values.operator.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit }}
   {{- end }}
   strategy:
     type: Recreate

--- a/deploy/helm/tests/configmap_operator_test.yaml
+++ b/deploy/helm/tests/configmap_operator_test.yaml
@@ -23,3 +23,51 @@ tests:
       - equal:
           path: data["scanJob.compressLogs"]
           value: "true"
+
+  - it: renders scanJob.automountServiceAccountToken as "false" when set to false
+    set:
+      trivyOperator.scanJobAutomountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: data["scanJob.automountServiceAccountToken"]
+          value: "false"
+
+  - it: renders scanJob.automountServiceAccountToken as "true" when set to true
+    set:
+      trivyOperator.scanJobAutomountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: data["scanJob.automountServiceAccountToken"]
+          value: "true"
+
+  - it: renders scanJob.skipInitContainers as "false" when set to false
+    set:
+      trivyOperator.skipInitContainers: false
+    asserts:
+      - equal:
+          path: data["scanJob.skipInitContainers"]
+          value: "false"
+
+  - it: renders scanJob.skipInitContainers as "true" when set to true
+    set:
+      trivyOperator.skipInitContainers: true
+    asserts:
+      - equal:
+          path: data["scanJob.skipInitContainers"]
+          value: "true"
+
+  - it: renders report.recordFailedChecksOnly as "false" when set to false
+    set:
+      trivyOperator.reportRecordFailedChecksOnly: false
+    asserts:
+      - equal:
+          path: data["report.recordFailedChecksOnly"]
+          value: "false"
+
+  - it: renders report.recordFailedChecksOnly as "true" when set to true
+    set:
+      trivyOperator.reportRecordFailedChecksOnly: true
+    asserts:
+      - equal:
+          path: data["report.recordFailedChecksOnly"]
+          value: "true"

--- a/deploy/helm/tests/configmap_operator_test.yaml
+++ b/deploy/helm/tests/configmap_operator_test.yaml
@@ -1,0 +1,25 @@
+suite: configmaps/operator.yaml — bool field rendering
+templates:
+  - configmaps/operator.yaml
+tests:
+  - it: renders scanJob.compressLogs as "false" when scanJobCompressLogs is set to false
+    set:
+      trivyOperator.scanJobCompressLogs: false
+    asserts:
+      - equal:
+          path: data["scanJob.compressLogs"]
+          value: "false"
+
+  - it: renders scanJob.compressLogs as "true" when scanJobCompressLogs is set to true
+    set:
+      trivyOperator.scanJobCompressLogs: true
+    asserts:
+      - equal:
+          path: data["scanJob.compressLogs"]
+          value: "true"
+
+  - it: renders scanJob.compressLogs as "true" when scanJobCompressLogs is unset (default)
+    asserts:
+      - equal:
+          path: data["scanJob.compressLogs"]
+          value: "true"

--- a/deploy/helm/tests/configmap_trivy_test.yaml
+++ b/deploy/helm/tests/configmap_trivy_test.yaml
@@ -1,0 +1,103 @@
+suite: configmaps/trivy.yaml — bool field rendering
+templates:
+  - configmaps/trivy.yaml
+tests:
+  - it: renders trivy.serverInsecure as "false" when set to false
+    set:
+      trivy.serverInsecure: false
+    asserts:
+      - equal:
+          path: data["trivy.serverInsecure"]
+          value: "false"
+
+  - it: renders trivy.serverInsecure as "true" when set to true
+    set:
+      trivy.serverInsecure: true
+    asserts:
+      - equal:
+          path: data["trivy.serverInsecure"]
+          value: "true"
+
+  - it: renders trivy.dbRepositoryInsecure as "false" when set to false
+    set:
+      trivy.dbRepositoryInsecure: false
+    asserts:
+      - equal:
+          path: data["trivy.dbRepositoryInsecure"]
+          value: "false"
+
+  - it: renders trivy.dbRepositoryInsecure as "true" when set to true
+    set:
+      trivy.dbRepositoryInsecure: true
+    asserts:
+      - equal:
+          path: data["trivy.dbRepositoryInsecure"]
+          value: "true"
+
+  - it: renders trivy.useBuiltinRegoPolicies as "false" when set to false
+    set:
+      trivy.useBuiltinRegoPolicies: false
+    asserts:
+      - equal:
+          path: data["trivy.useBuiltinRegoPolicies"]
+          value: "false"
+
+  - it: renders trivy.useEmbeddedRegoPolicies as "false" when set to false
+    set:
+      trivy.useEmbeddedRegoPolicies: false
+    asserts:
+      - equal:
+          path: data["trivy.useEmbeddedRegoPolicies"]
+          value: "false"
+
+  - it: renders trivy.offlineScan as "false" when set to false
+    set:
+      trivy.offlineScan: false
+    asserts:
+      - equal:
+          path: data["trivy.offlineScan"]
+          value: "false"
+
+  - it: renders trivy.offlineScan as "true" when set to true
+    set:
+      trivy.offlineScan: true
+    asserts:
+      - equal:
+          path: data["trivy.offlineScan"]
+          value: "true"
+
+  - it: renders trivy.ignoreUnfixed as "false" when set to false
+    set:
+      trivy.ignoreUnfixed: false
+    asserts:
+      - equal:
+          path: data["trivy.ignoreUnfixed"]
+          value: "false"
+
+  - it: renders trivy.ignoreUnfixed as "true" when set to true
+    set:
+      trivy.ignoreUnfixed: true
+    asserts:
+      - equal:
+          path: data["trivy.ignoreUnfixed"]
+          value: "true"
+
+  - it: renders trivy.clientServerSkipUpdate as "false" when set to false in ClientServer mode
+    set:
+      trivy.mode: ClientServer
+      trivy.serverURL: "https://trivy.example.com:4975"
+      trivy.clientServerSkipUpdate: false
+    asserts:
+      - equal:
+          path: data["trivy.clientServerSkipUpdate"]
+          value: "false"
+
+  - it: renders trivy.clientServerSkipUpdate as "true" when set to true in ClientServer mode
+    set:
+      trivy.mode: ClientServer
+      trivy.serverURL: "https://trivy.example.com:4975"
+      trivy.clientServerSkipUpdate: true
+    asserts:
+      - equal:
+          path: data["trivy.clientServerSkipUpdate"]
+          value: "true"

--- a/deploy/helm/tests/deployment_test.yaml
+++ b/deploy/helm/tests/deployment_test.yaml
@@ -1,0 +1,28 @@
+suite: deployment.yaml — numeric field rendering
+templates:
+  - deployment.yaml
+  - configmaps/trivy-operator-config.yaml
+tests:
+  - it: renders revisionHistoryLimit as 0 when set to 0
+    set:
+      operator.revisionHistoryLimit: 0
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0
+
+  - it: renders revisionHistoryLimit as 5 when set to 5
+    set:
+      operator.revisionHistoryLimit: 5
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: omits revisionHistoryLimit when unset (defers to Kubernetes default)
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.revisionHistoryLimit

--- a/deploy/helm/tests/values_schema_test.yaml
+++ b/deploy/helm/tests/values_schema_test.yaml
@@ -1,0 +1,21 @@
+suite: values.schema.json — type validation
+templates:
+  - configmaps/operator.yaml
+tests:
+  - it: rejects scanJobCompressLogs set to a string
+    set:
+      trivyOperator.scanJobCompressLogs: "false"
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects revisionHistoryLimit set to a string
+    set:
+      operator.revisionHistoryLimit: "five"
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects trivy.mode set to an unknown value
+    set:
+      trivy.mode: "Bogus"
+    asserts:
+      - failedTemplate: {}

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "trivy-operator chart values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "global": { "type": "object", "additionalProperties": true },
+    "managedBy": { "type": "string" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "namespaceOverride": { "type": "string" },
+    "targetNamespaces": { "type": "string" },
+    "excludeNamespaces": { "type": "string" },
+    "targetWorkloads": { "type": "string" },
+    "extraEnv": { "type": "array" },
+    "hostAliases": { "type": "array" },
+    "podAnnotations": { "type": "object", "additionalProperties": true },
+    "podSecurityContext": { "type": "object", "additionalProperties": true },
+    "securityContext": { "type": "object", "additionalProperties": true },
+    "volumeMounts": { "type": "array" },
+    "volumes": { "type": "array" },
+    "resources": { "type": "object", "additionalProperties": true },
+    "nodeSelector": { "type": "object", "additionalProperties": true },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object", "additionalProperties": true },
+    "priorityClassName": { "type": "string" },
+    "automountServiceAccountToken": { "type": "boolean" },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "registry": { "type": "string" },
+        "repository": { "type": "string" },
+        "tag": { "type": ["string", "null"] },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "pullSecrets": { "type": "array" }
+      }
+    },
+    "operator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "namespace": { "type": "string" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "revisionHistoryLimit": { "type": ["integer", "null"], "minimum": 0 },
+        "logDevMode": { "type": "boolean" },
+        "vulnerabilityScannerEnabled": { "type": "boolean" },
+        "sbomGenerationEnabled": { "type": "boolean" },
+        "clusterSbomCacheEnabled": { "type": "boolean" },
+        "configAuditScannerEnabled": { "type": "boolean" },
+        "rbacAssessmentScannerEnabled": { "type": "boolean" },
+        "infraAssessmentScannerEnabled": { "type": "boolean" },
+        "clusterComplianceEnabled": { "type": "boolean" },
+        "vulnerabilityScannerScanOnlyCurrentRevisions": { "type": "boolean" },
+        "configAuditScannerScanOnlyCurrentRevisions": { "type": "boolean" },
+        "accessGlobalSecretsAndServiceAccount": { "type": "boolean" },
+        "builtInTrivyServer": { "type": "boolean" },
+        "builtInServerRegistryInsecure": { "type": "boolean" },
+        "metricsFindingsEnabled": { "type": "boolean" },
+        "metricsVulnIdEnabled": { "type": "boolean" },
+        "exposedSecretScannerEnabled": { "type": "boolean" },
+        "metricsExposedSecretInfo": { "type": "boolean" },
+        "metricsConfigAuditInfo": { "type": "boolean" },
+        "metricsRbacAssessmentInfo": { "type": "boolean" },
+        "metricsInfraAssessmentInfo": { "type": "boolean" },
+        "metricsImageInfo": { "type": "boolean" },
+        "metricsClusterComplianceInfo": { "type": "boolean" },
+        "webhookSendDeletedReports": { "type": "boolean" },
+        "mergeRbacFindingWithConfigAudit": { "type": "boolean" }
+      }
+    },
+    "service": { "type": "object", "additionalProperties": true },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "honorLabels": { "type": "boolean" }
+      }
+    },
+    "trivyOperator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "vulnerabilityReportsPlugin": { "type": "string" },
+        "configAuditReportsPlugin": { "type": "string" },
+        "scanJobCompressLogs": { "type": "boolean" },
+        "scanJobsInSameNamespace": { "type": "boolean" },
+        "useGCRServiceAccount": { "type": "boolean" },
+        "scanJobAutomountServiceAccountToken": { "type": "boolean" },
+        "skipInitContainers": { "type": "boolean" },
+        "reportRecordFailedChecksOnly": { "type": "boolean" }
+      }
+    },
+    "trivy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "createConfig": { "type": "boolean" },
+        "serverInsecure": { "type": "boolean" },
+        "dbRepositoryInsecure": { "type": "boolean" },
+        "useBuiltinRegoPolicies": { "type": "boolean" },
+        "useEmbeddedRegoPolicies": { "type": "boolean" },
+        "offlineScan": { "type": "boolean" },
+        "ignoreUnfixed": { "type": "boolean" },
+        "clientServerSkipUpdate": { "type": "boolean" },
+        "skipJavaDBUpdate": { "type": "boolean" },
+        "slow": { "type": "boolean" },
+        "debug": { "type": "boolean" },
+        "includeDevDeps": { "type": "boolean" },
+        "mode": { "type": "string", "enum": ["Standalone", "ClientServer"] },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": ["string", "number"] }
+          }
+        }
+      }
+    },
+    "compliance": { "type": "object", "additionalProperties": true },
+    "rbac": { "type": "object", "additionalProperties": true },
+    "serviceAccount": { "type": "object", "additionalProperties": true },
+    "policiesBundle": { "type": "object", "additionalProperties": true },
+    "nodeCollector": { "type": "object", "additionalProperties": true },
+    "alternateReportStorage": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -567,17 +567,17 @@ trivy:
 
   # -- The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)
   #
-  dbRepositoryInsecure: "false"
+  dbRepositoryInsecure: false
 
   # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from mirror.gcr.io/aquasec/trivy-checks
   #
-  useBuiltinRegoPolicies: "false"
+  useBuiltinRegoPolicies: false
   # -- The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies
   #
   externalRegoPoliciesEnabled: false
   # -- To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments.
   # When useEmbeddedRegoPolicies is set to true, useBuiltinRegoPolicies should be set to false.
-  useEmbeddedRegoPolicies: "true"
+  useEmbeddedRegoPolicies: true
 
   # -- The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner
   #


### PR DESCRIPTION
## Summary

The chart uses `{{- with .Values.X }}` to conditionally render several bool and numeric ConfigMap keys. Go templates treat `false` and `0` as empty, so the block is silently skipped when a user sets the value to `false`/`0`, and the operator's hard-coded default wins instead — making the chart-side override a no-op.

The most user-visible instance is `scanJobCompressLogs: false`, which today does nothing despite being a documented value. The same antipattern affects ten other bool fields and one numeric field across the chart.

### Fixes

`deploy/helm/templates/configmaps/operator.yaml`

- `scanJob.compressLogs`
- `scanJob.automountServiceAccountToken`
- `scanJob.skipInitContainers`
- `report.recordFailedChecksOnly`

`deploy/helm/templates/configmaps/trivy.yaml`

- `trivy.serverInsecure`
- `trivy.dbRepositoryInsecure`
- `trivy.useBuiltinRegoPolicies`
- `trivy.useEmbeddedRegoPolicies`
- `trivy.offlineScan`
- `trivy.ignoreUnfixed`
- `trivy.clientServerSkipUpdate`

`deploy/helm/templates/deployment.yaml`

- `revisionHistoryLimit` — the numeric variant of the same bug; users could not pin to `0` (a legitimate Kubernetes value meaning "retain no old ReplicaSets"). Switched to a nil check that preserves the documented "omit when unset" behaviour while honouring `0`.

### Regression net

- `helm-unittest` adopted with explicit coverage for every fixed field — asserts both `true` and `false` render correctly, and that the default-unset case renders the documented default.
- `values.schema.json` added (draft 2020-12) — tight-types every bool/numeric field; object/array fields keep `additionalProperties: true` so unrecognised user keys still install cleanly. Helm validates `--set`/`--values` against this at install time, so a user accidentally passing `--set trivyOperator.scanJobCompressLogs=\"false\"` now gets a clear error rather than silent coercion.
- Three pre-existing string-typed bools in `values.yaml` (`dbRepositoryInsecure`, `useBuiltinRegoPolicies`, `useEmbeddedRegoPolicies`) were surfaced by the new schema and corrected. The rendered ConfigMap is byte-identical because the template re-quotes either way.
- `deploy/helm/ci/` scenarios added for chart-testing: chart defaults, compress-disabled, and built-in ClientServer mode. `ct lint-and-install` automatically iterates each.
- `helm-unittest` wired into `.github/workflows/chart-testing.yaml` as a parallel job so unit-level template regressions fail in seconds rather than waiting for the heavyweight kind install.

### Sets up follow-up work

A follow-up PR makes scan Jobs runnable on a distroless Trivy image (`cgr.dev/chainguard/trivy`), per #2823. That work depends on `scanJobCompressLogs: false` actually being honoured — which is what this PR enables.

## Test plan

- [x] `helm unittest deploy/helm` — 27 tests across 4 suites pass
- [x] `helm lint deploy/helm` — clean (only pre-existing \"icon is recommended\" info)
- [x] `helm template deploy/helm` — renders cleanly at defaults
- [x] `helm template deploy/helm -f deploy/helm/ci/compress-disabled-values.yaml` — renders with `scanJob.compressLogs: \"false\"` in the operator ConfigMap
- [x] `helm template deploy/helm -f deploy/helm/ci/client-server-values.yaml` — renders with `trivy.mode: \"ClientServer\"`
- [x] `helm template deploy/helm --set trivyOperator.scanJobCompressLogs=\"false\"` (string) — fails with schema validation error pointing at `/trivyOperator/scanJobCompressLogs`
- [ ] CI `helm-unittest` job (new) — green
- [ ] CI `chart-testing` job — green across all three `ci/*-values.yaml` scenarios