### PR TITLE
Add an optional  setting to run scanner containers sequentially withi…

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -79,6 +79,7 @@ Keeps security report resources updated
 | operator.replicas | int | `1` | replicas the number of replicas of the operator's pod |
 | operator.revisionHistoryLimit | string | `nil` | number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10) |
 | operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation, required for enabling ClusterVulnerabilityReports |
+| operator.scanJobMaxRetries | int | `nil` | scanJobMaxRetries maximum number of scan job pod recreations after failures. Leave unset to preserve unlimited retries; retries wait scanJobsRetryDelay between attempts. |
 | operator.scanJobTTL | string | `""` | scanJobTTL the set automatic cleanup time after the job is completed |
 | operator.scanJobTimeout | string | `"5m"` | scanJobTimeout the length of time to wait before giving up on a scan job |
 | operator.scanJobsConcurrentLimit | int | `10` | scanJobsConcurrentLimit the maximum number of scan jobs create by the operator |
@@ -86,6 +87,7 @@ Keeps security report resources updated
 | operator.scanNodeCollectorLimit | int | `1` | scanNodeCollectorLimit the maximum number of node collector jobs create by the operator |
 | operator.scanSecretTTL | string | `""` | scanSecretTTL set an automatic cleanup for scan job secrets |
 | operator.scannerReportTTL | string | `"24h"` | scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled |
+| operator.serializeScanJobScanners | bool | `false` | serializeScanJobScanners run scanner containers in a scan job sequentially instead of in parallel |
 | operator.serverAdditionalAnnotations | object | `{}` | serverAdditionalAnnotations the flag to set additional annotations for the trivy server pod |
 | operator.trivyServerHealthCheckCacheExpiration | string | `"10h"` | trivyServerHealthCheckCacheExpiration The flag to set the interval for trivy server health cache before it invalidate |
 | operator.valuesFromConfigMap | string | `""` | vaulesFromConfigMap name of a ConfigMap to apply OPERATOR_* environment variables. Will override Helm values. |
@@ -226,4 +228,3 @@ Keeps security report resources updated
 | volumeMounts[0].readOnly | bool | `false` |  |
 | volumes[0].emptyDir | object | `{}` |  |
 | volumes[0].name | string | `"cache-policies"` |  |
-

--- a/deploy/helm/generated/role.yaml
+++ b/deploy/helm/generated/role.yaml
@@ -109,6 +109,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - networking.k8s.io

--- a/deploy/helm/templates/configmaps/trivy-operator-config.yaml
+++ b/deploy/helm/templates/configmaps/trivy-operator-config.yaml
@@ -11,6 +11,10 @@ data:
   OPERATOR_LOG_DEV_MODE: {{ .Values.operator.logDevMode | quote }}
   OPERATOR_SCAN_JOB_TTL: {{ .Values.operator.scanJobTTL | quote }}
   OPERATOR_SCAN_JOB_TIMEOUT: {{ .Values.operator.scanJobTimeout | quote }}
