### PR TITLE
fix: handle missing report CRDs during old report cleanup

### DIFF
--- a/pkg/operator/workload/helper.go
+++ b/pkg/operator/workload/helper.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,10 +122,13 @@ func GetReportsByLabel(ctx context.Context, resolver kube.ObjectResolver, object
 		client.InNamespace(namespace),
 		client.MatchingLabels(labels))
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
 		return fmt.Errorf("listing reports in namespace %s matching labels %v: %w", namespace,
 			labels, err)
 	}
-	return err
+	return nil
 }
 
 // MarkOldReportForImmediateDeletion set old (historical replicaSets) reports with TTL = 0 for immediate deletion


### PR DESCRIPTION
This PR fixes ReplicaSet reconciliation failures when optional report CRDs, such as VulnerabilityReport, are not installed.
During old ReplicaSet cleanup, Trivy Operator lists report resources. If the `VulnerabilityReport` CRD is missing, Kubernetes returns a `NoMatch` error, which was previously treated as fatal and caused repeated `failed marking old reports for immediate deletion` reconciler errors.
The change updates the report listing logic to treat NoMatch errors as non-fatal. Missing report CRDs are now handled as no reports to clean, while all other list errors are still returned normally.