### PR TITLE
ci: increase goreleaser timeouts and fix snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   release-snapshot:
     name: Release unversioned snapshot
-    runs-on: ubuntu-2404-2core
+    runs-on: ubuntu-2404-4core
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     permissions:
@@ -39,13 +39,17 @@ jobs:
           cache: false
           go-version-file: go.mod
           check-latest: true
+
+      - name: Install ARM64 cross-compiler
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Install cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # was: sigstore/cosign-installer@v3.8.2
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # was: goreleaser/goreleaser-action@v6
         with:
           version: v2.4.8
-          args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean
+          args: release -f=goreleaser-e2e.yaml --snapshot --skip=publish --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
     name: Release
     needs:
       - itest-trivy-operator
-    runs-on: ubuntu-2404-2core
+    runs-on: ubuntu-2404-4core
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     permissions:
@@ -153,7 +153,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # was: goreleaser/goreleaser-action@v6
         with:
           version: v2.4.8
-          args: release --clean
+          args: release --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
## Description
This PR increases a Goreleaser timeout, uses more powerfull runner and also fix snapshot workflow.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
