### PR TITLE
fix: remove dead error checks in scanjob and filesystem plugin

### DIFF
--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -216,9 +216,6 @@ func GetPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, config Confi
 			return corev1.PodSpec{}, nil, err
 		}
 		command := config.GetCommand()
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
-		}
 
 		fscommand := []string{SharedVolumeLocationOfTrivy}
 		args := GetFSScanningArgs(ctx, command, Standalone, "")
@@ -446,9 +443,6 @@ func GetPodSpecForClientServerFSMode(ctx trivyoperator.PluginContext, config Con
 			return corev1.PodSpec{}, nil, err
 		}
 		command := config.GetCommand()
-		if err != nil {
-			return corev1.PodSpec{}, nil, err
-		}
 
 		fscommand := []string{SharedVolumeLocationOfTrivy}
 		args := GetFSScanningArgs(ctx, command, ClientServer, encodedTrivyServerURL.String())

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -324,9 +324,6 @@ func (r *ScanJobController) processScanJobResults(ctx context.Context,
 		vulnerabilityReports = VulnerabilityReports{vulnerabilityNamespaceReports: report, vulnerabilityClusterReports: clusterReport}
 	}
 	_, reused := job.Labels[trivyoperator.LabelReusedReport]
-	if !ok {
-		return VulnerabilityReports{}, nil, nil, fmt.Errorf("expected label %s not set", trivyoperator.LabelResourceSpecHash)
-	}
 
 	if r.ExposedSecretScannerEnabled && !reused {
 		secretReport, err := exposedsecretreport.NewReportBuilder(r.Client.Scheme()).


### PR DESCRIPTION
Fixes #2858

Hi, I work on supply-chain security and was going through the SVACE findings reported in #2858.

This PR covers two of the four findings from that issue: the `scanjob.go` `ok`-variable / error-message bug (item 4) and the two redundant error checks in `filesystem.go` (items 1 and 2). Item 3 (`plugin.go`) is already handled by the open PR #2980, so this change deliberately stays out of `plugin.go` to avoid overlap.

## scanjob.go: stale `ok` check with a misleading message

In `processScanJobResults` the reused-report label is read with the comma-ok idiom:

```go
_, reused := job.Labels[trivyoperator.LabelReusedReport]
if !ok {
    return VulnerabilityReports{}, nil, nil, fmt.Errorf("expected label %s not set", trivyoperator.LabelResourceSpecHash)
}
```

The `if !ok` here does not test the lookup that was just performed. `ok` comes from the earlier `LabelResourceSpecHash` lookup near the top of the function, and that case is already handled there (the function returns if that label is missing), so this block is unreachable. If it ever did fire it would also report the wrong label name.

The issue suggested rewriting it to gate on `LabelReusedReport` and return an error when that label is absent. That would change behaviour in the wrong direction: `LabelReusedReport` is set only when there are reused SBOM cluster reports (`builder.go`, where it is added only when `len(s.sbomClusterReports) > 0`). For every normal scan the label is intentionally absent, and the comma-ok result `reused == false` is exactly what the code below relies on (`!reused` at the secret-report and SBOM branches). Returning an error there would break ordinary scans.

The correct fix is to drop the dead block and keep the comma-ok assignment, which already gives the intended `reused` flag. No behaviour change on any reachable path.

## filesystem.go: redundant error checks after GetCommand()

In both `GetPodSpecForStandaloneFSMode` and `GetPodSpecForClientServerFSMode`:

```go
command := config.GetCommand()
if err != nil {
    return corev1.PodSpec{}, nil, err
}
```

`Config.GetCommand()` returns only a `Command` (no error). The `if err != nil` re-checks the `err` from the preceding `getConfig(ctx)` call, which was already checked one line above, so `err` is guaranteed nil here. These two blocks are removed. Purely a cleanup, no behaviour change.

## Verification

- `go build ./...`
- `go vet ./pkg/vulnerabilityreport/... ./pkg/plugins/trivy/...`
- `go test ./pkg/vulnerabilityreport/... ./pkg/plugins/trivy/...`

Reference: finding reported by the Linux Verification Center via SVACE in #2858.
