### PR TITLE
fix(vulnerabilityreport): fallback to highest vendor severity when SeveritySource is missing

### DIFF
--- a/pkg/vulnerabilityreport/io.go
+++ b/pkg/vulnerabilityreport/io.go
@@ -150,8 +150,7 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 			lmd = sr.LastModifiedDate.Format(time.RFC3339)
 		}
 
-		// if SeveritySource is empty or not present in VendorSeverity map, default to "UNKNOWN"
-		severity := sr.VendorSeverity[sr.SeveritySource].String()
+		severity := severityFromVendorSeverity(sr.VendorSeverity, sr.SeveritySource)
 
 		vulnerability := v1alpha1.Vulnerability{
 			VulnerabilityID:  sr.VulnerabilityID,
@@ -197,6 +196,23 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 	}
 
 	return vulnerabilities
+}
+
+
+// severityFromVendorSeverity prefers VendorSeverity[SeveritySource]. When the
+// source key is empty/missing, fall back to the maximum severity present in the
+// map so resolvable vendor ratings are not collapsed to UNKNOWN (see #3022).
+func severityFromVendorSeverity(vendorSeverity types.VendorSeverity, severitySource types.SourceID) string {
+	if sev, ok := vendorSeverity[severitySource]; ok {
+		return sev.String()
+	}
+	maxSev := types.SeverityUnknown
+	for _, sev := range vendorSeverity {
+		if sev > maxSev {
+			maxSev = sev
+		}
+	}
+	return maxSev.String()
 }
 
 func GetCvssV3(findingCvss types.VendorCVSS) map[string]*CVSS {

--- a/pkg/vulnerabilityreport/io.go
+++ b/pkg/vulnerabilityreport/io.go
@@ -150,9 +150,6 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 			lmd = sr.LastModifiedDate.Format(time.RFC3339)
 		}
 
-		// if SeveritySource is empty or not present in VendorSeverity map, default to "UNKNOWN"
-		severity := sr.VendorSeverity[sr.SeveritySource].String()
-
 		vulnerability := v1alpha1.Vulnerability{
 			VulnerabilityID:  sr.VulnerabilityID,
 			Resource:         sr.PkgName,
@@ -160,7 +157,7 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 			FixedVersion:     sr.FixedVersion,
 			PublishedDate:    pd,
 			LastModifiedDate: lmd,
-			Severity:         v1alpha1.Severity(severity),
+			Severity:         getSeverity(sr.VendorSeverity, sr.SeveritySource),
 			Title:            sr.Title,
 			PrimaryLink:      sr.PrimaryURL,
 			Links:            []string{},
@@ -197,6 +194,24 @@ func GetVulnerabilitiesFromScanResult(report ty.Result, addFields AdditionalFiel
 	}
 
 	return vulnerabilities
+}
+
+func getSeverity(vendorSeverity types.VendorSeverity, severitySource types.SourceID) v1alpha1.Severity {
+	if len(vendorSeverity) == 0 {
+		return v1alpha1.SeverityUnknown
+	}
+	if severitySource != "" {
+		if severity, ok := vendorSeverity[severitySource]; ok {
+			return v1alpha1.Severity(severity.String())
+		}
+	}
+	var maxSeverity types.Severity
+	for _, severity := range vendorSeverity {
+		if severity > maxSeverity {
+			maxSeverity = severity
+		}
+	}
+	return v1alpha1.Severity(maxSeverity.String())
 }
 
 func GetCvssV3(findingCvss types.VendorCVSS) map[string]*CVSS {

--- a/pkg/vulnerabilityreport/io_test.go
+++ b/pkg/vulnerabilityreport/io_test.go
@@ -3,6 +3,9 @@ package vulnerabilityreport_test
 import (
 	"testing"
 
+	dbtypes "github.com/aquasecurity/trivy-db/pkg/types"
+	ty "github.com/aquasecurity/trivy/pkg/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -267,4 +270,73 @@ func TestNewReadWriter(t *testing.T) {
 		}, reports)
 	})
 
