### PR TITLE
fix: skip empty report files in alternate report storage

### DIFF
--- a/pkg/configauditreport/controller/resource.go
+++ b/pkg/configauditreport/controller/resource.go
@@ -302,67 +302,56 @@ func (r *ResourceController) reconcileResource(resourceKind kube.Kind) reconcile
 func (r *ResourceController) writeAlternateReports(resource client.Object, misConfigData Misconfiguration, log logr.Logger) (ctrl.Result, error) {
 	// Write reports to alternate storage if enabled
 	if r.Config.AltReportStorageEnabled && r.Config.AltReportDir != "" {
-		// Get the report directory from the environment variable
 		reportDir := r.Config.AltReportDir
-		// Create subdirectories for each type of report
-		configAuditDir := filepath.Join(reportDir, "config_audit_reports")
-		rbacAssessmentDir := filepath.Join(reportDir, "rbac_assessment_reports")
-		infraAssessmentDir := filepath.Join(reportDir, "infra_assessment_reports")
+		kind := resource.GetObjectKind().GroupVersionKind().Kind
+		fileName := fmt.Sprintf("%s-%s.json", kind, resource.GetName())
 
-		// Ensure the directories exist
-		if err := os.MkdirAll(configAuditDir, 0o750); err != nil {
-			log.Error(err, "Failed to create configAuditDir")
-			return ctrl.Result{}, err
-		}
-		if err := os.MkdirAll(rbacAssessmentDir, 0o750); err != nil {
-			log.Error(err, "Failed to create rbacAssessmentDir")
-			return ctrl.Result{}, err
-		}
-		if err := os.MkdirAll(infraAssessmentDir, 0o750); err != nil {
-			log.Error(err, "Failed to create infraAssessmentDir")
-			return ctrl.Result{}, err
-		}
-		// Extract workload kind and name from resource labels
-		workloadKind := resource.GetObjectKind().GroupVersionKind().Kind
-		workloadName := resource.GetName()
+		// filter() only populates one report type per resource, so we mirror the
+		// same gating the CRD path uses. Writing every type unconditionally would
+		// serialize zero-value structs into empty report files (see #2853).
+		isRole := kube.IsRoleTypes(kube.Kind(kind))
 
-		// Write config audit report to a file
-		configReportData, err := json.Marshal(misConfigData.configAuditReportData)
-		if err != nil {
-			return ctrl.Result{}, err
+		// config-audit report
+		if !isRole || r.MergeRbacFindingWithConfigAudit {
+			if err := r.writeReportFile(reportDir, "config_audit_reports", fileName, misConfigData.configAuditReportData, log); err != nil {
+				return ctrl.Result{}, err
+			}
+			// infra-assessment report
+			if k8sCoreComponent(resource) && r.Config.InfraAssessmentScannerEnabled {
+				if err := r.writeReportFile(reportDir, "infra_assessment_reports", fileName, misConfigData.infraAssessmentReportData, log); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
 		}
-		configReportPath := filepath.Join(configAuditDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(configReportPath, configReportData, 0o600)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("Config audit report written", "path", configReportPath)
 
-		// Write infra assessment report to a file
-		infraReportData, err := json.Marshal(misConfigData.infraAssessmentReportData)
-		if err != nil {
-			return ctrl.Result{}, err
+		// rbac-assessment report
+		if isRole && r.Config.RbacAssessmentScannerEnabled && !r.MergeRbacFindingWithConfigAudit {
+			if err := r.writeReportFile(reportDir, "rbac_assessment_reports", fileName, misConfigData.rbacAssessmentReportData, log); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
-		infraReportPath := filepath.Join(infraAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(infraReportPath, infraReportData, 0o600)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("Infra assessment report written", "path", infraReportPath)
-
-		// Write RBAC assessment report to a file
-		rbacReportData, err := json.Marshal(misConfigData.rbacAssessmentReportData)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		rbacReportPath := filepath.Join(rbacAssessmentDir, fmt.Sprintf("%s-%s.json", workloadKind, workloadName))
-		err = os.WriteFile(rbacReportPath, rbacReportData, 0o600)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("RBAC assessment report written", "path", rbacReportPath)
 	}
 	return ctrl.Result{}, nil
+}
+
+// writeReportFile marshals report and writes it under reportDir/subDir/fileName,
+// creating the subdirectory only when there is something to write.
+func (r *ResourceController) writeReportFile(reportDir, subDir, fileName string, report any, log logr.Logger) error {
+	data, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(reportDir, subDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		log.Error(err, "Failed to create report directory", "dir", dir)
+		return err
+	}
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	log.Info("Report written", "path", path)
+	return nil
 }
 
 func (r *ResourceController) hasReport(ctx context.Context, owner kube.ObjectRef, podSpecHash, pluginConfigHash string) (bool, error) {

--- a/pkg/configauditreport/controller/resource_test.go
+++ b/pkg/configauditreport/controller/resource_test.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+)
+
+func TestWriteAlternateReports(t *testing.T) {
+	// filter() populates only the config-audit data for a non-role resource such
+	// as a ReplicaSet, leaving the rbac and infra report structs zero-valued.
+	// writeAlternateReports must not write empty files for the report types that
+	// do not apply to the resource (see #2853).
+	dir := t.TempDir()
+
+	r := &ResourceController{
+		Config: etc.Config{
+			AltReportStorageEnabled:       true,
+			AltReportDir:                  dir,
+			InfraAssessmentScannerEnabled: true,
+			RbacAssessmentScannerEnabled:  true,
+		},
+	}
+
+	resource := newTestResource("ReplicaSet")
+	resource.SetName("cilium-operator-77d76d7bbb")
+
+	misConfigData := Misconfiguration{
+		configAuditReportData: v1alpha1.ConfigAuditReportData{
+			Scanner: scanner(r.BuildInfo),
+			Checks:  []v1alpha1.Check{{ID: "KSV001", Category: "Kubernetes Security Check"}},
+		},
+	}
+
+	_, err := r.writeAlternateReports(resource, misConfigData, logr.Discard())
+	require.NoError(t, err)
+
+	fileName := "ReplicaSet-cilium-operator-77d76d7bbb.json"
+
+	// the config-audit report is the one filter() populated, so it is written
+	assert.FileExists(t, filepath.Join(dir, "config_audit_reports", fileName))
+
+	// the rbac and infra reports do not apply to a ReplicaSet, so neither the
+	// files nor their directories should be created
+	assert.NoFileExists(t, filepath.Join(dir, "rbac_assessment_reports", fileName))
+	assert.NoFileExists(t, filepath.Join(dir, "infra_assessment_reports", fileName))
+	assert.NoDirExists(t, filepath.Join(dir, "rbac_assessment_reports"))
+	assert.NoDirExists(t, filepath.Join(dir, "infra_assessment_reports"))
+}
+
+func TestWriteAlternateReportsRole(t *testing.T) {
+	// For a role-type resource (ClusterRole), filter() populates only the rbac
+	// report, so only the rbac file should be written.
+	dir := t.TempDir()
+
+	r := &ResourceController{
+		Config: etc.Config{
+			AltReportStorageEnabled:       true,
+			AltReportDir:                  dir,
+			InfraAssessmentScannerEnabled: true,
+			RbacAssessmentScannerEnabled:  true,
+		},
+	}
+
+	resource := newTestResource("ClusterRole")
+	resource.SetName("envoy-gateway-gateway-helm-certgen")
+
+	misConfigData := Misconfiguration{
+		rbacAssessmentReportData: v1alpha1.RbacAssessmentReportData{
+			Scanner: scanner(r.BuildInfo),
+			Checks:  []v1alpha1.Check{{ID: "KSV048", Category: "Kubernetes Security Check"}},
+		},
+	}
+
+	_, err := r.writeAlternateReports(resource, misConfigData, logr.Discard())
+	require.NoError(t, err)
+
+	fileName := "ClusterRole-envoy-gateway-gateway-helm-certgen.json"
+
+	assert.FileExists(t, filepath.Join(dir, "rbac_assessment_reports", fileName))
+	assert.NoFileExists(t, filepath.Join(dir, "config_audit_reports", fileName))
+	assert.NoFileExists(t, filepath.Join(dir, "infra_assessment_reports", fileName))
+	assert.NoDirExists(t, filepath.Join(dir, "config_audit_reports"))
+	assert.NoDirExists(t, filepath.Join(dir, "infra_assessment_reports"))
+}


### PR DESCRIPTION
## Description

When AltReportStorageEnabled is on, writeAlternateReports wrote all three report types (config-audit, infra-assessment, rbac-assessment) for every resource. But filter() only populates one of them per resource, so the other two get marshaled from zero-value structs and you end up with empty report files (and empty dirs) for types that don't apply.

This gates each write the same way the CRD path does: rbac reports only for role types, infra only for k8s core components when the infra scanner is enabled, config-audit otherwise. Pulled the marshal/mkdir/write into a small writeReportFile helper that only creates the subdirectory when there's actually something to write. Added two tests (a ReplicaSet and a ClusterRole) checking that only the applicable report file shows up and the other dirs aren't created; both fail before the change.

## Related issues
- Close #2853

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
