### PR TITLE
fix: artifact.tag contains the repository for digest-pinned Docker Hub images

### DIFF
--- a/pkg/plugins/trivy/plugin.go
+++ b/pkg/plugins/trivy/plugin.go
@@ -233,7 +233,14 @@ func ParseImageRef(imageRef, imageDigest string) (v1alpha1.Registry, v1alpha1.Ar
 		artifact.Tag = t.TagStr()
 	case containerimage.Digest:
 		artifact.Digest = t.DigestStr()
-		artifact.Tag = strings.TrimPrefix(strings.TrimSuffix(strings.TrimPrefix(imageRef, ref.Context().Name()), "@"+artifact.Digest), ":")
+		// A digest reference drops the tag, so parse the part before "@" again as a
+		// tag reference. This is what name.NewDigest does internally and it copes
+		// with every spelling of the repository (Docker Hub shorthand, registry
+		// ports, ...). An empty default tag keeps "repo@digest" tag-less.
+		base, _, _ := strings.Cut(imageRef, "@")
+		if tag, err := containerimage.NewTag(base, containerimage.WithDefaultTag("")); err == nil {
+			artifact.Tag = tag.TagStr()
+		}
 	}
 	if artifact.Digest == "" {
 		artifact.Digest = imageDigest

--- a/pkg/plugins/trivy/plugin_test.go
+++ b/pkg/plugins/trivy/plugin_test.go
@@ -8494,6 +8494,71 @@ func TestParseImageRef(t *testing.T) {
 			},
 		},
 		{
+			name:          "docker hub official image with tag & digest",
+			inputImageRef: "nginx:1.27.3@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			expectedRegistry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			expectedArtifact: v1alpha1.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "1.27.3",
+			},
+		},
+		{
+			name:          "docker hub short repo with tag & digest",
+			inputImageRef: "grafana/grafana:12.1.0@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			expectedRegistry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			expectedArtifact: v1alpha1.Artifact{
+				Repository: "grafana/grafana",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "12.1.0",
+			},
+		},
+		{
+			name:          "docker.io prefixed image ref with tag & digest",
+			inputImageRef: "docker.io/library/alpine:3.21@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			expectedRegistry: v1alpha1.Registry{
+				Server: "index.docker.io",
+			},
+			expectedArtifact: v1alpha1.Artifact{
+				Repository: "library/alpine",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "3.21",
+			},
+		},
+		{
+			name:          "registry with port and digest",
+			inputImageRef: "localhost:5000/my-app@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			expectedRegistry: v1alpha1.Registry{
+				Server: "localhost:5000",
+			},
+			expectedArtifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "",
+			},
+		},
+		{
+			name:          "registry with port, tag & digest",
+			inputImageRef: "localhost:5000/my-app:1.2.3@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",
+			expectedRegistry: v1alpha1.Registry{
+				Server: "localhost:5000",
+			},
+			expectedArtifact: v1alpha1.Artifact{
+				Repository: "my-app",
+				Digest:     "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+				Tag:        "1.2.3",
+			},
+		},
+		{
 			name:          "incorrect input",
 			inputImageRef: "## some incorrect input ###",
 			inputImageID:  "sha256:2bc57c6bcb194869d18676e003dfed47b87d257fce49667557fb8eb1f324d5d6",


### PR DESCRIPTION
## Description

`ParseImageRef` derives the tag of a `repository:tag@digest` reference by trimming `ref.Context().Name()` off the raw reference. That name is the canonical repository (`index.docker.io/library/nginx`), while the reference carries whatever the pod spec says (`nginx`, `grafana/grafana`, `docker.io/grafana/grafana`). For every non-canonical Docker Hub spelling the prefix does not match, so the repository stays inside `artifact.tag`. `Artifact.Tag` feeds the `image_tag` label of the `trivy_image_*` metrics, so the pollution ends up in Prometheus as well.

Before:

```yaml
report:
  artifact:
    repository: grafana/grafana
    tag: docker.io/grafana/grafana:12.1.0
```

After:

```yaml
report:
  artifact:
    repository: grafana/grafana
    tag: 12.1.0
```

The fix parses the part before `@` with `name.NewTag`, which is what `name.NewDigest` does internally anyway: it copes with every spelling of the repository and tells registry ports apart from tags. An empty default tag keeps `repository@digest` references tag-less, as before (the existing `repo with digest` test case passes unchanged).

New `TestParseImageRef` cases cover the three Docker Hub spellings (`nginx:tag@digest`, `grafana/grafana:tag@digest`, `docker.io/library/alpine:tag@digest`) and a registry with a port, with and without a tag.

## Related issues
- Close #3049

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
