### PR TITLE
fix(compliance): honour compliance.failEntriesLimit in the detail report

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/compliance_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/compliance_types.go
@@ -213,13 +213,20 @@ func FromSummaryReport(sr *report.SummaryReport) *SummaryReport {
 	}
 }
 
-// FromDetailReport map data from trivy summary report to crd summary report
-func FromDetailReport(sr *report.ComplianceReport) *ComplianceReport {
+// FromDetailReport map data from trivy summary report to crd summary report.
+// failEntriesLimit caps the number of failing checks kept per control — the
+// `compliance.failEntriesLimit` setting, which exists to keep the detail report
+// small enough to store. A value <= 0 means no limit.
+func FromDetailReport(sr *report.ComplianceReport, failEntriesLimit int) *ComplianceReport {
 	controlResults := make([]*ControlCheckResult, 0)
 	for _, sr := range sr.Results {
 		checks := make([]ComplianceCheck, 0)
+	collect:
 		for _, r := range sr.Results {
 			for _, ms := range r.Misconfigurations {
+				if failEntriesLimit > 0 && len(checks) >= failEntriesLimit {
+					break collect
+				}
 				checks = append(checks, ComplianceCheck{
 					ID:          ms.ID,
 					Target:      r.Target,

--- a/pkg/apis/aquasecurity/v1alpha1/compliance_types_test.go
+++ b/pkg/apis/aquasecurity/v1alpha1/compliance_types_test.go
@@ -1,0 +1,78 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/compliance/report"
+	ttypes "github.com/aquasecurity/trivy/pkg/types"
+)
+
+// complianceReportWith builds a report whose single control fails on n targets.
+func complianceReportWith(n int) *report.ComplianceReport {
+	results := make([]ttypes.Result, 0, n)
+	for i := 0; i < n; i++ {
+		results = append(results, ttypes.Result{
+			Target: fmt.Sprintf("default/replicaset-app-%d", i),
+			Misconfigurations: []ttypes.DetectedMisconfiguration{
+				{
+					ID:         "KSV0021",
+					Title:      "Runs with GID <= 10000",
+					Message:    "Force the container to run with group ID > 10000",
+					Severity:   "LOW",
+					Resolution: "Set 'containers[].securityContext.runAsGroup' to an integer > 10000.",
+				},
+			},
+		})
+	}
+	return &report.ComplianceReport{
+		ID:    "k8s-cis-1.23",
+		Title: "CIS Kubernetes Benchmarks v1.23",
+		Results: []*report.ControlCheckResult{
+			{
+				ID:       "5.7.3",
+				Name:     "Apply Security Context to Your Pods and Containers",
+				Severity: "LOW",
+				Results:  results,
+			},
+		},
+	}
+}
+
+func TestFromDetailReport_FailEntriesLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		failures   int
+		limit      int
+		wantChecks int
+	}{
+		{name: "caps the checks kept per control", failures: 1000, limit: 10, wantChecks: 10},
+		{name: "keeps everything below the limit", failures: 3, limit: 10, wantChecks: 3},
+		{name: "zero means no limit", failures: 25, limit: 0, wantChecks: 25},
+		{name: "negative means no limit", failures: 25, limit: -1, wantChecks: 25},
+		{name: "limit of one still records the control as failing", failures: 500, limit: 1, wantChecks: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromDetailReport(complianceReportWith(tt.failures), tt.limit)
+			assert.Len(t, got.Results, 1)
+			assert.Len(t, got.Results[0].Checks, tt.wantChecks)
+			for _, c := range got.Results[0].Checks {
+				assert.False(t, c.Success)
+			}
+		})
+	}
+}
+
+// A control with no misconfiguration must still get its synthetic passing check,
+// whatever the limit is.
+func TestFromDetailReport_PassingControl(t *testing.T) {
+	for _, limit := range []int{0, 1, 10} {
+		got := FromDetailReport(complianceReportWith(0), limit)
+		assert.Len(t, got.Results, 1)
+		assert.Len(t, got.Results[0].Checks, 1)
+		assert.True(t, got.Results[0].Checks[0].Success)
+	}
+}

--- a/pkg/compliance/io.go
+++ b/pkg/compliance/io.go
@@ -26,16 +26,18 @@ type Mgr interface {
 	GenerateComplianceReport(ctx context.Context, spec v1alpha1.ReportSpec) error
 }
 
-func NewMgr(c client.Client) Mgr {
+func NewMgr(c client.Client, trivyOperatorConfig trivyoperator.ConfigData) Mgr {
 	return &cm{
-		client: c,
+		client:              c,
+		trivyOperatorConfig: trivyOperatorConfig,
 	}
 }
 
 type cm struct {
 	logr.Logger
 	etc.Config
-	client client.Client
+	client              client.Client
+	trivyOperatorConfig trivyoperator.ConfigData
 }
 
 // GenerateComplianceReport generate and public compliance report by spec
@@ -129,7 +131,16 @@ func (w *cm) buildComplianceReport(spec v1alpha1.ReportSpec, complianceResults [
 		rs := report.BuildSummary(cr)
 		return v1alpha1.ReportStatus{SummaryReport: v1alpha1.FromSummaryReport(rs), Summary: summary}, nil
 	case v1alpha1.ReportDetail:
-		return v1alpha1.ReportStatus{DetailReport: v1alpha1.FromDetailReport(cr), Summary: summary}, nil
+		// compliance.failEntriesLimit caps the failing checks kept per control.
+		// Without it a cluster with many workloads produces a detail report that
+		// the API server refuses to store ("etcdserver: request is too large" /
+		// "Request entity too large"), and the report then silently stops
+		// updating. The summary counts above are computed from the full result
+		// set, so they stay accurate.
+		return v1alpha1.ReportStatus{
+			DetailReport: v1alpha1.FromDetailReport(cr, w.trivyOperatorConfig.ComplianceFailEntriesLimit()),
+			Summary:      summary,
+		}, nil
 	default:
 		return v1alpha1.ReportStatus{}, errors.New("report type is invalid")
 	}

--- a/pkg/compliance/io_test.go
+++ b/pkg/compliance/io_test.go
@@ -263,7 +263,7 @@ func TestGenerateComplianceReport(t *testing.T) {
 				WithObjects(tt.clusterComplianceReport).
 				WithStatusSubresource(tt.clusterComplianceReport).
 				Build()
-			mgr := NewMgr(c)
+			mgr := NewMgr(c, trivyoperator.ConfigData{})
 			err := mgr.GenerateComplianceReport(t.Context(), tt.clusterComplianceReport.Spec)
 			require.NoError(t, err)
 			ccr, err := getReport(t.Context(), c)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -375,7 +375,7 @@ func Start(ctx context.Context, buildInfo trivyoperator.BuildInfo, operatorConfi
 			Logger: logger,
 			Config: operatorConfig,
 			Client: mgr.GetClient(),
-			Mgr:    compliance.NewMgr(mgr.GetClient()),
+			Mgr:    compliance.NewMgr(mgr.GetClient(), trivyOperatorConfig),
 			Clock:  ext.NewSystemClock(),
 		}
 		if err := cc.SetupWithManager(mgr); err != nil {

--- a/tests/envtest/suite_test.go
+++ b/tests/envtest/suite_test.go
@@ -204,7 +204,7 @@ var _ = BeforeSuite(func() {
 		Logger: ctrl.Log.WithName("reconciler").WithName("compliance report"),
 		Client: k8sClient,
 		Config: config,
-		Mgr:    compliance.NewMgr(k8sClient),
+		Mgr:    compliance.NewMgr(k8sClient, trivyoperator.ConfigData{}),
 		Clock:  ext.NewSystemClock(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Description

`compliance.failEntriesLimit` is documented ("limit the number of fail entries per control check in the cluster compliance detail report — this limit is for preventing the report from being too large per control checks"), defaults to `10`, is rendered into the operator ConfigMap by the chart… and has **no call site**. `ConfigData.ComplianceFailEntriesLimit()` is only referenced by its own unit test:

```
pkg/trivyoperator/config.go:500:func (c ConfigData) ComplianceFailEntriesLimit() int {
pkg/trivyoperator/config_test.go:807:  gotLimit := tc.configData.ComplianceFailEntriesLimit()
```

`FromDetailReport` appends **every** failing misconfiguration of **every** control, so with `compliance.reportType: all` the `ClusterComplianceReport` grows with the number of workloads until the API server refuses to store it — and the report then silently stops updating, keeping stale data with a stale `updateTimestamp`:

```
"logger":"reconciler.clustercompliancereport","msg":"failed to generate compliance report",
"compliance report":{"name":"k8s-cis-1.23"},"error":"etcdserver: request is too large"

"controller":"clustercompliancereport","name":"k8s-nsa-1.0",
"error":"Request entity too large: limit is 3145728"
```

(the two shapes are the etcd `--max-request-bytes` cap and the API server's own body cap, depending on cluster configuration.)

Measured on a 9-node cluster with ~500 workloads, trivy-operator 0.33.0, `reportType: all`:

| | |
|---|---|
| `k8s-cis-1.23` `status` | **1 545 169 B** |
| control `5.7.3` alone | 697 217 B / **1241 checks** |
| same report with the configured limit of 10 applied | **125 079 B** |

So the report stops being writable at a fairly ordinary cluster size, and the setting that exists to prevent exactly that never runs.

### Change

* `FromDetailReport(sr, failEntriesLimit)` caps the failing checks kept per control. `<= 0` keeps the previous unlimited behaviour, so nothing changes for anyone who sets it to 0.
* `compliance.NewMgr` takes the `trivyoperator.ConfigData` (already available at the call site in `pkg/operator/operator.go`) and passes `ComplianceFailEntriesLimit()` through.
* A control with no misconfiguration still gets its synthetic passing check, whatever the limit.
* **Summary counts are unaffected** — `TotalsCheckCount(cr)` is computed from the full trivy result set before the detail report is built, so `passCount` / `failCount` stay exact. Only the per-control *sample* of failing targets is capped, which is what the setting documents.

### Tests

New `pkg/apis/aquasecurity/v1alpha1/compliance_types_test.go`: cap applied, below-cap untouched, `0` and negative meaning unlimited, `1` still recording the control as failing, and the passing-control case. Verified failing without the change and passing with it:

```
--- FAIL: TestFromDetailReport_FailEntriesLimit/caps_the_checks_kept_per_control
--- FAIL: TestFromDetailReport_FailEntriesLimit/limit_of_one_still_records_the_control_as_failing
```

`go build ./...`, `go vet` and `go test ./pkg/apis/aquasecurity/v1alpha1/... ./pkg/compliance/...` all green.

### Checklist

- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the documentation with the relevant information (the setting was already documented — this makes the documentation true).