+}
+
+
+func TestGetVulnerabilitiesFromScanResult_SeverityFallback(t *testing.T) {
+	t.Run("uses SeveritySource when present in VendorSeverity", func(t *testing.T) {
+		vulns := vulnerabilityreport.GetVulnerabilitiesFromScanResult(ty.Result{
+			Vulnerabilities: []ty.DetectedVulnerability{{
+				VulnerabilityID: "CVE-TEST-SOURCE",
+				PkgName:         "pkg",
+				SeveritySource:  "nvd",
+				Vulnerability: dbtypes.Vulnerability{
+					VendorSeverity: dbtypes.VendorSeverity{
+						"nvd":    dbtypes.SeverityMedium,
+						"amazon": dbtypes.SeverityCritical,
+					},
+				},
+			}},
+		}, vulnerabilityreport.AdditionalFields{})
+		require.Len(t, vulns, 1)
+		assert.Equal(t, v1alpha1.SeverityMedium, vulns[0].Severity)
+	})
+
+	t.Run("falls back to max VendorSeverity when SeveritySource empty", func(t *testing.T) {
+		// Issue #3022 reproduction shape: empty SeveritySource, VendorSeverity has amazon=HIGH.
+		vulns := vulnerabilityreport.GetVulnerabilitiesFromScanResult(ty.Result{
+			Vulnerabilities: []ty.DetectedVulnerability{{
+				VulnerabilityID: "CVE-2026-53615",
+				PkgName:         "bsdutils",
+				SeveritySource:  "",
+				Vulnerability: dbtypes.Vulnerability{
+					VendorSeverity: dbtypes.VendorSeverity{
+						"amazon": dbtypes.SeverityHigh,
+					},
+				},
+			}},
+		}, vulnerabilityreport.AdditionalFields{})
+		require.Len(t, vulns, 1)
+		assert.Equal(t, v1alpha1.SeverityHigh, vulns[0].Severity)
+	})
+
+	t.Run("falls back to max when SeveritySource missing from map", func(t *testing.T) {
+		vulns := vulnerabilityreport.GetVulnerabilitiesFromScanResult(ty.Result{
+			Vulnerabilities: []ty.DetectedVulnerability{{
+				VulnerabilityID: "CVE-TEST-MISSING-SOURCE",
+				PkgName:         "pkg",
+				SeveritySource:  "debian",
+				Vulnerability: dbtypes.Vulnerability{
+					VendorSeverity: dbtypes.VendorSeverity{
+						"amazon": dbtypes.SeverityCritical,
+						"nvd":    dbtypes.SeverityLow,
+					},
+				},
+			}},
+		}, vulnerabilityreport.AdditionalFields{})
+		require.Len(t, vulns, 1)
+		assert.Equal(t, v1alpha1.SeverityCritical, vulns[0].Severity)
+	})
+
+	t.Run("UNKNOWN when VendorSeverity empty", func(t *testing.T) {
+		vulns := vulnerabilityreport.GetVulnerabilitiesFromScanResult(ty.Result{
+			Vulnerabilities: []ty.DetectedVulnerability{{
+				VulnerabilityID: "CVE-TEST-EMPTY",
+				PkgName:         "pkg",
+				SeveritySource:  "",
+			}},
+		}, vulnerabilityreport.AdditionalFields{})
+		require.Len(t, vulns, 1)
+		assert.Equal(t, v1alpha1.SeverityUnknown, vulns[0].Severity)
+	})
 }

--- a/pkg/vulnerabilityreport/io_test.go
+++ b/pkg/vulnerabilityreport/io_test.go
@@ -9,10 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	dbtypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/trivy-operator/pkg/kube"
 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
+	ty "github.com/aquasecurity/trivy/pkg/types"
 )
 
 func TestNewReadWriter(t *testing.T) {
@@ -267,4 +269,123 @@ func TestNewReadWriter(t *testing.T) {
 		}, reports)
 	})
 
