### PR TITLE
Match the report casing in the PSS compliance spec check IDs

### DIFF
--- a/deploy/helm/templates/specs/k8s-pss-baseline-0.1.yaml
+++ b/deploy/helm/templates/specs/k8s-pss-baseline-0.1.yaml
@@ -61,7 +61,7 @@ spec:
           list.
         id: "6"
         checks:
-          - id: avd-ksv-0024
+          - id: AVD-KSV-0024
         severity: HIGH
       - name: AppArmor
         description: On supported hosts, the runtime/default AppArmor profile is applied
@@ -70,27 +70,27 @@ spec:
           of profiles.
         id: "7"
         checks:
-          - id: avd-ksv-0002
+          - id: AVD-KSV-0002
         severity: HIGH
       - name: SELinux
         description: Setting the SELinux type is restricted, and setting a custom
           SELinux user or role option is forbidden.
         id: "8"
         checks:
-          - id: avd-ksv-0025
+          - id: AVD-KSV-0025
         severity: MEDIUM
       - name: /proc Mount Type
         description: The default /proc masks are set up to reduce attack surface, and
           should be required.
         id: "9"
         checks:
-          - id: avd-ksv-0027
+          - id: AVD-KSV-0027
         severity: MEDIUM
       - name: Seccomp
         description: Seccomp profile must not be explicitly set to Unconfined.
         id: "10"
         checks:
-          - id: avd-ksv-0104
+          - id: AVD-KSV-0104
         severity: MEDIUM
       - name: Sysctls
         description: Sysctls can disable security mechanisms or affect all containers on
@@ -100,6 +100,6 @@ spec:
           Node.
         id: "11"
         checks:
-          - id: avd-ksv-0026
+          - id: AVD-KSV-0026
         severity: MEDIUM
 {{- end }}

--- a/deploy/helm/templates/specs/k8s-pss-restricted-0.1.yaml
+++ b/deploy/helm/templates/specs/k8s-pss-restricted-0.1.yaml
@@ -61,7 +61,7 @@ spec:
           list.
         id: "6"
         checks:
-          - id: avd-ksv-0024
+          - id: AVD-KSV-0024
         severity: HIGH
       - name: AppArmor
         description: On supported hosts, the runtime/default AppArmor profile is applied
@@ -70,27 +70,27 @@ spec:
           of profiles.
         id: "7"
         checks:
-          - id: avd-ksv-0002
+          - id: AVD-KSV-0002
         severity: HIGH
       - name: SELinux
         description: Setting the SELinux type is restricted, and setting a custom
           SELinux user or role option is forbidden.
         id: "8"
         checks:
-          - id: avd-ksv-0025
+          - id: AVD-KSV-0025
         severity: MEDIUM
       - name: /proc Mount Type
         description: The default /proc masks are set up to reduce attack surface, and
           should be required.
         id: "9"
         checks:
-          - id: avd-ksv-0027
+          - id: AVD-KSV-0027
         severity: MEDIUM
       - name: Seccomp
         description: Seccomp profile must not be explicitly set to Unconfined.
         id: "10"
         checks:
-          - id: avd-ksv-0104
+          - id: AVD-KSV-0104
         severity: MEDIUM
       - name: Sysctls
         description: Sysctls can disable security mechanisms or affect all containers on
@@ -100,32 +100,32 @@ spec:
           Node.
         id: "11"
         checks:
-          - id: avd-ksv-0026
+          - id: AVD-KSV-0026
         severity: MEDIUM
       - name: Volume Types
         description: The restricted policy only permits specific volume types.
         id: "12"
         checks:
-          - id: avd-ksv-0028
+          - id: AVD-KSV-0028
         severity: LOW
       - name: Privilege Escalation
         description: Privilege escalation (such as via set-user-ID or set-group-ID file
           mode) should not be allowed.
         id: "13"
         checks:
-          - id: avd-ksv-0001
+          - id: AVD-KSV-0001
         severity: MEDIUM
       - name: Running as Non-root
         description: Containers must be required to run as non-root users.
         id: "14"
         checks:
-          - id: avd-ksv-0012
+          - id: AVD-KSV-0012
         severity: MEDIUM
       - name: Running as Non-root user
         description: Containers must not set runAsUser to 0
         id: "15"
         checks:
-          - id: avd-ksv-0105
+          - id: AVD-KSV-0105
         severity: LOW
       - name: Seccomp
         description: Seccomp profile must be explicitly set to one of the allowed
@@ -133,13 +133,13 @@ spec:
           prohibited
         id: "16"
         checks:
-          - id: avd-ksv-0030
+          - id: AVD-KSV-0030
         severity: LOW
       - name: Capabilities
         description: Containers must drop ALL capabilities, and are only permitted to
           add back the NET_BIND_SERVICE capability.
         id: "17"
         checks:
-          - id: avd-ksv-0106
+          - id: AVD-KSV-0106
         severity: LOW
 {{- end }}

