### PR TITLE
fix: failed marking old reports

### DIFF
--- a/pkg/operator/workload/helper.go
+++ b/pkg/operator/workload/helper.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -224,6 +225,9 @@ func markReportTTL[T client.Object](ctx context.Context, resolver kube.ObjectRes
 	report.SetAnnotations(annotation)
 	err := resolver.Client.Update(ctx, report)
 	if err != nil {
+		if k8sapierror.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Description
We occasionally observed the following error in the logs (example: https://github.com/aquasecurity/trivy-operator/actions/runs/25849196279/job/75952949061?pr=2963):
```sh
{"level":"error","ts":"2026-05-14T08:27:45Z","msg":"Reconciler error","controller":"replicaset","controllerGroup":"apps","controllerKind":"ReplicaSet","ReplicaSet":{"name":"wordpress-58s4v-75756fd5f","namespace":"default"},"namespace":"default","name":"wordpress-58s4v-75756fd5f","reconcileID":"b1985177-6190-46cb-95df-90f91ba5b1c8","error":"failed marking old reports for immediate deletion : vulnerabilityreports.aquasecurity.github.io \"replicaset-wordpress-58s4v-75756fd5f-wordpress\" not found","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296"}
```
The root cause is a race condition in `markReportTTL`: the function performs a `List` followed by an `Update`, and between those two calls the target report can be deleted by `TTLReportReconciler` — which acts on a prior TTL=0 annotation independently and concurrently.

As a result, the `not found` error returned by the `Update` call was propagated as a reconciliation error, causing the affected resource to be requeued. This generated significant log noise and unnecessary reconciliation overhead.

Now `markReportTTL` ignores `IsNotFound` — if the report is already gone, there's nothing to mark, which is the desired outcome.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