+}
+
+func TestGetVulnerabilitiesFromScanResult_SeverityResolution(t *testing.T) {
+	testCases := []struct {
+		name             string
+		severitySource   dbtypes.SourceID
+		vendorSeverity   dbtypes.VendorSeverity
+		expectedSeverity v1alpha1.Severity
+	}{
+		{
+			name:           "exact match",
+			severitySource: "nvd",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd": dbtypes.SeverityHigh,
+			},
+			expectedSeverity: v1alpha1.SeverityHigh,
+		},
+		{
+			name:           "exact match where source severity is lower than another vendor in map",
+			severitySource: "nvd",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd":    dbtypes.SeverityLow,
+				"redhat": dbtypes.SeverityCritical,
+			},
+			expectedSeverity: v1alpha1.SeverityLow,
+		},
+		{
+			name:           "exact match with unknown severity",
+			severitySource: "nvd",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd":    dbtypes.SeverityUnknown,
+				"redhat": dbtypes.SeverityCritical,
+			},
+			expectedSeverity: v1alpha1.SeverityUnknown,
+		},
+		{
+			name:           "empty source with single vendor",
+			severitySource: "",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd": dbtypes.SeverityHigh,
+			},
+			expectedSeverity: v1alpha1.SeverityHigh,
+		},
+		{
+			name:           "empty source with multiple vendors picks highest",
+			severitySource: "",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd":    dbtypes.SeverityLow,
+				"redhat": dbtypes.SeverityCritical,
+				"ubuntu": dbtypes.SeverityMedium,
+			},
+			expectedSeverity: v1alpha1.SeverityCritical,
+		},
+		{
+			name:           "non-empty source missing from map falls back to highest vendor",
+			severitySource: "debian",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd":    dbtypes.SeverityLow,
+				"redhat": dbtypes.SeverityHigh,
+				"ubuntu": dbtypes.SeverityMedium,
+			},
+			expectedSeverity: v1alpha1.SeverityHigh,
+		},
+		{
+			name:             "empty map returns UNKNOWN",
+			severitySource:   "",
+			vendorSeverity:   dbtypes.VendorSeverity{},
+			expectedSeverity: v1alpha1.SeverityUnknown,
+		},
+		{
+			name:             "nil map returns UNKNOWN",
+			severitySource:   "",
+			vendorSeverity:   nil,
+			expectedSeverity: v1alpha1.SeverityUnknown,
+		},
+		{
+			name:           "tie-break between same severities",
+			severitySource: "",
+			vendorSeverity: dbtypes.VendorSeverity{
+				"nvd":    dbtypes.SeverityHigh,
+				"redhat": dbtypes.SeverityHigh,
+			},
+			expectedSeverity: v1alpha1.SeverityHigh,
+		},
+		{
+			name:             "non-empty source missing from empty map returns UNKNOWN",
+			severitySource:   "nvd",
+			vendorSeverity:   dbtypes.VendorSeverity{},
+			expectedSeverity: v1alpha1.SeverityUnknown,
+		},
+		{
+			name:             "non-empty source missing from nil map returns UNKNOWN",
+			severitySource:   "nvd",
+			vendorSeverity:   nil,
+			expectedSeverity: v1alpha1.SeverityUnknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			report := ty.Result{
+				Vulnerabilities: []ty.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2023-0001",
+						PkgName:         "test-pkg",
+						SeveritySource:  tc.severitySource,
+						Vulnerability: dbtypes.Vulnerability{
+							Title:          "Test vulnerability",
+							VendorSeverity: tc.vendorSeverity,
+						},
+					},
+				},
+			}
+
+			vulns := vulnerabilityreport.GetVulnerabilitiesFromScanResult(report, vulnerabilityreport.AdditionalFields{})
+			require.Len(t, vulns, 1)
+			assert.Equal(t, tc.expectedSeverity, vulns[0].Severity)
+		})
+	}
 }


### PR DESCRIPTION
## Description

When a vulnerability has an empty `SeveritySource` or references a vendor key missing from `VendorSeverity`, the report previously defaulted the vulnerability severity to `UNKNOWN`, even if valid vendor ratings (such as `amazon=HIGH`) were present.

This PR updates the severity resolution logic in `pkg/vulnerabilityreport` to fall back to the highest vendor rating when `SeveritySource` is empty or unmapped, before falling back to `UNKNOWN`.

- Resolve severity from highest available `VendorSeverity` rating when `SeveritySource` is missing or unmapped.
- Fix import grouping in `io_test.go` to satisfy `gci`.
- Add table-driven unit tests covering empty sources, missing vendor keys, tie-breaks, and source priority.

## Related issues
- Close #3022

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).