--- a/pkg/compliance/spec_check_id_test.go
+++ b/pkg/compliance/spec_check_id_test.go
@@ -1,0 +1,97 @@
+package compliance
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+)
+
+// Check IDs in a compliance spec are compared against the IDs on the
+// misconfiguration findings with a case sensitive match, so a control that
+// spells its check ID in lower case aggregates to zero checks and renders as
+// passing even while the underlying check is failing.
+func TestComplianceCheckIDMatchIsCaseSensitive(t *testing.T) {
+	configAuditList := &v1alpha1.ConfigAuditReportList{
+		TypeMeta: v1.TypeMeta{Kind: "ConfigAuditReport"},
+		Items: []v1alpha1.ConfigAuditReport{
+			{
+				ObjectMeta: v1.ObjectMeta{Name: "resource"},
+				Report: v1alpha1.ConfigAuditReportData{
+					Checks: []v1alpha1.Check{
+						{ID: "AVD-KSV-0030", Title: "Seccomp policies should be set", Success: false},
+					},
+				},
+			},
+		},
+	}
+	report := &v1alpha1.ClusterComplianceReport{
+		TypeMeta:   v1.TypeMeta{Kind: "ConfigAuditReport"},
+		ObjectMeta: v1.ObjectMeta{Name: "nsa"},
+		Spec: v1alpha1.ReportSpec{
+			ReportFormat: "summary",
+			Compliance: v1alpha1.Compliance{
+				ID:    "nsa",
+				Title: "nsa",
+				Controls: []v1alpha1.Control{
+					{
+						ID:          "1.0",
+						Description: "seccomp, spelled as the report spells it",
+						Checks:      []v1alpha1.SpecCheck{{ID: "AVD-KSV-0030"}},
+					},
+					{
+						ID:          "2.0",
+						Description: "seccomp, spelled in lower case",
+						Checks:      []v1alpha1.SpecCheck{{ID: "avd-ksv-0030"}},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(trivyoperator.NewScheme()).
+		WithLists(configAuditList).
+		WithObjects(report).
+		WithStatusSubresource(report).
+		Build()
+	require.NoError(t, NewMgr(c).GenerateComplianceReport(t.Context(), report.Spec))
+
+	got, err := getReport(t.Context(), c)
+	require.NoError(t, err)
+	require.NotNil(t, got.Status.SummaryReport)
+
+	fails := make(map[string]int)
+	for _, control := range got.Status.SummaryReport.SummaryControls {
+		require.NotNil(t, control.TotalFail, "control %s has no failure count", control.ID)
+		fails[control.ID] = *control.TotalFail
+	}
+	assert.Equal(t, 1, fails["1.0"], "the upper case control should see the failing check")
+	assert.Equal(t, 0, fails["2.0"], "the lower case control matches nothing and reports as passing")
+}
+
+// The shipped specs are the input to that match, so none of their check IDs
+// may be lower cased.
+func TestShippedSpecCheckIDsAreUpperCase(t *testing.T) {
+	specs, err := filepath.Glob(filepath.Join("..", "..", "deploy", "helm", "templates", "specs", "*.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, specs)
+
+	checkID := regexp.MustCompile(`(?m)^\s+- id: ((?i:avd|ksv|kcv|cmd)-\S+)`)
+	for _, spec := range specs {
+		content, err := os.ReadFile(spec)
+		require.NoError(t, err)
+		for _, match := range checkID.FindAllStringSubmatch(string(content), -1) {
+			id := match[1]
+			assert.Equal(t, strings.ToUpper(id), id, "%s: check ID %q is not upper case", filepath.Base(spec), id)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3040.

The two PSS specs shipped in the chart write most of their check IDs in lower case (`avd-ksv-0030`), while the IDs that end up on the misconfiguration findings are upper case: `reportsToResults` in `pkg/compliance/io.go` carries the `checkID` from the ConfigAuditReport straight through, and the normalising branch below it only ever produces `AVD-...`. The spec IDs are then compared to those with a plain `slices.Contains`, so the lower-cased controls match nothing, aggregate to zero checks, and come out of `BuildComplianceReport` looking like they passed. That covers 6 controls in `k8s-pss-baseline-0.1` and 12 in `k8s-pss-restricted-0.1`, including Seccomp, Privilege Escalation, Running as Non-root, Capabilities, AppArmor, SELinux and Volume Types.

The change is just the casing in those two files. The other four shipped specs were already consistently upper case, so nothing else moves.

I added two tests in `pkg/compliance`. The first drives `GenerateComplianceReport` with one failing `AVD-KSV-0030` finding and two controls that differ only in the casing of that ID; the upper-case control reports one failure and the lower-case one reports zero, which is the behaviour the fix depends on. The second walks `deploy/helm/templates/specs/*.yaml` and asserts every `AVD`/`KSV`/`KCV`/`CMD` check ID is upper case, so a future spec cannot reintroduce this quietly. Reverting the yaml change makes that second test fail with all 18 IDs named.

`go test ./pkg/compliance/...` passes.
