### PR TITLE
test: use lighter containers for integration tests

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -156,8 +156,8 @@ func prepareImages() error {
 	images := []string{
 		"mirror.gcr.io/aquasec/trivy:0.71.0",
 		"mirror.gcr.io/knqyf263/vuln-image:1.2.3",
-		"wordpress:4.9",
-		"wordpress:6.7",
+		"alpine:3.21.1",
+		"alpine:3.22",
 	}
 	fmt.Printf("Preparing %d image(s) for Trivy Operator...\n", len(images))
 	for _, image := range images {

--- a/tests/itest/helper/helper.go
+++ b/tests/itest/helper/helper.go
@@ -202,8 +202,10 @@ func (b *DeploymentBuilder) WithNamespace(namespace string) *DeploymentBuilder {
 
 func (b *DeploymentBuilder) WithContainer(name, image string) *DeploymentBuilder {
 	b.containers = append(b.containers, corev1.Container{
-		Name:  name,
-		Image: image,
+		Name:    name,
+		Image:   image,
+		Command: []string{"/bin/sh", "-c", "--"},
+		Args:    []string{"while true; do sleep 3600; done;"},
 	})
 	return b
 }
@@ -489,7 +491,7 @@ func (h *Helper) UpdateDeploymentImage(ctx context.Context, namespace, name stri
 		}
 
 		dcDeploy := deployment.DeepCopy()
-		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:6.7"
+		dcDeploy.Spec.Template.Spec.Containers[0].Image = "alpine:3.22"
 		err = h.kubeClient.Update(ctx, dcDeploy)
 		if err != nil && errors.IsConflict(err) {
 			return false, nil

--- a/tests/itest/trivy-operator/behavior/behavior.go
+++ b/tests/itest/trivy-operator/behavior/behavior.go
@@ -76,7 +76,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContainer("alpine", "alpine:3.21.1").
 					Build()
 
 				err := inputs.Create(ctx, deploy)
@@ -104,12 +104,12 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 			var deploy *appsv1.Deployment
 
 			BeforeEach(func() {
-				By("Creating Deployment wordpress")
+				By("Creating Deployment alpine")
 				ctx = context.Background()
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContainer("alpine", "alpine:3.21.1").
 					Build()
 
 				err := inputs.Create(ctx, deploy)
@@ -126,7 +126,7 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 				By("Waiting for VulnerabilityReport")
 				Eventually(inputs.HasVulnerabilityReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:6.7")
+				By("Updating deployment image to alpine:3.22")
 				err = inputs.UpdateDeploymentImage(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -252,7 +252,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContainer("alpine", "alpine:3.21.1").
 					Build()
 
 				err := inputs.Create(ctx, deploy)
@@ -280,12 +280,12 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 			var deploy *appsv1.Deployment
 
 			BeforeEach(func() {
-				By("Creating Deployment wordpress")
+				By("Creating Deployment alpine")
 				ctx = context.Background()
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContainer("alpine", "alpine:3.21.1").
 					Build()
 
 				err := inputs.Create(ctx, deploy)
@@ -302,7 +302,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				By("Waiting for ConfigAuditReport")
 				Eventually(inputs.HasConfigAuditReportOwnedBy(ctx, rs), inputs.AssertTimeout).Should(BeTrue())
 
-				By("Updating deployment image to wordpress:6.7")
+				By("Updating deployment image to alpine:3.22")
 				err = inputs.UpdateDeploymentImage(ctx, inputs.PrimaryNamespace, deploy.Name)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -384,7 +384,7 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 				deploy = helper.NewDeployment().
 					WithRandomName(inputs.PrimaryWorkloadPrefix).
 					WithNamespace(inputs.PrimaryNamespace).
-					WithContainer("wordpress", "wordpress:4.9").
+					WithContainer("alpine", "alpine:3.21.1").
 					Build()
 
 				err := inputs.Create(ctx, deploy)

--- a/tests/itest/trivy-operator/suite_test.go
+++ b/tests/itest/trivy-operator/suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 		AssertTimeout:         5 * time.Minute,
 		PollingInterval:       5 * time.Second,
 		PrimaryNamespace:      corev1.NamespaceDefault,
-		PrimaryWorkloadPrefix: "wordpress",
+		PrimaryWorkloadPrefix: "alpine",
 		Client:                kubeClient,
 		Helper:                helper.NewHelper(kubeClient),
 	}


### PR DESCRIPTION
## Description
This PR replaces the heavyweight `wordpress:4.9` / `wordpress:6.7` test images with lightweight `alpine:3.21.1` / `alpine:3.22` across all integration tests.

During integration tests, the reconciler occasionally fails with the following error: `"error":"etcdserver: request is too large"`. The full log sample (https://github.com/aquasecurity/trivy-operator/actions/runs/25849196279/job/75952949061?pr=2963): 
```sh
 {"level":"error","ts":"2026-05-14T08:28:27Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"scan-vulnerabilityreport-5cf9c49d9b","namespace":"trivy-system"},"namespace":"trivy-system","name":"scan-vulnerabilityreport-5cf9c49d9b","reconcileID":"40824adf-ddc4-488a-a1e2-24e4a27be24e","error":"etcdserver: request is too large","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296"}
```
`wordpress:4.9` and `wordpress:6.7` images carry an exceptionally large number of known CVEs. When the trivy operator scans these images and attempts to persist the resulting VulnerabilityReport resource, the serialized object exceeds etcd's default request size limit (~1.5 MB), causing the reconciler to fail and leaving the report unwritten.
This is a known etcd issue - https://github.com/aquasecurity/trivy-operator/discussions/2570

Since alpine doesn't run a long-lived process by default, `DeploymentBuilder.WithContainer` now sets a sleep-loop command/args so the container stays running for the scanner/config-audit checks to observe.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
