### PR TITLE
ci: triger Publish Helm chart on pull_request_target

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -4,7 +4,7 @@
 name: Publish Helm chart
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
## Description

This PR changes an event to triger `Publish Helm chart` workflow.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
