### PR TITLE
feat(helm): make aggregate report ClusterRole names configurable

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -106,6 +106,9 @@ Keeps security report resources updated
 | policiesBundle.repository | string | `"aquasec/trivy-checks"` | repository of the policies bundle |
 | policiesBundle.tag | int | `1` | tag version of the policies bundle |
 | priorityClassName | string | `""` | priorityClassName set the operator priorityClassName |
+| rbac.aggregateClusterRoles | object | `{"create":true,"namePrefix":""}` | aggregateClusterRoles controls the aggregation ClusterRoles that expose the report CRDs (vulnerability/config-audit/exposed-secret) to the built-in view/edit/admin roles |
+| rbac.aggregateClusterRoles.create | bool | `true` | create specifies whether the aggregation ClusterRoles should be created. When multiple releases are installed in the same cluster, set this to true on a single release only to avoid ownership conflicts on these cluster-scoped resources |
+| rbac.aggregateClusterRoles.namePrefix | string | `""` | namePrefix is prepended to the aggregation ClusterRole names. Set a unique value per release (e.g. "{{ .Release.Name }}-") to avoid ArgoCD ownership conflicts across releases. Empty keeps the historical fixed names |
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | securityContext security context |

--- a/deploy/helm/templates/rbac/view-configauditreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-configauditreports-clusterrole.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.rbac.aggregateClusterRoles.create }}
 # permissions for end users to view configauditreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aggregate-config-audit-reports-view
+  name: {{ tpl .Values.rbac.aggregateClusterRoles.namePrefix . }}aggregate-config-audit-reports-view
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/deploy/helm/templates/rbac/view-exposedsecretreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-exposedsecretreports-clusterrole.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.rbac.aggregateClusterRoles.create }}
 # permissions for end users to view exposedsecretreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aggregate-exposed-secret-reports-view
+  name: {{ tpl .Values.rbac.aggregateClusterRoles.namePrefix . }}aggregate-exposed-secret-reports-view
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/deploy/helm/templates/rbac/view-vulnerabilityreports-clusterrole.yaml
+++ b/deploy/helm/templates/rbac/view-vulnerabilityreports-clusterrole.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.rbac.aggregateClusterRoles.create }}
 # permissions for end users to view vulnerabilityreports
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aggregate-vulnerability-reports-view
+  name: {{ tpl .Values.rbac.aggregateClusterRoles.namePrefix . }}aggregate-vulnerability-reports-view
   labels:
     {{- include "trivy-operator.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -18,3 +19,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -671,6 +671,17 @@ compliance:
 
 rbac:
   create: true
+  # -- aggregateClusterRoles controls the aggregation ClusterRoles that expose the
+  # report CRDs (vulnerability/config-audit/exposed-secret) to the built-in view/edit/admin roles
+  aggregateClusterRoles:
+    # -- create specifies whether the aggregation ClusterRoles should be created.
+    # When multiple releases are installed in the same cluster, set this to true on a
+    # single release only to avoid ownership conflicts on these cluster-scoped resources
+    create: true
+    # -- namePrefix is prepended to the aggregation ClusterRole names. Set a unique value
+    # per release (e.g. "{{ .Release.Name }}-") to avoid ArgoCD ownership conflicts across
+    # releases. Empty keeps the historical fixed names
+    namePrefix: ""
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true


### PR DESCRIPTION
  ## Description

  The `aggregate-vulnerability-reports-view`, `aggregate-config-audit-reports-view`
  and `aggregate-exposed-secret-reports-view` ClusterRoles are **cluster-scoped**
  but their names are hardcoded in the chart templates. When multiple releases of
  the chart are installed in the same cluster (multi-team setups), every release
  tries to own the same cluster-scoped resources, which causes **perpetual diffs
  in ArgoCD**.

  This PR makes them configurable while keeping full backward compatibility:

  - `rbac.aggregateClusterRoles.create` (default `true`) — toggle creation, so
    only a single release needs to own these cluster-wide roles.
  - `rbac.aggregateClusterRoles.namePrefix` (default `""`, rendered via `tpl`) —
    prepend a per-release prefix (e.g. `"{{ .Release.Name }}-"`) so each release
    gets uniquely named copies.

  Because these ClusterRoles are consumed purely through the
  `rbac.authorization.k8s.io/aggregate-*` labels (not by name), renaming them has
  **no functional impact** — they are not referenced by the operator code or by
  any RoleBinding. Aggregation into the built-in `view`/`edit`/`admin` roles keeps
  working regardless of the name.

  Defaults are unchanged, so existing installs and the generated `deploy/static`
  manifests are byte-for-byte identical.

  ### Usage

  De-duplicate across releases (only one release creates the roles):
```yaml
  rbac:
    aggregateClusterRoles:
      create: false
```

  Unique names per release (each release owns its own copy):
  ```yaml
  rbac:
    aggregateClusterRoles:
      namePrefix: "{{ .Release.Name }}-"
```

  ### Verification

  - `helm template` with defaults → names unchanged (`aggregate-*-reports-view`).
  - `--set rbac.aggregateClusterRoles.namePrefix=teamA-` → `teamA-aggregate-*-reports-view`.
  - `namePrefix: "{{ .Release.Name }}-"` via values → `<release>-aggregate-*-reports-view`.
  - `--set rbac.aggregateClusterRoles.create=false` → roles not rendered.
  - `hack/update-static.yaml.sh` → `deploy/static` diff is empty.
  - `helm-docs` → `deploy/helm/README.md` values table regenerated.

  ## Related issues

  Remove this section if you don't have related PRs.

  ## Checklist
  - [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
  - [ ] I've added tests that prove my fix is effective or that my feature works.
  - [x] I've updated the documentation with the relevant information (README values table regenerated).
  - [x] I've added usage information (if the PR introduces new options)
  - [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
