### PR TITLE
chore: bump up UBI9 minimal to 9.8-1780378819

### DIFF
--- a/build/trivy-operator/Dockerfile.fips.ubi9
+++ b/build/trivy-operator/Dockerfile.fips.ubi9
@@ -1,7 +1,7 @@
 # If you need to update the base image, please use manifest list digest SHA256 from the following link:
 # https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti&gti-tabs=unauthenticated
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 
 # Image metadata
 LABEL name="Trivy" \

--- a/build/trivy-operator/Dockerfile.ubi9
+++ b/build/trivy-operator/Dockerfile.ubi9
@@ -1,7 +1,7 @@
 # If you need to update the base image, please use manifest list digest SHA256 from the following link:
 # https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti&gti-tabs=unauthenticated
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 
 # Image metadata
 LABEL name="Trivy" \


### PR DESCRIPTION
## Description

this PR bumps up UBI9 minimal to 9.8-1780378819.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