+  OPERATOR_SCAN_JOB_SERIALIZE_SCANNERS: {{ .Values.operator.serializeScanJobScanners | quote }}
+  {{- if ne .Values.operator.scanJobMaxRetries nil }}
+  OPERATOR_SCAN_JOB_MAX_RETRIES: {{ .Values.operator.scanJobMaxRetries | quote }}
+  {{- end }}
   OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
   OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: {{ .Values.operator.scanNodeCollectorLimit | quote }}
   OPERATOR_SCAN_JOB_RETRY_AFTER: {{ .Values.operator.scanJobsRetryDelay | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -80,6 +80,12 @@ operator:
   # -- scanJobTimeout the length of time to wait before giving up on a scan job
   scanJobTimeout: 5m
 
+  # -- serializeScanJobScanners run scanner containers in a scan job sequentially instead of in parallel
+  serializeScanJobScanners: false
+
+  # -- scanJobMaxRetries maximum number of scan job pod recreations after failures. Leave unset to preserve unlimited retries; retries wait scanJobsRetryDelay between attempts.
+  scanJobMaxRetries: ~
+
   # -- scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
   scanJobsConcurrentLimit: 10
 

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	ServiceAccount                               string         `env:"OPERATOR_SERVICE_ACCOUNT" envDefault:"trivy-operator"`
 	LogDevMode                                   bool           `env:"OPERATOR_LOG_DEV_MODE" envDefault:"false"`
 	ScanJobTimeout                               time.Duration  `env:"OPERATOR_SCAN_JOB_TIMEOUT" envDefault:"5m"`
+	SerializeScanJobScanners                     bool           `env:"OPERATOR_SCAN_JOB_SERIALIZE_SCANNERS" envDefault:"false"`
+	ScanJobMaxRetries                            *int           `env:"OPERATOR_SCAN_JOB_MAX_RETRIES"`
 	ScanJobTTL                                   *time.Duration `env:"OPERATOR_SCAN_JOB_TTL"`
 	ScanSecretTTL                                *time.Duration `env:"OPERATOR_SCAN_SECRET_TTL"`
 	ConcurrentScanJobsLimit                      int            `env:"OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT" envDefault:"10"`

--- a/pkg/trivyoperator/constants.go
+++ b/pkg/trivyoperator/constants.go
@@ -49,5 +49,8 @@ const (
 )
 
 const (
-	AnnotationContainerImages = "trivy-operator.container-images"
+	AnnotationContainerImages    = "trivy-operator.container-images"
+	AnnotationScanJobRetryCount = "trivy-operator.aquasecurity.github.io/scan-job-retry-count"
+	AnnotationScanJobRetryAt    = "trivy-operator.aquasecurity.github.io/scan-job-retry-at"
+	AnnotationScanJobRetryDone  = "trivy-operator.aquasecurity.github.io/scan-job-retry-done"
 )

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -28,6 +28,7 @@ type ScanJobBuilder struct {
 	ttl                      *time.Duration
 	scanSecretTTL            *time.Duration
 	timeout                  time.Duration
+	serializeScanners        bool
 	object                   client.Object
 	credentials              map[string]docker.Auth
 	affinity                 *corev1.Affinity
@@ -60,6 +61,11 @@ func (s *ScanJobBuilder) WithPluginContext(pluginContext trivyoperator.PluginCon
 
 func (s *ScanJobBuilder) WithTimeout(timeout time.Duration) *ScanJobBuilder {
 	s.timeout = timeout
+	return s
+}
+
+func (s *ScanJobBuilder) WithSerializeScanners(serializeScanners bool) *ScanJobBuilder {
+	s.serializeScanners = serializeScanners
 	return s
 }
 
@@ -178,6 +184,15 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 
 	templateSpec.NodeSelector = s.nodeSelector
 
+	if s.serializeScanners && len(templateSpec.Containers) > 1 {
+		// A Kubernetes Pod must have at least one regular container. Keep the
+		// final scanner as the regular container and run the preceding scanners
+		// as init containers, which makes the scanner sequence deterministic.
+		scannerInitContainers := append([]corev1.Container(nil), templateSpec.Containers[:len(templateSpec.Containers)-1]...)
+		templateSpec.InitContainers = append(templateSpec.InitContainers, scannerInitContainers...)
+		templateSpec.Containers = templateSpec.Containers[len(templateSpec.Containers)-1:]
+	}
+
 	containerImagesAsJSON, err := kube.GetContainerImagesFromPodSpec(spec, s.skipInitContainers).AsJSON()
 	if err != nil {
 		return nil, nil, err
@@ -203,6 +218,8 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 	}
 
 	jobSpec := batchv1.JobSpec{
+		// Failed scan Pods are retried by the scan-job controller so the
+		// operator can apply scanJobsRetryDelay and its optional retry limit.
 		BackoffLimit:          ptr.To[int32](0),
 		Completions:           ptr.To[int32](1),
 		ActiveDeadlineSeconds: utils.DurationSecondsPtr(s.timeout),

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -680,6 +680,39 @@ func TestReportBuilder_TTLAnnotation(t *testing.T) {
 	g.Expect(reportNoTTL.Annotations).To(gomega.BeNil())
 }
 
+func TestScanJobBuilderOptions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	job, _, err := vulnerabilityreport.NewScanJobBuilder().
+		WithPlugin(&testMultipleContainersPlugin{}).
+		WithPluginContext(trivyoperator.NewPluginContext().
+			WithName("test-plugin").
+			WithNamespace("trivy-operator-ns").
+			WithServiceAccountName("trivy-operator-sa").
+			Get()).
+		WithTimeout(3 * time.Second).
+		WithSerializeScanners(true).
+		WithObject(&appsv1.ReplicaSet{
+			TypeMeta:   metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "nginx-6799fc88d8", Namespace: "prod-ns"},
+			Spec: appsv1.ReplicaSetSpec{
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.16"}},
+				}},
+				Selector: &metav1.LabelSelector{},
+			},
+		}).
+		Get()
+
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(*job.Spec.BackoffLimit).To(gomega.Equal(int32(0)))
+	g.Expect(job.Spec.Template.Spec.InitContainers).To(gomega.HaveLen(3))
+	g.Expect(job.Spec.Template.Spec.InitContainers[0].Name).To(gomega.Equal("test-init-container"))
+	g.Expect(job.Spec.Template.Spec.InitContainers[1].Name).To(gomega.Equal("scanner-one"))
+	g.Expect(job.Spec.Template.Spec.InitContainers[2].Name).To(gomega.Equal("scanner-two"))
+	g.Expect(job.Spec.Template.Spec.Containers).To(gomega.HaveLen(1))
+	g.Expect(job.Spec.Template.Spec.Containers[0].Name).To(gomega.Equal("scanner-three"))
+}
+
 type testPlugin struct {
 }
 
@@ -720,6 +753,28 @@ func (p *testContainersPlugin) GetScanJobSpec(_ trivyoperator.PluginContext, _ c
 }
 
 func (p *testContainersPlugin) ParseReportData(_ trivyoperator.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, *v1alpha1.SbomReportData, error) {
+	return v1alpha1.VulnerabilityReportData{}, v1alpha1.ExposedSecretReportData{}, &v1alpha1.SbomReportData{}, nil
+}
+
+type testMultipleContainersPlugin struct {
+}
+
+func (p *testMultipleContainersPlugin) Init(_ trivyoperator.PluginContext) error {
+	return nil
+}
+
+func (p *testMultipleContainersPlugin) GetScanJobSpec(_ trivyoperator.PluginContext, _ client.Object, _ map[string]docker.Auth, _ *corev1.SecurityContext, _ map[string]v1alpha1.SbomReportData) (corev1.PodSpec, []*corev1.Secret, error) {
+	return corev1.PodSpec{
+		InitContainers: []corev1.Container{{Name: "test-init-container", Image: "test-init-image"}},
+		Containers: []corev1.Container{
+			{Name: "scanner-one", Image: "scanner-image-one"},
+			{Name: "scanner-two", Image: "scanner-image-two"},
+			{Name: "scanner-three", Image: "scanner-image-three"},
+		},
+	}, nil, nil
+}
+
+func (p *testMultipleContainersPlugin) ParseReportData(_ trivyoperator.PluginContext, _ string, _ io.ReadCloser) (v1alpha1.VulnerabilityReportData, v1alpha1.ExposedSecretReportData, *v1alpha1.SbomReportData, error) {
 	return v1alpha1.VulnerabilityReportData{}, v1alpha1.ExposedSecretReportData{}, &v1alpha1.SbomReportData{}, nil
 }
 

--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"go.uber.org/multierr"
@@ -66,7 +68,7 @@ type ScanJobController struct {
 
 // Manage scan jobs with image pull secrets
 // kubebuilder:rbac:groups="",resources=secrets,verbs=create;update
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete
 
 func (r *ScanJobController) SetupWithManager(mgr ctrl.Manager) error {
 	var predicates []predicate.Predicate
@@ -100,6 +102,9 @@ func (r *ScanJobController) reconcileJobs() reconcile.Func {
 
 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
 		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet, batchv1.JobFailed, batchv1.JobFailureTarget:
+			if jobCondition == batchv1.JobFailed || jobCondition == batchv1.JobFailureTarget {
+				return r.reconcileFailedScanJob(ctx, job)
+			}
 			completedContainers, err := r.completedContainers(ctx, job)
 			if err != nil {
 				return ctrl.Result{}, r.deleteJob(ctx, job)
@@ -115,19 +120,148 @@ func (r *ScanJobController) reconcileJobs() reconcile.Func {
 	}
 }
 
+func (r *ScanJobController) reconcileFailedScanJob(ctx context.Context, job *batchv1.Job) (ctrl.Result, error) {
+	if job.Annotations[trivyoperator.AnnotationScanJobRetryDone] == "true" {
+		return ctrl.Result{}, nil
+	}
+
+	retryCount, err := scanJobRetryCount(job)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if r.ScanJobMaxRetries != nil && *r.ScanJobMaxRetries < 0 {
+		return ctrl.Result{}, fmt.Errorf("scan job max retries must be non-negative: %d", *r.ScanJobMaxRetries)
+	}
+
+	if retryAt := job.Annotations[trivyoperator.AnnotationScanJobRetryAt]; retryAt != "" {
+		retryAtTime, err := time.Parse(time.RFC3339Nano, retryAt)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("parsing scan job retry time %q: %w", retryAt, err)
+		}
+		if remaining := time.Until(retryAtTime); remaining > 0 {
+			return ctrl.Result{RequeueAfter: remaining}, nil
+		}
+
+		return ctrl.Result{}, r.createRetryScanJob(ctx, job, retryCount)
+	}
+
+	// Preserve the existing behavior of writing reports for containers that
+	// completed successfully even when another scanner in the Pod failed.
+	completedContainers, err := r.completedContainers(ctx, job)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(completedContainers) > 0 {
+		if err := r.processCompleteScanJobWithoutDeleting(ctx, job, completedContainers...); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if r.ScanJobMaxRetries != nil && retryCount >= *r.ScanJobMaxRetries {
+		return ctrl.Result{}, r.markScanJobRetryDone(ctx, job)
+	}
+
+	retryCount++
+	if err := r.scheduleScanJobRetry(ctx, job, retryCount); err != nil {
+		return ctrl.Result{}, err
+	}
+	if r.ScanJobRetryAfter <= 0 {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{RequeueAfter: r.ScanJobRetryAfter}, nil
+}
+
+func scanJobRetryCount(job *batchv1.Job) (int, error) {
+	retryCount := job.Annotations[trivyoperator.AnnotationScanJobRetryCount]
+	if retryCount == "" {
+		return 0, nil
+	}
+	count, err := strconv.Atoi(retryCount)
+	if err != nil || count < 0 {
+		return 0, fmt.Errorf("invalid scan job retry count %q", retryCount)
+	}
+	return count, nil
+}
+
+func (r *ScanJobController) scheduleScanJobRetry(ctx context.Context, job *batchv1.Job, retryCount int) error {
+	annotations := job.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[trivyoperator.AnnotationScanJobRetryCount] = strconv.Itoa(retryCount)
+	annotations[trivyoperator.AnnotationScanJobRetryAt] = time.Now().Add(r.ScanJobRetryAfter).UTC().Format(time.RFC3339Nano)
+	job.Annotations = annotations
+	return r.Update(ctx, job)
+}
+
+func (r *ScanJobController) markScanJobRetryDone(ctx context.Context, job *batchv1.Job) error {
+	annotations := job.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	delete(annotations, trivyoperator.AnnotationScanJobRetryAt)
+	annotations[trivyoperator.AnnotationScanJobRetryDone] = "true"
+	job.Annotations = annotations
+	return r.Update(ctx, job)
+}
+
+func (r *ScanJobController) createRetryScanJob(ctx context.Context, job *batchv1.Job, retryCount int) error {
+	retryJob := job.DeepCopy()
+	retryJob.Name = fmt.Sprintf("%s-retry-%d", job.Name, retryCount)
+	retryJob.GenerateName = ""
+	retryJob.ResourceVersion = ""
+	retryJob.UID = ""
+	retryJob.CreationTimestamp = metav1.Time{}
+	retryJob.ManagedFields = nil
+	retryJob.Status = batchv1.JobStatus{}
+	retryJob.Spec.Selector = nil
+	for _, key := range []string{
+		"controller-uid",
+		"job-name",
+		"batch.kubernetes.io/controller-uid",
+		"batch.kubernetes.io/job-name",
+	} {
+		delete(retryJob.Spec.Template.Labels, key)
+	}
+	retryJob.Annotations = make(map[string]string, len(job.Annotations))
+	for key, value := range job.Annotations {
+		retryJob.Annotations[key] = value
+	}
+	delete(retryJob.Annotations, trivyoperator.AnnotationScanJobRetryAt)
+	delete(retryJob.Annotations, trivyoperator.AnnotationScanJobRetryDone)
+
+	if err := r.Create(ctx, retryJob); err != nil {
+		return fmt.Errorf("creating retry scan job: %w", err)
+	}
+	if err := r.markScanJobRetryDone(ctx, job); err != nil {
+		return fmt.Errorf("marking previous scan job as retried: %w", err)
+	}
+	return r.deleteJob(ctx, job)
+}
+
 func (r *ScanJobController) processCompleteScanJob(ctx context.Context, job *batchv1.Job, completedContainers ...string) error {
+	return r.processCompleteScanJobWithDelete(ctx, job, true, completedContainers...)
+}
+
+func (r *ScanJobController) processCompleteScanJobWithoutDeleting(ctx context.Context, job *batchv1.Job, completedContainers ...string) error {
+	return r.processCompleteScanJobWithDelete(ctx, job, false, completedContainers...)
+}
+
+func (r *ScanJobController) processCompleteScanJobWithDelete(ctx context.Context, job *batchv1.Job, deleteJob bool, completedContainers ...string) error {
 	log := r.Logger.WithValues("job", fmt.Sprintf("%s/%s", job.Namespace, job.Name))
 	var owner client.Object
 
-	// Always attempt to delete the job on function exit.
-	// Ensures cleanup even if writing reports to the API server fails.
-	defer func() {
-		log.V(1).Info("Deleting complete scan job", "owner", owner)
-		if err := r.deleteJob(ctx, job); err != nil {
-			// Best-effort cleanup; only log the failure
-			log.Error(err, "failed deferred job deletion")
-		}
-	}()
+	if deleteJob {
+		// Always attempt to delete the job on function exit.
+		// Ensures cleanup even if writing reports to the API server fails.
+		defer func() {
+			log.V(1).Info("Deleting complete scan job", "owner", owner)
+			if err := r.deleteJob(ctx, job); err != nil {
+				// Best-effort cleanup; only log the failure
+				log.Error(err, "failed deferred job deletion")
+			}
+		}()
+	}
 
 	ownerRef, err := kube.ObjectRefFromObjectMeta(job.ObjectMeta)
 	if err != nil {

--- a/pkg/vulnerabilityreport/controller/scanjob_test.go
+++ b/pkg/vulnerabilityreport/controller/scanjob_test.go
@@ -25,6 +25,31 @@ import (
 	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
 )
 
+func TestScanJobRetryCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        int
+		wantErr     bool
+	}{
+		{name: "not set", want: 0},
+		{name: "set", annotations: map[string]string{trivyoperator.AnnotationScanJobRetryCount: "5"}, want: 5},
+		{name: "invalid", annotations: map[string]string{trivyoperator.AnnotationScanJobRetryCount: "invalid"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := scanJobRetryCount(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}})
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, count)
+		})
+	}
+}
+
 // Function for creating all the required objects required for the tests to succeed
 func setupTestEnvironment(testid string) (*ScanJobController, *batchv1.Job, error) {
 

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -233,17 +233,30 @@ func (r *WorkloadController) ProcessScanJob() {
 }
 
 func (r *WorkloadController) hasActiveScanJob(ctx context.Context, owner kube.ObjectRef, hash string) (bool, *batchv1.Job, error) {
-	jobName := fmt.Sprintf("scan-vulnerabilityreport-%s", kube.ComputeHash(owner))
-	job := &batchv1.Job{}
-	err := r.Get(ctx, client.ObjectKey{Namespace: r.Config.Namespace, Name: jobName}, job)
+	scanJobNamespace := r.Config.Namespace
+	if r.ConfigData.VulnerabilityScanJobsInSameNamespace() && owner.Namespace != "" {
+		scanJobNamespace = owner.Namespace
+	}
+	jobs := &batchv1.JobList{}
+	listOptions := []client.ListOption{client.MatchingLabels{
+		trivyoperator.LabelResourceKind:      string(owner.Kind),
+		trivyoperator.LabelResourceNamespace: owner.Namespace,
+		trivyoperator.LabelResourceSpecHash:  hash,
+	}}
+	if scanJobNamespace != "" {
+		listOptions = append(listOptions, client.InNamespace(scanJobNamespace))
+	}
+	err := r.List(ctx, jobs, listOptions...)
 	if err != nil {
-		if k8sapierror.IsNotFound(err) {
-			return false, nil, nil
-		}
 		return false, nil, fmt.Errorf("getting job from cache: %w", err)
 	}
-	if job.Labels[trivyoperator.LabelResourceSpecHash] == hash {
-		return true, job, nil
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if job.Labels[trivyoperator.LabelResourceName] == owner.Name ||
+			job.Labels[trivyoperator.LabelResourceNameHash] == kube.ComputeHash(owner.Name) ||
+			job.Annotations[trivyoperator.LabelResourceName] == owner.Name {
+			return true, job, nil
+		}
 	}
 	return false, nil, nil
 }
@@ -340,6 +353,7 @@ func (r *WorkloadController) SubmitScanJob(ctx context.Context, owner client.Obj
 		WithPlugin(r.Plugin).
 		WithPluginContext(r.PluginContext).
 		WithTimeout(r.Config.ScanJobTimeout).
+		WithSerializeScanners(r.Config.SerializeScanJobScanners).
 		WithTTL(r.Config.ScanJobTTL).
 		WithScanSecretTTL(r.Config.ScanSecretTTL).
 		WithObject(owner).


### PR DESCRIPTION
## Changes

- Add an optional `serializeScanJobScanners` setting to run scanner containers sequentially within a scan Job.
- Add an optional `scanJobMaxRetries` setting to limit failed scan Pod recreations.
- Retries continue to use `scanJobsRetryDelay`.
- Leave `scanJobMaxRetries` unset by default to preserve the existing unlimited retry behavior.
- Keep Kubernetes `backoffLimit` at zero so retry control remains handled by the operator.
- Preserve reports from scanners that completed successfully before another scanner failed.
- Update the required RBAC permissions for scan Job updates.
- Add tests covering scanner serialization and retry-count handling.

## Motivation

In validation or testing environments, scan Pods are more likely to fail because workload image tags may be removed, registry authentication may be unavailable, or images may no longer exist.

Repeated failed scans can cause the same target images and vulnerability databases to be downloaded multiple times. Concurrent scanner containers can also contend for the Trivy cache, causing additional failures and network traffic.

This change provides configuration options to reduce unnecessary registry traffic, cache contention, and network costs in environments where scan failures are more common.

## Expected impact

Enabling scanner serialization and configuring a retry limit should reduce:

- Duplicate target-image downloads.
- Repeated vulnerability database downloads.
- Trivy cache contention.
- Registry requests caused by permanently missing or unauthorized images.
- Unnecessary network egress and associated costs.

The new behavior is opt-in through Helm values, so existing installations can preserve their current behavior by leaving the new options unset or disabled.

## Before and after

Before, scan retries were unlimited and scanner containers ran in parallel:

```yaml
operator:
  scanJobsRetryDelay: 10m
```

After, validation can serialize scanners and limit failed scan Pod recreations:

```yaml
operator:
  serializeScanJobScanners: true
  scanJobMaxRetries: 5
  scanJobsRetryDelay: 10m
```

With this configuration:

- Scanner containers within a scan Job run sequentially.
- A failed scan Pod can be recreated up to five times.
- Each retry waits 10 minutes.
- If `scanJobMaxRetries` is omitted or left unset, unlimited retries remain enabled.
- Setting `scanJobMaxRetries: 0` disables replacement Pods after the initial failure.

## Validation

- Helm lint passes.
- Helm rendering was verified with the default configuration.
- Helm rendering was verified with scanner serialization enabled and `scanJobMaxRetries` set.
- Added unit tests for scanner serialization and retry-count handling.
- `git diff --check` passes.

## Checklist

- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the documentation with the relevant information.
- [x] I've added usage information for the new Helm options.
- [x] I've included a before-and-after example because this PR introduces user-facing configuration options.