### PR TITLE
fix: excludeNamespaces does not work on report watch, missing install mode predicate during report watches

### DIFF
--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -107,13 +107,22 @@ func (r *WorkloadController) SetupWithManager(mgr ctrl.Manager) error {
 			CacheSyncTimeout: r.CacheSyncTimeout,
 		}).
 			For(resource.ForObject, builder.WithPredicates(
-				Not(ManagedByTrivyOperator),
-				Not(IsBeingTerminated),
-				installModePredicate,
+			    Not(ManagedByTrivyOperator),
+			    Not(IsBeingTerminated),
+			    installModePredicate,
 			)).
-			Owns(&v1alpha1.VulnerabilityReport{}).
-			Owns(&v1alpha1.ExposedSecretReport{}).
-			Owns(&v1alpha1.SbomReport{}).
+			Owns(
+			    &v1alpha1.VulnerabilityReport{},
+			    builder.WithPredicates(installModePredicate),
+			).
+			Owns(
+			    &v1alpha1.ExposedSecretReport{},
+			    builder.WithPredicates(installModePredicate),
+			).
+			Owns(
+			    &v1alpha1.SbomReport{},
+			    builder.WithPredicates(installModePredicate),
+			).
 			Complete(r.reconcileWorkload(resource.Kind))
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
`excludeNamespaces` is currently applied to the primary workload watch, but not to the owned report watches.

This can cause workloads in excluded namespaces to be reconciled when a `VulnerabilityReport`, `ExposedSecretReport`, or `SbomReport` event is received.

Apply the existing installModePredicate to these watches as well, ensuring namespace exclusions are respected consistently across all workload controller event sources.


## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
